### PR TITLE
add content/location to error message from addVariableDeclarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "Brian Donovan",
   "license": "MIT",
   "dependencies": {
-    "add-variable-declarations": "^1.5.0",
+    "add-variable-declarations": "1.5.0",
     "ast-processor-babylon-config": "^1.0.0",
     "automatic-semicolon-insertion": "^1.0.1",
     "babylon": "^6.7.0",

--- a/src/stages/add-variable-declarations/index.js
+++ b/src/stages/add-variable-declarations/index.js
@@ -9,7 +9,19 @@ export default class AddVariableDeclarationsStage {
     log(content);
 
     let editor = new MagicString(content);
-    addVariableDeclarations(content, editor);
+    try {
+      addVariableDeclarations(content, editor);
+    } catch (err) {
+      if (err.loc) {
+        let {line, column} = err.loc;
+        let lines = content.split('\n');
+        let l = '-'.repeat(column) + '^';
+        lines.splice(line, 0, l, '').join('\n');
+        content = lines.join('\n');
+      }
+      err.message += '\n' + content;
+      throw(err);
+    }
     return {
       code: editor.toString(),
       map: editor.generateMap({


### PR DESCRIPTION
addVariableDeclarations passes the generated JS through babel for the first time. if this throws an exception, you're left with pretty much no idea what happened.
now, if this exceptions contains `loc` information, the generated JS is appended to the err.message to give a hint, where decaffeinate failed.