### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ project. In addition, not all language constructs are supported.
 [1]: #1
 [CoffeeScriptRedux]: https://github.com/michaelficarra/CoffeeScriptRedux
 [deviations]: https://github.com/michaelficarra/CoffeeScriptRedux/wiki/Intentional-Deviations-From-jashkenas-coffee-script
-[issues]: https://github.com/eventualbuddha/decaffeinate/issues
+[issues]: https://github.com/decaffeinate/decaffeinate/issues


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/eventualbuddha/decaffeinate/issues | https://github.com/decaffeinate/decaffeinate/issues 
