### PR TITLE
Add class properties to patchers.

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -7,6 +7,25 @@ import { isSemanticToken } from '../utils/types.js';
 import { logger } from '../utils/debug.js';
 
 export default class NodePatcher {
+  node: Node;
+  context: ParseContext;
+  editor: Editor;
+  log: (...args: Array<any>) => void;
+  parent: ?NodePatcher;
+
+  contentStart: number;
+  contentEnd: number;
+  contentStartTokenIndex: SourceTokenListIndex;
+  contentEndTokenIndex: SourceTokenListIndex;
+  innerStart: number;
+  innerEnd: number;
+  innerStartTokenIndex: SourceTokenListIndex;
+  innerEndTokenIndex: SourceTokenListIndex;
+  outerStart: number;
+  outerEnd: number;
+  outerStartTokenIndex: SourceTokenListIndex;
+  outerEndTokenIndex: SourceTokenListIndex;
+  
   constructor(node: Node, context: ParseContext, editor: Editor) {
     this.log = logger(this.constructor.name);
 
@@ -206,9 +225,6 @@ export default class NodePatcher {
     this.editor.insert(index, content);
   }
 
-  /**
-   * @protected
-   */
   allowPatchingOuterBounds(): boolean {
     return false;
   }
@@ -362,8 +378,6 @@ export default class NodePatcher {
   /**
    * Override this to express whether the patcher prefers to be represented as
    * an expression. By default it's simply an alias for `canPatchAsExpression`.
-   *
-   * @protected
    */
   prefersToPatchAsExpression(): boolean {
     return this.canPatchAsExpression();
@@ -371,8 +385,6 @@ export default class NodePatcher {
 
   /**
    * Override this if a node cannot be represented as an expression.
-   *
-   * @protected
    */
   canPatchAsExpression(): boolean {
     return true;

--- a/src/stages/main/patchers/ArrayInitialiserPatcher.js
+++ b/src/stages/main/patchers/ArrayInitialiserPatcher.js
@@ -3,6 +3,8 @@ import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
 import { COMMA } from 'coffee-lex';
 
 export default class ArrayInitialiserPatcher extends NodePatcher {
+  members: Array<NodePatcher>;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, members: Array<NodePatcher>) {
     super(node, context, editor);
     this.members = members;

--- a/src/stages/main/patchers/AssignOpPatcher.js
+++ b/src/stages/main/patchers/AssignOpPatcher.js
@@ -3,6 +3,9 @@ import ObjectInitialiserPatcher from './ObjectInitialiserPatcher.js';
 import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
 
 export default class AssignOpPatcher extends NodePatcher {
+  assignee: NodePatcher;
+  expression: NodePatcher;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, assignee: NodePatcher, expression: NodePatcher) {
     super(node, context, editor);
     this.assignee = assignee;

--- a/src/stages/main/patchers/BinaryOpPatcher.js
+++ b/src/stages/main/patchers/BinaryOpPatcher.js
@@ -3,6 +3,9 @@ import type { SourceToken, SourceType, Node, ParseContext, Editor } from './../.
 import { OPERATOR } from 'coffee-lex';
 
 export default class BinaryOpPatcher extends NodePatcher {
+  left: NodePatcher;
+  right: NodePatcher;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, left: NodePatcher, right: NodePatcher) {
     super(node, context, editor);
     this.left = left;
@@ -26,9 +29,6 @@ export default class BinaryOpPatcher extends NodePatcher {
     this.patchAsExpression();
   }
 
-  /**
-   * @protected
-   */
   getOperatorToken(): SourceToken {
     let expectedOperatorTokenType = this.expectedOperatorTokenType();
     let operatorTokenIndex = this.indexOfSourceTokenBetweenPatchersMatching(
@@ -42,9 +42,6 @@ export default class BinaryOpPatcher extends NodePatcher {
     return this.sourceTokenAtIndex(operatorTokenIndex);
   }
 
-  /**
-   * @protected
-   */
   expectedOperatorTokenType(): SourceType {
     return OPERATOR;
   }

--- a/src/stages/main/patchers/BlockPatcher.js
+++ b/src/stages/main/patchers/BlockPatcher.js
@@ -3,6 +3,8 @@ import type { SourceToken, Node, ParseContext, Editor } from './../../../patcher
 import { SEMICOLON } from 'coffee-lex';
 
 export default class BlockPatcher extends NodePatcher {
+  statements: Array<NodePatcher>;
+
   constructor(node: Node, context: ParseContext, editor: Editor, statements: Array<NodePatcher>) {
     super(node, context, editor);
     this.statements = statements;

--- a/src/stages/main/patchers/BoundFunctionPatcher.js
+++ b/src/stages/main/patchers/BoundFunctionPatcher.js
@@ -1,4 +1,3 @@
-import BlockPatcher from './BlockPatcher.js';
 import FunctionPatcher from './FunctionPatcher.js';
 import ManuallyBoundFunctionPatcher from './ManuallyBoundFunctionPatcher.js';
 import NodePatcher from './../../../patchers/NodePatcher.js';
@@ -84,20 +83,10 @@ export default class BoundFunctionPatcher extends FunctionPatcher {
   }
 
   willPatchBodyInline(): boolean {
-    let body = this.getBody();
-    return body ? body.willPatchAsExpression() : false;
+    return this.body ? this.body.willPatchAsExpression() : false;
   }
 
   hasInlineBody(): boolean {
-    let body = this.getBody();
-    return body ? body.inline() : false;
-  }
-
-  getBody(): ?BlockPatcher {
-    if (!this.body) {
-      return null;
-    }
-
-    return (this.body: BlockPatcher);
+    return this.body ? this.body.inline() : false;
   }
 }

--- a/src/stages/main/patchers/ChainedComparisonOpPatcher.js
+++ b/src/stages/main/patchers/ChainedComparisonOpPatcher.js
@@ -6,6 +6,8 @@ import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
  * Handles constructs of the form `a < b < c < … < z`.
  */
 export default class ChainedComparisonOpPatcher extends NodePatcher {
+  expression: NodePatcher;
+  
   /**
    * `node` should have type `ChainedComparisonOp`.
    */

--- a/src/stages/main/patchers/ClassBlockPatcher.js
+++ b/src/stages/main/patchers/ClassBlockPatcher.js
@@ -3,14 +3,10 @@ import ClassAssignOpPatcher from './ClassAssignOpPatcher.js';
 import ConstructorPatcher from './ConstructorPatcher.js';
 import NodePatcher from './../../../patchers/NodePatcher.js';
 import adjustIndent from '../../../utils/adjustIndent.js';
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type ClassPatcher from './ClassPatcher.js';
+import type { Node } from './../../../patchers/types.js';
 
 export default class ClassBlockPatcher extends BlockPatcher {
-  constructor(node: Node, context: ParseContext, editor: Editor, statements: Array<NodePatcher>) {
-    super(node, context, editor);
-    this.statements = statements;
-  }
-
   static patcherClassForChildNode(node: Node, property: string): ?Class<NodePatcher> {
     if (property === 'statements' && node.type === 'AssignOp') {
       return ClassAssignOpPatcher;
@@ -26,7 +22,7 @@ export default class ClassBlockPatcher extends BlockPatcher {
         let methodIndent = adjustIndent(source, insertionPoint, 0);
         let methodBodyIndent = adjustIndent(source, insertionPoint, 1);
         let constructor = '';
-        if (this.parent.isSubclass()) {
+        if (this.getClassPatcher().isSubclass()) {
           constructor += `constructor(...args) {\n${methodBodyIndent}super(...args);\n`;
         } else {
           constructor += `constructor() {\n`;
@@ -40,6 +36,10 @@ export default class ClassBlockPatcher extends BlockPatcher {
       }
     }
     super.patch(options);
+  }
+  
+  getClassPatcher(): ClassPatcher {
+    return this.parent;
   }
 
   canPatchAsExpression(): boolean {

--- a/src/stages/main/patchers/ClassBoundMethodFunctionPatcher.js
+++ b/src/stages/main/patchers/ClassBoundMethodFunctionPatcher.js
@@ -4,10 +4,4 @@ export default class ClassBoundMethodFunctionPatcher extends FunctionPatcher {
   expectedArrowType(): string {
     return '=>';
   }
-
-  getBindingStatement(): string {
-    let method = this.parent;
-    let key = this.context.source.slice(method.key.contentStart, method.key.contentEnd);
-    return `this.${key} = this.${key}.bind(this)`;
-  }
 }

--- a/src/stages/main/patchers/ClassPatcher.js
+++ b/src/stages/main/patchers/ClassPatcher.js
@@ -6,6 +6,10 @@ import type { SourceToken, Node, ParseContext, Editor } from './../../../patcher
 import { CLASS } from 'coffee-lex';
 
 export default class ClassPatcher extends NodePatcher {
+  nameAssignee: ?NodePatcher;
+  superclass: ?NodePatcher;
+  body: ?ClassBlockPatcher;
+
   constructor(node: Node, context: ParseContext, editor: Editor, nameAssignee: ?NodePatcher, parent: ?NodePatcher, body: ?ClassBlockPatcher) {
     super(node, context, editor);
     this.nameAssignee = nameAssignee;

--- a/src/stages/main/patchers/ConditionalPatcher.js
+++ b/src/stages/main/patchers/ConditionalPatcher.js
@@ -4,6 +4,10 @@ import type { Node, SourceTokenListIndex, ParseContext, Editor } from './../../.
 import { ELSE, IF, THEN } from 'coffee-lex';
 
 export default class ConditionalPatcher extends NodePatcher {
+  condition: NodePatcher;
+  consequent: BlockPatcher;
+  alternate: ?BlockPatcher;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, condition: NodePatcher, consequent: BlockPatcher, alternate: ?BlockPatcher) {
     super(node, context, editor);
     this.condition = condition;

--- a/src/stages/main/patchers/DynamicMemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/DynamicMemberAccessOpPatcher.js
@@ -2,6 +2,9 @@ import NodePatcher from './../../../patchers/NodePatcher.js';
 import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
 
 export default class DynamicMemberAccessOpPatcher extends NodePatcher {
+  expression: NodePatcher;
+  indexingExpr: NodePatcher;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher, indexingExpr: NodePatcher) {
     super(node, context, editor);
     this.expression = expression;

--- a/src/stages/main/patchers/EqualityPatcher.js
+++ b/src/stages/main/patchers/EqualityPatcher.js
@@ -1,20 +1,13 @@
 import BinaryOpPatcher from './BinaryOpPatcher.js';
-import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { SourceToken, Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { SourceToken } from './../../../patchers/types.js';
 import { OPERATOR } from 'coffee-lex';
 
 /**
  * Handles equality and inequality comparisons.
  */
 export default class EqualityPatcher extends BinaryOpPatcher {
-  /**
-   * `node` is either `EQOp` or `NEQOp`.
-   */
-  constructor(node: Node, context: ParseContext, editor: Editor, left: NodePatcher, right: NodePatcher) {
-    super(node, context, editor, left, right);
-    this.negated = false;
-  }
-
+  negated: boolean = false;
+  
   patchAsExpression() {
     this.left.patch();
     let compareToken = this.getCompareToken();

--- a/src/stages/main/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/main/patchers/FunctionApplicationPatcher.js
@@ -3,6 +3,9 @@ import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
 import { CALL_START, COMMA } from 'coffee-lex';
 
 export default class FunctionApplicationPatcher extends NodePatcher {
+  fn: NodePatcher;
+  args: Array<NodePatcher>;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, fn: NodePatcher, args: Array<NodePatcher>) {
     super(node, context, editor);
     this.fn = fn;

--- a/src/stages/main/patchers/FunctionPatcher.js
+++ b/src/stages/main/patchers/FunctionPatcher.js
@@ -1,8 +1,12 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
+import type BlockPatcher from './BlockPatcher.js';
 import type { Node, ParseContext, Editor, SourceToken } from './../../../patchers/types.js';
 import { FUNCTION, LPAREN, RPAREN } from 'coffee-lex';
 
 export default class FunctionPatcher extends NodePatcher {
+  parameters: Array<NodePatcher>;
+  body: ?BlockPatcher;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, parameters: Array<NodePatcher>, body: ?NodePatcher) {
     super(node, context, editor);
     this.parameters = parameters;

--- a/src/stages/main/patchers/InOpPatcher.js
+++ b/src/stages/main/patchers/InOpPatcher.js
@@ -12,6 +12,8 @@ const IN_HELPER =
  * Handles `in` operators, e.g. `a in b` and `a not in b`.
  */
 export default class InOpPatcher extends BinaryOpPatcher {
+  negated: boolean;
+  
   /**
    * `node` is of type `InOp`.
    */
@@ -24,9 +26,6 @@ export default class InOpPatcher extends BinaryOpPatcher {
     this.negated = !this.negated;
   }
 
-  /**
-   * @protected
-   */
   expectedOperatorTokenType(): SourceType {
     return RELATION;
   }

--- a/src/stages/main/patchers/LogicalOpPatcher.js
+++ b/src/stages/main/patchers/LogicalOpPatcher.js
@@ -14,6 +14,8 @@ import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
  * [1]: https://en.wikipedia.org/wiki/De_Morgan%27s_laws
  */
 export default class LogicalOpPatcher extends BinaryOpPatcher {
+  negated: boolean = false;
+
   /**
    * `node` is expected to be either `LogicalAndOp` or `LogicalOrOp`.
    */
@@ -21,7 +23,6 @@ export default class LogicalOpPatcher extends BinaryOpPatcher {
     super(node, context, editor);
     this.left = left;
     this.right = right;
-    this.negated = false;
   }
 
   /**

--- a/src/stages/main/patchers/MemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/MemberAccessOpPatcher.js
@@ -3,6 +3,8 @@ import type { Node, ParseContext, Editor, SourceToken } from './../../../patcher
 import { AT, DOT, IDENTIFIER, PROTO } from 'coffee-lex';
 
 export default class MemberAccessOpPatcher extends NodePatcher {
+  expression: NodePatcher;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher) {
     super(node, context, editor);
     this.expression = expression;

--- a/src/stages/main/patchers/NegatableBinaryOpPatcher.js
+++ b/src/stages/main/patchers/NegatableBinaryOpPatcher.js
@@ -6,6 +6,8 @@ import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
  * Handles `instanceof` operator, e.g. `a instanceof b`.
  */
 export default class NegatableBinaryOpPatcher extends BinaryOpPatcher {
+  negated: boolean;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, left: NodePatcher, right: NodePatcher) {
     super(node, context, editor, left, right);
     this.negated = node.isNot;
@@ -15,9 +17,6 @@ export default class NegatableBinaryOpPatcher extends BinaryOpPatcher {
     this.negated = !this.negated;
   }
 
-  /**
-   * @protected
-   */
   javaScriptOperator() {
     throw new Error(`'javaScriptOperator' should be implemented in subclass`);
   }

--- a/src/stages/main/patchers/NewOpPatcher.js
+++ b/src/stages/main/patchers/NewOpPatcher.js
@@ -6,6 +6,9 @@ import { COMMA } from 'coffee-lex';
  * Handles construction of objects with `new`.
  */
 export default class NewOpPatcher extends NodePatcher {
+  ctor: NodePatcher;
+  args: Array<NodePatcher>;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, ctor: NodePatcher, args: Array<NodePatcher>) {
     super(node, context, editor);
     this.ctor = ctor;

--- a/src/stages/main/patchers/ObjectBodyMemberPatcher.js
+++ b/src/stages/main/patchers/ObjectBodyMemberPatcher.js
@@ -7,6 +7,9 @@ import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
  * Handles object properties.
  */
 export default class ObjectBodyMemberPatcher extends NodePatcher {
+  key: NodePatcher;
+  expression: NodePatcher;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, key: NodePatcher, expression: NodePatcher) {
     super(node, context, editor);
     this.key = key;
@@ -33,9 +36,6 @@ export default class ObjectBodyMemberPatcher extends NodePatcher {
     this.patchAsExpression(options);
   }
 
-  /**
-   * @protected
-   */
   patchAsMethod() {
     let computedKey = this.isComputed();
     if (computedKey) {
@@ -55,24 +55,15 @@ export default class ObjectBodyMemberPatcher extends NodePatcher {
     this.patchExpression();
   }
 
-  /**
-   * @protected
-   */
   patchAsProperty() {
     this.patchKey();
     this.patchExpression();
   }
 
-  /**
-   * @protected
-   */
   patchKey() {
     this.key.patch();
   }
 
-  /**
-   * @protected
-   */
   patchExpression() {
     this.expression.patch({ method: this.isMethod() });
   }

--- a/src/stages/main/patchers/ObjectInitialiserMemberPatcher.js
+++ b/src/stages/main/patchers/ObjectInitialiserMemberPatcher.js
@@ -6,9 +6,6 @@ import ThisPatcher from './ThisPatcher.js';
  * Handles object properties.
  */
 export default class ObjectInitialiserMemberPatcher extends ObjectBodyMemberPatcher {
-  /**
-   * @protected
-   */
   patchAsProperty() {
     if (this.key.node === this.expression.node) {
       this.patchAsShorthand();

--- a/src/stages/main/patchers/ObjectInitialiserPatcher.js
+++ b/src/stages/main/patchers/ObjectInitialiserPatcher.js
@@ -6,6 +6,8 @@ import { COMMA, LBRACE } from 'coffee-lex';
  * Handles object literals.
  */
 export default class ObjectInitialiserPatcher extends NodePatcher {
+  members: Array<NodePatcher>;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, members: Array<NodePatcher>) {
     super(node, context, editor);
     this.members = members;

--- a/src/stages/main/patchers/OfOpPatcher.js
+++ b/src/stages/main/patchers/OfOpPatcher.js
@@ -6,16 +6,10 @@ import { RELATION } from 'coffee-lex';
  * Handles `of` operators, e.g. `a of b` and `a not of b`.
  */
 export default class OfOpPatcher extends NegatableBinaryOpPatcher {
-  /**
-   * @protected
-   */
   expectedOperatorTokenType(): SourceType {
     return RELATION;
   }
 
-  /**
-   * @protected
-   */
   javaScriptOperator() {
     return 'in';
   }

--- a/src/stages/main/patchers/ProgramPatcher.js
+++ b/src/stages/main/patchers/ProgramPatcher.js
@@ -9,6 +9,10 @@ import type { Editor, Node, ParseContext, SourceToken } from './../../../patcher
 const BLOCK_COMMENT_DELIMITER = '###';
 
 export default class ProgramPatcher extends NodePatcher {
+  body: BlockPatcher;
+  helpers: { [key: string]: string };
+  _indentString: ?string;
+
   constructor(node: Node, context: ParseContext, editor: Editor, body: BlockPatcher) {
     super(node, context, editor);
     this.body = body;
@@ -17,9 +21,6 @@ export default class ProgramPatcher extends NodePatcher {
     this._indentString = null;
   }
 
-  /**
-   * @protected
-   */
   canPatchAsExpression(): boolean {
     return false;
   }

--- a/src/stages/main/patchers/ReturnPatcher.js
+++ b/src/stages/main/patchers/ReturnPatcher.js
@@ -2,6 +2,8 @@ import NodePatcher from './../../../patchers/NodePatcher.js';
 import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
 
 export default class ReturnPatcher extends NodePatcher {
+  expression: NodePatcher;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, expression: ?NodePatcher) {
     super(node, context, editor);
     this.expression = expression;

--- a/src/stages/main/patchers/SlicePatcher.js
+++ b/src/stages/main/patchers/SlicePatcher.js
@@ -6,6 +6,10 @@ import { LBRACKET, RANGE, RBRACKET } from 'coffee-lex';
  * Handles array or string slicing, e.g. `names[i..]`.
  */
 export default class SlicePatcher extends NodePatcher {
+  expression: NodePatcher;
+  left: ?NodePatcher;
+  right: ?NodePatcher;
+  
   /**
    * `node` is of type `Slice`.
    */

--- a/src/stages/main/patchers/SpreadPatcher.js
+++ b/src/stages/main/patchers/SpreadPatcher.js
@@ -5,6 +5,8 @@ import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
  * Handles spread operations, e.g. `a(b...)` or `[a...]`.
  */
 export default class SpreadPatcher extends NodePatcher {
+  expression: ?NodePatcher;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, expression: ?NodePatcher) {
     super(node, context, editor);
     this.expression = expression;

--- a/src/stages/main/patchers/SwitchCasePatcher.js
+++ b/src/stages/main/patchers/SwitchCasePatcher.js
@@ -3,6 +3,9 @@ import type { Editor, Node, ParseContext, SourceToken } from '../../../patchers/
 import { BREAK, COMMA, THEN, WHEN } from 'coffee-lex';
 
 export default class SwitchCasePatcher extends NodePatcher {
+  conditions: Array<NodePatcher>;
+  consequent: NodePatcher;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, conditions: Array<NodePatcher>, consequent: NodePatcher) {
     super(node, context, editor);
     this.conditions = conditions;

--- a/src/stages/main/patchers/SwitchPatcher.js
+++ b/src/stages/main/patchers/SwitchPatcher.js
@@ -3,6 +3,10 @@ import type { Editor, Node, ParseContext, SourceToken } from '../../../patchers/
 import { ELSE, SWITCH } from 'coffee-lex';
 
 export default class SwitchPatcher extends NodePatcher {
+  expression: NodePatcher;
+  cases: Array<NodePatcher>;
+  alternate: ?NodePatcher;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher, cases: Array<NodePatcher>, alternate: ?NodePatcher) {
     super(node, context, editor);
     this.expression = expression;

--- a/src/stages/main/patchers/TemplateLiteralPatcher.js
+++ b/src/stages/main/patchers/TemplateLiteralPatcher.js
@@ -4,6 +4,9 @@ import { escapeTemplateStringContents } from '../../../utils/escape.js';
 import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
 
 export default class TemplateLiteralPatcher extends NodePatcher {
+  quasis: Array<NodePatcher>;
+  expressions: Array<NodePatcher>;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, quasis: Array<NodePatcher>, expressions: Array<NodePatcher>) {
     super(node, context, editor);
     this.quasis = quasis;

--- a/src/stages/main/patchers/ThrowPatcher.js
+++ b/src/stages/main/patchers/ThrowPatcher.js
@@ -2,6 +2,8 @@ import NodePatcher from './../../../patchers/NodePatcher.js';
 import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
 
 export default class ThrowPatcher extends NodePatcher {
+  expression: NodePatcher;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher) {
     super(node, context, editor);
     this.expression = expression;

--- a/src/stages/main/patchers/UnaryExistsOpPatcher.js
+++ b/src/stages/main/patchers/UnaryExistsOpPatcher.js
@@ -1,14 +1,10 @@
 import UnaryOpPatcher from './UnaryOpPatcher.js';
-import type { Node, ParseContext, Editor, NodePatcher } from './../../../patchers/types.js';
 
 /**
  * Handles unary exists, e.g. `a?`.
  */
 export default class UnaryExistsOpPatcher extends UnaryOpPatcher {
-  constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher) {
-    super(node, context, editor, expression);
-    this.negated = false;
-  }
+  negated: boolean = false;
 
   /**
    * The expression version of this sometimes needs parentheses, but we don't

--- a/src/stages/main/patchers/UnaryOpPatcher.js
+++ b/src/stages/main/patchers/UnaryOpPatcher.js
@@ -2,6 +2,8 @@ import NodePatcher from './../../../patchers/NodePatcher.js';
 import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
 
 export default class UnaryOpPatcher extends NodePatcher {
+  expression: NodePatcher;
+  
   constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher) {
     super(node, context, editor);
     this.expression = expression;

--- a/src/stages/main/patchers/WhilePatcher.js
+++ b/src/stages/main/patchers/WhilePatcher.js
@@ -10,7 +10,11 @@ import { LOOP, THEN, WHILE } from 'coffee-lex';
  *     b
  */
 export default class WhilePatcher extends NodePatcher {
-  constructor(node: Node, context: ParseContext, editor: Editor, condition: NodePatcher, guard: ?NodePatcher, body: ?BlockPatcher) {
+  condition: NodePatcher;
+  guard: ?NodePatcher;
+  body: BlockPatcher;
+  
+  constructor(node: Node, context: ParseContext, editor: Editor, condition: NodePatcher, guard: ?NodePatcher, body: BlockPatcher) {
     super(node, context, editor);
     this.condition = condition;
     this.guard = guard;

--- a/src/stages/normalize/patchers/ConditionalPatcher.js
+++ b/src/stages/normalize/patchers/ConditionalPatcher.js
@@ -11,6 +11,10 @@ import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
  *   unless list? then return []
  */
 export default class ConditionalPatcher extends NodePatcher {
+  condition: NodePatcher;
+  guard: ?NodePatcher;
+  body: ?NodePatcher;
+
   constructor(node: Node, context: ParseContext, editor: Editor, condition: NodePatcher, consequent: NodePatcher, alternate: ?NodePatcher) {
     super(node, context, editor);
     this.condition = condition;

--- a/src/stages/normalize/patchers/WhilePatcher.js
+++ b/src/stages/normalize/patchers/WhilePatcher.js
@@ -11,7 +11,11 @@ import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
  *   while b() then a()
  */
 export default class WhilePatcher extends NodePatcher {
-  constructor(node: Node, context: ParseContext, editor: Editor, condition: NodePatcher, guard: ?NodePatcher, body: ?NodePatcher) {
+  condition: NodePatcher;
+  guard: ?NodePatcher;
+  body: NodePatcher;
+  
+  constructor(node: Node, context: ParseContext, editor: Editor, condition: NodePatcher, guard: ?NodePatcher, body: NodePatcher) {
     super(node, context, editor);
     this.condition = condition;
     this.guard = guard;


### PR DESCRIPTION
This also removes the `@protected` annotation in some places since WebStorm 2016.1 is not so happy about them.