### PR TITLE
Add esnext as the final transformation stage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,12 @@
   "license": "MIT",
   "dependencies": {
     "add-variable-declarations": "^1.2.0",
+    "babel-eslint": "^5.0.0",
     "coffee-lex": "^1.3.2",
     "decaffeinate-parser": "^1.2.5",
     "detect-indent": "^4.0.0",
     "eslint": "^1.10.3",
+    "esnext": "^1.15.6",
     "magic-string": "^0.10.2",
     "repeating": "^2.0.0"
   },
@@ -44,7 +46,7 @@
   ],
   "devDependencies": {
     "babel": "^6.5.1",
-    "babel-eslint": "^5.0.0-beta6",
+    "babel-eslint": "^5.0.0",
     "babel-plugin-syntax-flow": "^6.5.0",
     "babel-plugin-transform-flow-strip-types": "^6.5.0",
     "babel-preset-es2015": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "Brian Donovan",
   "license": "MIT",
   "dependencies": {
-    "add-variable-declarations": "^1.2.0",
+    "add-variable-declarations": "^1.3.1",
     "babel-eslint": "^5.0.0",
     "coffee-lex": "^1.3.2",
     "decaffeinate-parser": "^1.2.5",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import AddVariableDeclarationsStage from './stages/add-variable-declarations/index.js';
 import EslintStage from './stages/eslint/index.js';
+import EsnextStage from './stages/esnext/index.js';
 import MainStage from './stages/main/index.js';
 import NormalizeStage from './stages/normalize/index.js';
 
@@ -27,7 +28,8 @@ export function convert(source: string, options: ?Options={}): ConversionResult 
     NormalizeStage,
     MainStage,
     AddVariableDeclarationsStage,
-    EslintStage
+    EslintStage,
+    EsnextStage
   ]);
 }
 

--- a/src/stages/esnext/index.js
+++ b/src/stages/esnext/index.js
@@ -1,0 +1,20 @@
+import { basename } from 'path';
+import { convert } from 'esnext';
+import { logger } from '../../utils/debug.js';
+import { parse } from 'babel-eslint';
+
+export default class EsnextStage {
+  static run(content: string, filename: string): { code: string, map: Object } {
+    let log = logger(this.name);
+    log(content);
+
+    let { code, map } = convert(content, {
+      parse,
+      'declarations.block-scope': {
+        disableConst: true
+      }
+    });
+    map.file = `${basename(filename, '.js')}-${this.name}.js`;
+    return { code, map };
+  }
+}

--- a/test/binary_operator_test.js
+++ b/test/binary_operator_test.js
@@ -121,7 +121,7 @@ describe('binary operators', () => {
     check(`
       (a() ? b)
     `, `
-      var left;
+      let left;
       ((left = a()) != null ? left : b);
     `);
   });
@@ -130,7 +130,7 @@ describe('binary operators', () => {
     check(`
       value = object.id << 8 | object.type
     `, `
-      var value = object.id << 8 | object.type;
+      let value = object.id << 8 | object.type;
     `);
   });
 

--- a/test/chained_comparison_test.js
+++ b/test/chained_comparison_test.js
@@ -31,7 +31,7 @@ describe('chained comparison', () => {
     check(`
       a < b() < c
     `, `
-      var middle;
+      let middle;
       a < (middle = b()) && middle < c;
     `);
   });
@@ -41,8 +41,8 @@ describe('chained comparison', () => {
       middle = 1
       a < b() < c
     `, `
-      var middle1;
-      var middle = 1;
+      let middle1;
+      let middle = 1;
       a < (middle1 = b()) && middle1 < c;
     `);
   });
@@ -70,8 +70,8 @@ describe('chained comparison', () => {
     check(`
       a() < b() < c() < d()
     `, `
-      var middle;
-      var middle1;
+      let middle;
+      let middle1;
       a() < (middle = b()) && middle < (middle1 = c()) && middle1 < d();
     `);
   });

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -15,7 +15,7 @@ describe('classes', () => {
         a: ->
           1
     `, `
-      var A = class {
+      let A = class {
         a() {
           return 1;
         }
@@ -35,19 +35,22 @@ describe('classes', () => {
         }
       }
     `);
+    // FIXME: Ideally the semi-colon would be directly after the closing curly.
+    // This is due to an edge case that esnext chose not to address in its
+    // `functions.arrow` plugin.
     check(`
       ->
         class A
           a: ->
             1
     `, `
-      (function() {
-        return class A {
+      () =>
+        class A {
           a() {
             return 1;
           }
-        };
-      });
+        }
+      ;
     `);
   });
 

