### PR TITLE
Pinpoint nodes causing errors.

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -172,12 +172,25 @@ export default class NodePatcher {
    * to other patcher methods which can be overridden individually.
    */
   patch(options={}) {
-    if (this.forcedToPatchAsExpression()) {
-      this.patchAsForcedExpression(options);
-    } else if (this.willPatchAsExpression()) {
-      this.patchAsExpression(options);
-    } else {
-      this.patchAsStatement(options);
+    try {
+      if (this.forcedToPatchAsExpression()) {
+        this.patchAsForcedExpression(options);
+      } else if (this.willPatchAsExpression()) {
+        this.patchAsExpression(options);
+      } else {
+        this.patchAsStatement(options);
+      }
+    } catch (err) {
+      if (!PatcherError.isA(err)) {
+        throw this.error(
+          err.message,
+          this.contentStart,
+          this.contentEnd,
+          err
+        );
+      } else {
+        throw err;
+      }
     }
   }
 
@@ -658,8 +671,8 @@ export default class NodePatcher {
   /**
    * Generate an error referring to a particular section of the source.
    */
-  error(message: string, start: number=this.contentStart, end: number=this.contentEnd): PatcherError {
-    return new PatcherError(message, this.context, start, end);
+  error(message: string, start: number=this.contentStart, end: number=this.contentEnd, error: ?Error=null): PatcherError {
+    return new PatcherError(message, this.context, start, end, error);
   }
 
   /**

--- a/src/utils/PatchError.js
+++ b/src/utils/PatchError.js
@@ -3,20 +3,39 @@ import repeat from 'repeating';
 import type { ParseContext } from '../patchers/types.js';
 
 export default class PatchError extends Error {
-  constructor(message: string, context: ParseContext, start: number, end: number) {
+  message: string;
+  context: ParseContext;
+  start: number;
+  end: number;
+  error: ?Error;
+
+  constructor(message: string, context: ParseContext, start: number, end: number, error: ?Error) {
     super(message);
     this.message = message;
     this.context = context;
     this.start = start;
     this.end = end;
+    this.error = error;
   }
 
   toString(): string {
     return this.message;
   }
 
-  static isA(error: Object): boolean {
-    return 'context' in error && 'start' in error && 'end' in error;
+  /**
+   * Due to babel's inability to simulate extending native types, we have our
+   * own method for determining whether an object is an instance of
+   * `PatchError`.
+   * 
+   * @see http://stackoverflow.com/a/33837088/549363
+   */
+  static isA(error: Error): boolean {
+    return (
+      error instanceof Error &&
+      'context' in error &&
+      'start' in error &&
+      'end' in error
+    );
   }
 
   static prettyPrint(error: PatchError) {


### PR DESCRIPTION
Inspired by #150 since the error occurs on a large file and it isn’t obvious what caused it.