### PR TITLE
Ensure conditional-as-ternary has parens if needed.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -326,8 +326,8 @@ export default class PlusOpPatcher extends NodePatcher {
 }
 ```
 
-Now `a + if b then c else d` will become `a + b ? c : d;` as intended, since the
-`right` patcher knows to patch using `patchAsExpression` instead of
+Now `a + if b then c else d` will become `a + (b ? c : d);` as intended, since
+the `right` patcher knows to patch using `patchAsExpression` instead of
 `patchAsStatement`. In reality, `PlusOp` and several other binary operators are
 all handled by [`BinaryOpPatcher`][BinaryOpPatcher].
 

--- a/src/stages/main/patchers/BinaryOpPatcher.js
+++ b/src/stages/main/patchers/BinaryOpPatcher.js
@@ -18,8 +18,8 @@ export default class BinaryOpPatcher extends NodePatcher {
    * LEFT OP RIGHT
    */
   patchAsExpression() {
-    this.left.patch();
-    this.right.patch();
+    this.left.patch({ needsParens: true });
+    this.right.patch({ needsParens: true });
   }
 
   patchAsStatement() {

--- a/src/stages/main/patchers/ConditionalPatcher.js
+++ b/src/stages/main/patchers/ConditionalPatcher.js
@@ -1,6 +1,4 @@
-import BinaryOpPatcher from './BinaryOpPatcher.js';
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import UnaryOpPatcher from './UnaryOpPatcher.js';
 import type BlockPatcher from './BlockPatcher.js';
 import type { Node, SourceTokenListIndex, ParseContext, Editor } from './../../../patchers/types.js';
 import { ELSE, IF, THEN } from 'coffee-lex';
@@ -57,8 +55,8 @@ export default class ConditionalPatcher extends NodePatcher {
     return !this.willPatchAsTernary() && this.forcedToPatchAsExpression();
   }
 
-  patchAsExpression() {
-    let addParens = this.ternaryNeedsParens() && !this.isSurroundedByParentheses();
+  patchAsExpression({ needsParens }={}) {
+    let addParens = needsParens && !this.isSurroundedByParentheses();
 
     // `if a then b` → `a then b`
     //  ^^^
@@ -99,13 +97,6 @@ export default class ConditionalPatcher extends NodePatcher {
     if (addParens) {
       this.insert(this.contentEnd, ')');
     }
-  }
-
-  ternaryNeedsParens(): boolean {
-    return (
-      this.parent instanceof BinaryOpPatcher ||
-      this.parent instanceof UnaryOpPatcher
-    );
   }
 
   patchAsForcedExpression() {

--- a/src/stages/main/patchers/FloorDivideOpPatcher.js
+++ b/src/stages/main/patchers/FloorDivideOpPatcher.js
@@ -11,13 +11,13 @@ export default class FloorDivideOpPatcher extends BinaryOpPatcher {
     //             ^^^^^^^^^^^
     this.insert(this.contentStart, 'Math.floor(');
 
-    this.left.patch();
+    this.left.patch({ needsParens: true });
 
     // `Math.floor(a // b)` → `Math.floor(a / b)`
     //               ^^                     ^
     this.overwrite(operator.start, operator.end, '/');
 
-    this.right.patch();
+    this.right.patch({ needsParens: true });
 
     // `Math.floor(a // b` → `Math.floor(a // b)`
     //                                         ^

--- a/src/stages/main/patchers/UnaryOpPatcher.js
+++ b/src/stages/main/patchers/UnaryOpPatcher.js
@@ -15,7 +15,7 @@ export default class UnaryOpPatcher extends NodePatcher {
    * OP EXPRESSION
    */
   patchAsExpression() {
-    this.expression.patch();
+    this.expression.patch({ needsParens: true });
   }
 
   patchAsStatement() {

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -283,4 +283,12 @@ describe('conditionals', () => {
       a + (b ? c : d);
     `);
   });
+
+  it('does not add unnecessary parens to a conditional expression', () => {
+    check(`
+      a ** if b then c else d
+    `, `
+      Math.pow(a, b ? c : d);
+    `);
+  });
 });

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -259,4 +259,28 @@ describe('conditionals', () => {
       if (!e(f)) { if (c(d)) { a(b); } }
     `);
   });
+
+  it('surrounds the conditional expression in parens as part of a binary expression', () => {
+    check(`
+      a + if b then c else d
+    `, `
+      a + (b ? c : d);
+    `);
+  });
+
+  it('surrounds the conditional expression in parens as part of a unary expression', () => {
+    check(`
+      -if b then c else d
+    `, `
+      -(b ? c : d);
+    `);
+  });
+
+  it('does not add extra parens to a conditional expression', () => {
+    check(`
+      a + (if b then c else d)
+    `, `
+      a + (b ? c : d);
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #144.