### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # decaffeinate [![Build Status](https://travis-ci.org/decaffeinate/decaffeinate.svg?branch=master)](https://travis-ci.org/decaffeinate/decaffeinate)
 
 CoffeeScript in, modern JavaScript out.
-
-JavaScript is the future, in part thanks to CoffeeScript. Now that it has served
-its purpose, it's time to move on. Convert your CoffeeScript source to modern
-JavaScript with decaffeinate.
+Convert your CoffeeScript source to modern JavaScript with decaffeinate.
 
 ## Install
 


### PR DESCRIPTION
*'time to move on'* might look a bit opiniated / demotivating to use coffeescript as a syntax.
Imho coffeescript users can just keep using coffeescript syntax thanks to decaffeinate :)