### PR TITLE
Fix logical compound assignments

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "dependencies": {
     "add-variable-declarations": "^1.3.1",
     "babel-eslint": "^5.0.0",
-    "coffee-lex": "^1.3.7",
-    "decaffeinate-parser": "^1.2.10",
+    "coffee-lex": "^1.3.9",
+    "decaffeinate-parser": "^1.2.12",
     "detect-indent": "^4.0.0",
     "eslint": "^1.10.3",
     "esnext": "^1.15.7",

--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -786,7 +786,7 @@ export default class NodePatcher {
   /**
    * Claim a binding that is unique in the current scope.
    */
-  claimFreeBinding(ref: string|Array<string>='ref'): string {
+  claimFreeBinding(ref: ?string|Array<string>=null): string {
     return this.node.scope.claimFreeBinding(this.node, ref);
   }
 

--- a/src/utils/Scope.js
+++ b/src/utils/Scope.js
@@ -54,7 +54,8 @@ export default class Scope {
    * @param {string|Array<string>=} name
    * @returns {string}
    */
-  claimFreeBinding(node, name='ref') {
+  claimFreeBinding(node, name=null) {
+    if (!name) { name = 'ref'; }
     let names = Array.isArray(name) ? name : [name];
     let binding = find(names, name => !this.getBinding(name));
 

--- a/test/compound_assignment_test.js
+++ b/test/compound_assignment_test.js
@@ -441,5 +441,14 @@ describe('compound assignment', () => {
         if ((base = a())[name = b()] == null) { base[name] = 1; }
       `);
     });
+
+    it('patches children', () => {
+      check(`
+        (a or b).c or= d or e
+      `, `
+        let base;
+        if (!((base = a || b)).c) { base.c = d || e; }
+      `);
+    });
   });
 });


### PR DESCRIPTION
- `or=` was being interpreted as two tokens, `or` and `=`
- `or=` wasn’t identified as needing to negate its condition
- logical op compound assignments didn’t patch their expressions