--- a/test/compound_assignment_test.js
+++ b/test/compound_assignment_test.js
@@ -114,7 +114,7 @@ describe('compound assignment', () => {
       check(`
         [a[b()] ||= c]
       `, `
-        var name;
+        let name;
         [a[name = b()] || (a[name] = c)];
       `);
     });
@@ -123,7 +123,7 @@ describe('compound assignment', () => {
       check(`
         [a[b()] &&= c]
       `, `
-        var name;
+        let name;
         [a[name = b()] && (a[name] = c)];
       `);
     });
@@ -132,7 +132,7 @@ describe('compound assignment', () => {
       check(`
         [a()[c] ||= d]
       `, `
-        var base;
+        let base;
         [(base = a())[c] || (base[c] = d)];
       `);
     });
@@ -141,7 +141,7 @@ describe('compound assignment', () => {
       check(`
         [a()[c] &&= d]
       `, `
-        var base;
+        let base;
         [(base = a())[c] && (base[c] = d)];
       `);
     });
@@ -150,8 +150,8 @@ describe('compound assignment', () => {
       check(`
         [a()[b()] ||= c]
       `, `
-        var base;
-        var name;
+        let base;
+        let name;
         [(base = a())[name = b()] || (base[name] = c)];
       `);
     });
@@ -160,8 +160,8 @@ describe('compound assignment', () => {
       check(`
         [a()[b()] &&= c]
       `, `
-        var base;
-        var name;
+        let base;
+        let name;
         [(base = a())[name = b()] && (base[name] = c)];
       `);
     });
@@ -171,8 +171,8 @@ describe('compound assignment', () => {
         name = 'abc'
         [a[b()] ||= c]
       `, `
-        var name1;
-        var name = 'abc';
+        let name1;
+        let name = 'abc';
         [a[name1 = b()] || (a[name1] = c)];
       `);
     });
@@ -190,7 +190,7 @@ describe('compound assignment', () => {
         a = 1
         [a ?= 2]
       `, `
-        var a = 1;
+        let a = 1;
         [a != null ? a : (a = 2)];
       `);
     });
@@ -215,7 +215,7 @@ describe('compound assignment', () => {
       check(`
         [a[b()] ?= 1]
       `, `
-        var name;
+        let name;
         [a[name = b()] != null ? a[name] : (a[name] = 1)];
       `);
     });
@@ -224,7 +224,7 @@ describe('compound assignment', () => {
       check(`
         [a()[b] ?= 1]
       `, `
-        var base;
+        let base;
         [(base = a())[b] != null ? base[b] : (base[b] = 1)];
       `);
     });
@@ -233,8 +233,8 @@ describe('compound assignment', () => {
       check(`
         [a()[b()] ?= 1]
       `, `
-        var base;
-        var name;
+        let base;
+        let name;
         [(base = a())[name = b()] != null ? base[name] : (base[name] = 1)];
       `);
     });
@@ -325,7 +325,7 @@ describe('compound assignment', () => {
       check(`
         a[b()] ||= c
       `, `
-        var name;
+        let name;
         if (!a[name = b()]) { a[name] = c; }
       `);
     });
@@ -334,7 +334,7 @@ describe('compound assignment', () => {
       check(`
         a[b()] &&= c
       `, `
-        var name;
+        let name;
         if (a[name = b()]) { a[name] = c; }
       `);
     });
@@ -343,7 +343,7 @@ describe('compound assignment', () => {
       check(`
         a()[c] ||= d
       `, `
-        var base;
+        let base;
         if (!(base = a())[c]) { base[c] = d; }
       `);
     });
@@ -352,7 +352,7 @@ describe('compound assignment', () => {
       check(`
         a()[c] &&= d
       `, `
-        var base;
+        let base;
         if ((base = a())[c]) { base[c] = d; }
       `);
     });
@@ -361,8 +361,8 @@ describe('compound assignment', () => {
       check(`
         a()[b()] ||= c
       `, `
-        var base;
-        var name;
+        let base;
+        let name;
         if (!(base = a())[name = b()]) { base[name] = c; }
       `);
     });
