### PR TITLE
Handle implicit objects wrapped in parens

### DIFF
--- a/src/stages/main/patchers/ObjectInitialiserPatcher.js
+++ b/src/stages/main/patchers/ObjectInitialiserPatcher.js
@@ -29,7 +29,7 @@ export default class ObjectInitialiserPatcher extends NodePatcher {
       let textToInsert = '{';
       let shouldIndent = false;
       if (this.shouldExpandCurlyBraces()) {
-        if (this.implicitlyReturns()) {
+        if (this.implicitlyReturns() && !this.isSurroundedByParentheses()) {
           textToInsert = `{\n${this.getIndent()}`;
           shouldIndent = true;
         } else {

--- a/src/stages/main/patchers/ObjectInitialiserPatcher.js
+++ b/src/stages/main/patchers/ObjectInitialiserPatcher.js
@@ -95,7 +95,7 @@ export default class ObjectInitialiserPatcher extends NodePatcher {
       this.insert(this.contentStart, '(');
     }
     if (implicitObject) {
-      if (this.shouldExpandCurlyBraces()) {
+      if (this.shouldExpandCurlyBraces() && !this.isSurroundedByParentheses()) {
         this.insert(this.innerStart, `{\n${this.getIndent()}`);
         this.indent();
       } else {
@@ -104,7 +104,7 @@ export default class ObjectInitialiserPatcher extends NodePatcher {
     }
     this.patchMembers();
     if (implicitObject) {
-      if (this.shouldExpandCurlyBraces()) {
+      if (this.shouldExpandCurlyBraces() && !this.isSurroundedByParentheses()) {
         this.appendLineAfter('}', -1);
       } else {
         this.insert(this.innerEnd, '}');

--- a/src/stages/main/patchers/ObjectInitialiserPatcher.js
+++ b/src/stages/main/patchers/ObjectInitialiserPatcher.js
@@ -9,7 +9,7 @@ import { isSemanticToken } from '../../../utils/types.js';
  */
 export default class ObjectInitialiserPatcher extends NodePatcher {
   members: Array<NodePatcher>;
-  
+
   constructor(node: Node, context: ParseContext, editor: Editor, members: Array<NodePatcher>) {
     super(node, context, editor);
     this.members = members;
@@ -33,7 +33,11 @@ export default class ObjectInitialiserPatcher extends NodePatcher {
           textToInsert = `{\n${this.getIndent()}`;
           shouldIndent = true;
         } else {
-          let tokenIndexBeforeOuterStartTokenIndex = this.outerStartTokenIndex.previous();
+          let tokenIndexBeforeOuterStartTokenIndex = this.outerStartTokenIndex;
+          if (!this.isSurroundedByParentheses()) {
+            tokenIndexBeforeOuterStartTokenIndex = tokenIndexBeforeOuterStartTokenIndex.previous();
+          }
+
           if (tokenIndexBeforeOuterStartTokenIndex) {
             let precedingTokenIndex = this.context.sourceTokens.lastIndexOfTokenMatchingPredicate(
               isSemanticToken,
@@ -63,7 +67,7 @@ export default class ObjectInitialiserPatcher extends NodePatcher {
     }
     this.patchMembers();
     if (implicitObject) {
-      if (this.shouldExpandCurlyBraces()) {
+      if (this.shouldExpandCurlyBraces() && !this.isSurroundedByParentheses()) {
         this.appendLineAfter('}', -1);
       } else {
         this.insert(this.innerEnd, '}');

--- a/test/object_test.js
+++ b/test/object_test.js
@@ -300,4 +300,21 @@ describe('objects', () => {
       ;
     `);
   });
+
+  it('adds braces when implicitly returning an implicit multi-line object wrapped in parens', () => {
+    check(`
+      ->
+        (
+          a: b
+          c: d
+        )
+    `, `
+      () =>
+        ({
+          a: b,
+          c: d
+        })
+      ;
+    `);
+  });
 });

--- a/test/object_test.js
+++ b/test/object_test.js
@@ -269,4 +269,18 @@ describe('objects', () => {
       let x = {[ref = \`a\${b}c\`]: ref};
     `);
   });
+
+  it('adds braces when implicit multi-line object is wrapped in parens', () => {
+    check(`
+      x = (
+        a: b
+        c: d
+      )
+    `, `
+      let x = ({
+        a: b,
+        c: d
+      });
+    `);
+  });
 });

--- a/test/object_test.js
+++ b/test/object_test.js
@@ -283,4 +283,21 @@ describe('objects', () => {
       });
     `);
   });
+
+  it('adds braces when explicitly returning an implicit multi-line object wrapped in parens', () => {
+    check(`
+      ->
+        return (
+          a: b
+          c: d
+        )
+    `, `
+      () =>
+        ({
+          a: b,
+          c: d
+        })
+      ;
+    `);
+  });
 });


### PR DESCRIPTION
Some code that I've been attempting to convert to es6 does some fairly odd looking things with parens. However, it is valid CoffeeScript and when compiled to JavaScript "does the right thing".

For example:

```
someFunction = ->
    return (
        a: b
        b: c
    )
```
Compiles to:
```
var someFunction;

someFunction = function() {
  return {
    a: b,
    b: c
  };
};
```
In decaffeinate this currently results in an error raised in the ObjectInitialiserPatcher:

```
NormalizeStage someFunction = ->
    return (
        a: b
        b: c
    )

MainStage someFunction = ->
    return (
        a: b
        b: c
    )

FunctionPatcher INSERT 15 "function" BEFORE "->\n    r"
FunctionPatcher INSERT 15 "() " BEFORE "->\n    r"
FunctionPatcher OVERWRITE [15, 17) "->" → "{"
ObjectInitialiserPatcher INSERT 30 "{\n        " BEFORE "\n       "
ObjectInitialiserPatcher INSERT 29 "    " BEFORE "(\n      "
fail.coffee: cannot edit index 29 because it is not editable (i.e. outside [30, 61))
  1 | someFunction = ->
> 2 |     return (
> 3 |         a: b
> 4 |         b: c
> 5 |     )
  6 | 
```

This PR attempts to fix the above issue and 2 other closely related cases. I've broken each fix down into a single commit with fix + test to make reviewing a little easier. I'm happy to squash into a single commit if you want.