### PR TITLE
Converted ESLint rules into a plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,11 +15,12 @@
     "babel/object-shorthand": 1,
     "babel/generator-star-spacing": 1,
     "babel/new-cap": 1,
-    "require-import-extension": 2,
-    "no-const-except-at-top": 2
+    "decaffeinate/require-import-extension": 2,
+    "decaffeinate/no-const-except-at-top": 2
   },
   "plugins": [
-    "eslint-plugin-babel"
+    "babel",
+    "decaffeinate"
   ],
   "globals": {
     "Class": true

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -1,0 +1,10 @@
+module.exports = {
+	rules: {
+		'no-const-except-at-top': require('./no-const-except-at-top'),
+		'require-import-extension': require('./require-import-extension')
+	},
+	rulesConfig: {
+		'no-const-except-at-top': 0,
+		'require-import-extension': 0
+	}
+};

--- a/eslint-rules/package.json
+++ b/eslint-rules/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "eslint-plugin-decaffeinate",
+	"version": "0.1.0",
+	"main": "index.js"
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "decaffeinate": "./bin/decaffeinate"
   },
   "scripts": {
-    "lint": "eslint --rulesdir eslint-rules src test",
+    "lint": "eslint src test",
     "pretest": "npm run build",
     "test": "mocha --compilers js:./test/support/babel-register.js --recursive",
     "prebuild": "npm run lint",
@@ -58,6 +58,7 @@
     "browserify": "^13.0.0",
     "eslint": "^1.10.3",
     "eslint-plugin-babel": "^3.1.0",
+    "eslint-plugin-decaffeinate": "file:eslint-rules",
     "mocha": "^2.4.5",
     "mversion": "^1.10.1",
     "rollup": "^0.25.4",


### PR DESCRIPTION
as rulesdir is deprecated: eslint/eslint#2715

this has the sideeffect that you can run eslint without commandline options