@@ -371,8 +371,8 @@ describe('compound assignment', () => {
       check(`
         a()[b()] &&= c
       `, `
-        var base;
-        var name;
+        let base;
+        let name;
         if ((base = a())[name = b()]) { base[name] = c; }
       `);
     });
@@ -382,8 +382,8 @@ describe('compound assignment', () => {
         name = 'abc'
         a[b()] ||= c
       `, `
-        var name1;
-        var name = 'abc';
+        let name1;
+        let name = 'abc';
         if (!a[name1 = b()]) { a[name1] = c; }
       `);
     });
@@ -393,7 +393,7 @@ describe('compound assignment', () => {
         a = 1
         a ?= 2
       `, `
-        var a = 1;
+        let a = 1;
         if (typeof a === 'undefined' || a === null) { a = 2; }
       `);
     });
@@ -418,7 +418,7 @@ describe('compound assignment', () => {
       check(`
         a[b()] ?= 1
       `, `
-        var name;
+        let name;
         if (a[name = b()] == null) { a[name] = 1; }
       `);
     });
@@ -427,7 +427,7 @@ describe('compound assignment', () => {
       check(`
         a()[b] ?= 1
       `, `
-        var base;
+        let base;
         if ((base = a())[b] == null) { base[b] = 1; }
       `);
     });
