### PR TITLE
Fix patching booleans in some contexts.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ import NodePatcher from './NodePatcher.js';
 
 export default class BoolPatcher extends NodePatcher {
   patchAsExpression() {
-    let source = this.context.source.slice(this.contentStart, this.contentEnd);
+    let source = this.getOriginalSource();
     switch (source) {
       case 'yes':
       case 'on':
@@ -158,7 +158,7 @@ import NodePatcher from './NodePatcher.js';
 
 export default class BoolPatcher extends NodePatcher {
   patchAsExpression() {
-    let source = this.context.source.slice(this.contentStart, this.contentEnd);
+    let source = this.getOriginalSource();
     switch (source) {
       case 'yes':
       case 'on':

--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -488,6 +488,20 @@ export default class NodePatcher {
   }
 
   /**
+   * Gets the original source of this patcher's node.
+   */
+  getOriginalSource(): string {
+    return this.context.source.slice(this.contentStart, this.contentEnd);
+  }
+
+  /**
+   * Gets the patched source of this patcher's node.
+   */
+  getPatchedSource(): string {
+    return this.slice(this.contentStart, this.contentEnd);
+  }
+
+  /**
    * Gets the index of a token after `contentStart` with the matching type, ignoring
    * non-semantic types by default.
    */
@@ -672,7 +686,7 @@ export default class NodePatcher {
   makeRepeatable(parens: boolean, ref: ?string=null): string {
     if (this.isRepeatable()) {
       // If we can repeat it, just return the original source.
-      return this.context.source.slice(this.contentStart, this.contentEnd);
+      return this.getOriginalSource();
     } else {
       // Can't repeat it, so we assign it to a free variable and return that,
       // i.e. `a + b` → `(ref = a + b)`.

--- a/src/stages/main/patchers/BoolPatcher.js
+++ b/src/stages/main/patchers/BoolPatcher.js
@@ -2,7 +2,7 @@ import NodePatcher from './../../../patchers/NodePatcher.js';
 
 export default class BoolPatcher extends NodePatcher {
   patchAsExpression() {
-    switch (this.slice(this.contentStart, this.contentEnd)) {
+    switch (this.getOriginalSource()) {
       case 'off':
       case 'no':
         this.overwrite(this.contentStart, this.contentEnd, 'false');

--- a/src/stages/main/patchers/ThisPatcher.js
+++ b/src/stages/main/patchers/ThisPatcher.js
@@ -12,6 +12,6 @@ export default class ThisPatcher extends NodePatcher {
   }
 
   isShorthandThis() {
-    return this.context.source.slice(this.contentStart, this.contentEnd) === '@';
+    return this.getOriginalSource() === '@';
   }
 }

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -186,4 +186,12 @@ describe('function calls', () => {
   it('converts rest params in function calls', () => {
     check(`(a,b...)->b[0]`, `(a,...b)=> b[0];`);
   });
+
+  it('works when the entire span of arguments is replaced', () => {
+    check(`
+      a yes
+    `, `
+      a(true);
+    `);
+  });
 });


### PR DESCRIPTION
Introduces `getOriginalSource` and `getPatchedSource`. The reason the original code failed is that we might have replaced up to the start of the node, and magic string does not allow slicing using the end of an edited range as a slice anchor.

Fixes #150.