### PR TITLE
Bring `NewOpPatcher` in line with `FunctionApplicationPatcher`.

### DIFF
--- a/src/stages/main/patchers/NewOpPatcher.js
+++ b/src/stages/main/patchers/NewOpPatcher.js
@@ -1,51 +1,6 @@
-import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
-import { COMMA } from 'coffee-lex';
+import FunctionApplicationPatcher from './FunctionApplicationPatcher.js';
 
 /**
  * Handles construction of objects with `new`.
  */
-export default class NewOpPatcher extends NodePatcher {
-  ctor: NodePatcher;
-  args: Array<NodePatcher>;
-  
-  constructor(node: Node, context: ParseContext, editor: Editor, ctor: NodePatcher, args: Array<NodePatcher>) {
-    super(node, context, editor);
-    this.ctor = ctor;
-    this.args = args;
-  }
-
-  initialize() {
-    this.ctor.setRequiresExpression();
-    this.args.forEach(arg => arg.setRequiresExpression());
-  }
-
-  patchAsExpression() {
-    this.ctor.patch();
-    let implicitCall = this.isImplicitCall();
-    if (this.args.length > 0) {
-      if (implicitCall) {
-        this.overwrite(this.ctor.outerEnd, this.args[0].outerStart, '(');
-      }
-      this.args.forEach((arg, i, args) => {
-        arg.patch();
-        let isLast = i === args.length - 1;
-        if (!isLast && !arg.hasSourceTokenAfter(COMMA)) {
-          this.insert(arg.outerEnd, ',');
-        }
-      });
-      if (implicitCall) {
-        this.insert(this.args[this.args.length - 1].outerEnd, ')');
-      }
-    } else if (implicitCall) {
-      this.insert(this.ctor.outerEnd, '()');
-    }
-  }
-
-  /**
-   * @private
-   */
-  isImplicitCall(): boolean {
-    return this.context.source[this.ctor.outerEnd] !== '(';
-  }
-}
+export default class NewOpPatcher extends FunctionApplicationPatcher {}

--- a/test/new_op_test.js
+++ b/test/new_op_test.js
@@ -30,4 +30,17 @@ describe('`new` operator', () => {
       new Object();
     `);
   });
+
+  it('inserts missing parentheses before an implicit object brace', () => {
+    check(`
+      new A
+        a: a
+        b: b
+    `, `
+      new A({
+        a,
+        b
+      });
+    `);
+  });
 });


### PR DESCRIPTION
This ensures they're always patched the same way. Fixes #198.