@@ -436,8 +436,8 @@ describe('compound assignment', () => {
       check(`
         a()[b()] ?= 1
       `, `
-        var base;
-        var name;
+        let base;
+        let name;
         if ((base = a())[name = b()] == null) { base[name] = 1; }
       `);
     });

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -182,8 +182,8 @@ describe('conditionals', () => {
           a - d)
     `, `
       (function() {
-        var c;
-        var d;
+        let c;
+        let d;
         return z(a ?
           (c = a,
           a + c)

--- a/test/decaffeinate_test.js
+++ b/test/decaffeinate_test.js
@@ -116,7 +116,7 @@ describe('automatic conversions', () => {
 
   describe('converting all at once', () => {
     it('adds semicolons after call parentheses', () => {
-      check(`Ember = require "ember"`, `var Ember = require("ember");`);
+      check(`Ember = require "ember"`, `import Ember from "ember";`);
     });
 
     it('adds braces to implicit object literals', () => {
@@ -138,10 +138,12 @@ describe('automatic conversions', () => {
     it('does not add parentheses to objects that are implicit returns', () => {
       check(`
         ->
-          {a: b}
+          a = 1
+          {a}
       `, `
         (function() {
-          return {a: b};
+          let a = 1;
+          return {a};
         });
       `);
     });

--- a/test/declaration_test.js
+++ b/test/declaration_test.js
@@ -2,14 +2,14 @@ import check from './support/check.js';
 
 describe('declarations', () => {
   it('adds inline declarations for assignments as statements', () => {
-    check(`a = 1`, `var a = 1;`);
+    check(`a = 1`, `let a = 1;`);
   });
 
   it('adds separate declarations for assignments as expressions', () => {
     check(`
       a(b = 1)
     `, `
-      var b;
+      let b;
       a(b = 1);
     `);
   });
@@ -19,7 +19,7 @@ describe('declarations', () => {
       a = 1
       a = 2
     `, `
-      var a = 1;
+      let a = 1;
       a = 2;
     `);
   });
@@ -29,9 +29,7 @@ describe('declarations', () => {
       (a) ->
         a = 1
     `, `
-      (function(a) {
-        return a = 1;
-      });
+      a => a = 1;
     `);
   });
 
@@ -41,7 +39,7 @@ describe('declarations', () => {
         a = 1
     `, `
       (function() {
-        var a;
+        let a;
         return a = 1;
       });
     `);
@@ -53,10 +51,8 @@ describe('declarations', () => {
       ->
         a = 2
     `, `
-      var a = 1;
-      (function() {
-        return a = 2;
-      });
+      let a = 1;
+      () => a = 2;
     `);
   });
 
@@ -68,7 +64,7 @@ describe('declarations', () => {
     `, `
       if (a) {
         if (b) {
-          var c = 1;
+          let c = 1;
         }
       }
     `);
@@ -79,7 +75,7 @@ describe('declarations', () => {
       if a = 1
         b
     `, `
-      var a;
+      let a;
       if (a = 1) {
         b;
       }
@@ -91,11 +87,11 @@ describe('declarations', () => {
   });
 
   it('adds variable declarations for destructuring array assignment', () => {
-    check(`[a] = b`, `var [a] = b;`);
+    check(`[a] = b`, `let [a] = b;`);
   });
 
   it('adds variable declarations for destructuring object assignment', () => {
-    check(`{a} = b`, `var {a} = b;`);
+    check(`{a} = b`, `let {a} = b;`);
   });
 
   it('does not add variable declarations for destructuring array assignment with previously declared bindings', () => {
@@ -103,7 +99,7 @@ describe('declarations', () => {
       a = 1
       [a] = b
     `, `
-      var a = 1;
+      let a = 1;
       [a] = b;
     `);
   });
@@ -113,7 +109,7 @@ describe('declarations', () => {
       a = 1
       {a} = b
     `, `
-      var a = 1;
+      let a = 1;
       ({a} = b);
     `);
   });
@@ -123,25 +119,25 @@ describe('declarations', () => {
       a = 1
       [a, b] = c
     `, `
-      var b;
-      var a = 1;
+      let b;
+      let a = 1;
       [a, b] = c;
     `);
   });
 
   it('adds pre-declarations when the assignment is in an expression context', () => {
-    check(`a(b = c)`, `var b;\na(b = c);`);
+    check(`a(b = c)`, `let b;\na(b = c);`);
   });
 
   it('adds pre-declarations when the assignment would be implicitly returned', () => {
-    check('->\n  a = 1', '(function() {\n  var a;\n  return a = 1;\n});');
+    check('->\n  a = 1', '(function() {\n  let a;\n  return a = 1;\n});');
   });
 
   it('adds pre-declarations at the right indent level when the assignment is in an expression context', () => {
-    check(`->\n  a(b = c)`, `(function() {\n  var b;\n  return a(b = c);\n});`);
+    check(`->\n  a(b = c)`, `(function() {\n  let b;\n  return a(b = c);\n});`);
   });
 
   it('adds pre-declarations and regular declarations together properly', () => {
-    check('a = 1\nb = c = 2', 'var c;\nvar a = 1;\nvar b = c = 2;');
+    check('a = 1\nb = c = 2', 'let c;\nlet a = 1;\nlet b = c = 2;');
   });
 });

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -78,7 +78,7 @@ describe('function calls', () => {
     check(`
       a= new c ([b()])
     `, `
-      var a= new c(([b()]));
+      let a= new c(([b()]));
     `);
   });
 
@@ -184,6 +184,6 @@ describe('function calls', () => {
   });
 
   it('converts rest params in function calls', () => {
-    check(`(a,b...)->b[0]`, `(function(a,...b){return b[0]; });`);
+    check(`(a,b...)->b[0]`, `(a,...b)=> b[0];`);
   });
 });

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -8,30 +8,30 @@ describe('functions', () => {
   it('put the closing curly brace on a new line', () => {
     check(`
       ->
-        a
+        return
     `, `
       (function() {
-        return a;
+        return;
       });
     `);
   });
 
   it('put the closing curly brace on the same line if the original is a single line', () => {
     check(`
-      -> a
+      -> return
     `, `
-      (function() { return a; });
+      (function() { return; });
     `);
   });
 
   it('puts the closing curly brace before any trailing comments on the last statement in the body', () => {
     check(`
       ->
-        a # hey
+        return # hey
       b
     `, `
       (function() {
-        return a; // hey
+        return; // hey
       });
       b;
     `);
@@ -39,19 +39,19 @@ describe('functions', () => {
 
   it('puts the closing punctuation before trailing comments for one-line functions', () => {
     check(`
-      -> a # b
+      -> return # b
     `, `
-      (function() { return a; }); // b
+      (function() { return; }); // b
     `);
   });
 
   it('puts the closing punctuation before trailing comments for parentheses-wrapped functions', () => {
     check(`
       (->
-        a) # b
+        return) # b
     `, `
       (function() {
-        return a;
+        return;
       }); // b
     `);
   });
@@ -61,7 +61,7 @@ describe('functions', () => {
   });
 
   it('leaves fat arrow functions as arrow functions', () => {
-    check(`add = (a, b) => a + b`, `var add = (a, b) => a + b;`);
+    check(`add = (a, b) => a + b`, `let add = (a, b) => a + b;`);
   });
 
   it('adds a block to fat arrow functions if their body is a block', () => {
@@ -69,7 +69,7 @@ describe('functions', () => {
       add = (a, b) =>
         a + b
     `, `
-      var add = (a, b) => {
+      let add = (a, b) => {
         return a + b;
       };
     `);

--- a/test/implicit_return_test.js
+++ b/test/implicit_return_test.js
@@ -2,11 +2,19 @@ import check from './support/check.js';
 
 describe('implicit return', () => {
   it('is added for the last expression in a typical function', () => {
-    check(`-> 1`, `(function() { return 1; });`);
+    check(`
+      ->
+        a = 1
+    `, `
+      (function() {
+        let a;
+        return a = 1;
+      });
+    `);
   });
 
   it('is not added when one is already there', () => {
-    check(`a = -> return 1`, `var a = function() { return 1; };`);
+    check(`a = -> b(); return c`, `let a = function() { b(); return c; };`);
   });
 
   it('is not added for the last expression in a block-less bound function', () => {

--- a/test/javascript_test.js
+++ b/test/javascript_test.js
@@ -2,10 +2,10 @@ import check from './support/check.js';
 
 describe('embedded JavaScript', () => {
   it('strips the backticks off in a statement context', () => {
-    check('`var a = 1;`', 'var a = 1;');
+    check('`var a = 1;`', 'let a = 1;');
   });
 
   it('strips the backticks off in an expression context', () => {
-    check('a = `void 0`', 'var a = void 0;');
+    check('a = `void 0`', 'let a = void 0;');
   });
 });

--- a/test/javascript_test.js
+++ b/test/javascript_test.js
@@ -8,4 +8,8 @@ describe('embedded JavaScript', () => {
   it('strips the backticks off in an expression context', () => {
     check('a = `void 0`', 'let a = void 0;');
   });
+
+  it('allows passing JSX through', () => {
+    check('-> `<MyComponent />`', '() => <MyComponent />;');
+  });
 });

--- a/test/prototype_member_access_test.js
+++ b/test/prototype_member_access_test.js
@@ -21,7 +21,7 @@ describe('changing prototype member access into normal member access', () => {
     check(`
       a():: ?= b
     `, `
-      var base;
+      let base;
       if ((base = a()).prototype == null) { base.prototype = b; }
     `);
   });
@@ -30,7 +30,7 @@ describe('changing prototype member access into normal member access', () => {
     check(`
       a()::b ?= c
     `, `
-      var base;
+      let base;
       if ((base = a()).prototype.b == null) { base.prototype.b = c; }
     `);
   });

--- a/test/regular_expression_test.js
+++ b/test/regular_expression_test.js
@@ -2,11 +2,11 @@ import check from './support/check.js';
 
 describe('regular expressions', () => {
   it('passes regular expressions through as-is', () => {
-    check(`a = /foo\s/`, `var a = /foo\s/;`);
+    check(`a = /foo\s/`, `let a = /foo\s/;`);
   });
 
   it('passes regular expressions with hash through as-is in an assignment context', () => {
-    check(`a = /foo#\s/`, `var a = /foo#\s/;`);
+    check(`a = /foo#\s/`, `let a = /foo#\s/;`);
   });
 
   it('passes regular expressions with hash through as-is in a function call context', () => {
@@ -20,16 +20,16 @@ describe('regular expressions', () => {
           bar
         ///
       `, `
-        var a = /foo.*bar/;
+        let a = /foo.*bar/;
       `);
   });
 
   it('preserves slash escapes in regular expressions', () => {
-    check(`a = /foo\\/bar/`, `var a = /foo\\/bar/;`);
+    check(`a = /foo\\/bar/`, `let a = /foo\\/bar/;`);
   });
 
   it('preserves regular expression flags', () => {
-    check(`a = /a/ig`, `var a = /a/ig;`);
+    check(`a = /a/ig`, `let a = /a/ig;`);
   });
 
   it('handles back-to-back escapes correctly', () => {

--- a/test/return_test.js
+++ b/test/return_test.js
@@ -3,9 +3,9 @@ import check from './support/check.js';
 describe('return', () => {
   it('works with a return value', () =>
     check(`
-      -> return 1
+      -> a; return 1
     `, `
-      (function() { return 1; });
+      (function() { a; return 1; });
     `)
   );
 

--- a/test/semicolon_test.js
+++ b/test/semicolon_test.js
@@ -18,7 +18,7 @@ describe('semicolons', () => {
         b # c
       d
     `, `
-      var a = function() {
+      let a = function() {
         return b; // c
       };
       d;
@@ -46,7 +46,7 @@ describe('semicolons', () => {
   });
 
   it('adds them after assignments', () => {
-    check(`a = 1`, `var a = 1;`);
+    check(`a = 1`, `let a = 1;`);
   });
 
   it('does not add them after `if` statements', () => {
@@ -65,7 +65,7 @@ describe('semicolons', () => {
       for a in b
         a
     `, `
-      for (var i = 0, a; i < b.length; i++) {
+      for (let i = 0, a; i < b.length; i++) {
         a = b[i];
         a;
       }
@@ -74,7 +74,7 @@ describe('semicolons', () => {
       for a of b
         a
     `, `
-      for (var a in b) {
+      for (let a in b) {
         a;
       }
     `);
@@ -108,8 +108,8 @@ describe('semicolons', () => {
       x = 1
       -> 2
     `, `
-      var x = 1;
-      (function() { return 2; });
+      let x = 1;
+      () => 2;
     `);
   });
 });

--- a/test/shorthand_this_test.js
+++ b/test/shorthand_this_test.js
@@ -2,11 +2,11 @@ import check from './support/check.js';
 
 describe('changing shorthand this to longhand this', function() {
   it('changes shorthand member expressions to longhand member expressions', () => {
-    check(`a = @a`, `var a = this.a;`);
+    check(`a = @b`, `let a = this.b;`);
   });
 
   it('changes shorthand computed member expressions to longhand computed member expressions', () => {
-    check(`a = @[a]`, `var a = this[a];`);
+    check(`a = @[a]`, `let a = this[a];`);
   });
 
   it('changes shorthand standalone this to longhand standalone this', () => {

--- a/test/string_interpolation_test.js
+++ b/test/string_interpolation_test.js
@@ -10,7 +10,7 @@ describe('string interpolation', () => {
   });
 
   it('can return interpolated strings', () => {
-    check('-> "#{a}"', '(function() { return `${a}`; });');
+    check('-> "#{a}"', '() => `${a}`;');
   });
 
   it('ensures backticks are escaped', () => {
@@ -22,7 +22,7 @@ describe('string interpolation', () => {
   });
 
   it('handles multi-line triple-quoted strings correctly', () => {
-    check('a = """\n     #{b}\n     c\n    """', 'var a = `${b}\nc`;');
+    check('a = """\n     #{b}\n     c\n    """', 'let a = `${b}\nc`;');
   });
 
   it('handles double quotes inside triple-double quotes', () => {
@@ -31,7 +31,7 @@ describe('string interpolation', () => {
       bar="#{bar}"
       """
     `, `
-      var a=\`bar="\${bar}"\`;
+      let a=\`bar="\${bar}"\`;
     `);
   });
 
@@ -41,7 +41,7 @@ describe('string interpolation', () => {
       b # foo!
       }"
     `, `
-      var a=\`\${
+      let a=\`\${
       b // foo!
       }\`;
     `);

--- a/test/string_test.js
+++ b/test/string_test.js
@@ -60,7 +60,7 @@ describe('strings', () => {
            bar
           """
     `, `
-      var a = \`foo
+      let a = \`foo
       bar\`;
     `);
   });

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -205,7 +205,7 @@ describe('switch', () => {
             d
       e
     `, `
-      var a = function() {
+      let a = function() {
         switch (b) {
           case c:
             return d;
@@ -242,7 +242,7 @@ describe('switch', () => {
           return g
         else e
     `, `
-      var a = (() => { switch (b) {
+      let a = (() => { switch (b) {
         case c: return d;
         case f:
           return g;

--- a/test/unary_operator_test.js
+++ b/test/unary_operator_test.js
@@ -48,7 +48,7 @@ describe('unary operators', () => {
     check(`
       (a) -> a?
     `, `
-      (function(a) { return (a != null); });
+      a => a != null;
     `);
   });
 


### PR DESCRIPTION
This upgrades the resulting code to use even more modern features, such as `let`.