### PR TITLE
fix isSurroundedByParentheses

### DIFF
--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -304,4 +304,12 @@ describe('conditionals', () => {
       Math.pow(a, b ? c : d);
     `);
   });
+
+  it('adds parenthesis if needed', () => {
+    check(`
+      alert if (a) and (b)
+    `, `
+      if ((a) && (b)) { alert; }
+    `);
+  });
 });


### PR DESCRIPTION
current implementation assumes "surrounded", when it starts with a left and ends with a right parenthese, which is false positiv in case of `(a) and (b)`