### PR TITLE
WIP - Improve multi line string support

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "babel-preset-es2015-rollup": "^1.1.1",
     "babel-register": "^6.7.2",
     "browserify": "^13.0.0",
+    "coffee-script": "^1.10.0",
     "eslint": "^2.10.1",
     "eslint-plugin-babel": "^3.2.0",
     "eslint-plugin-decaffeinate": "file:eslint-rules",

--- a/src/stages/main/index.js
+++ b/src/stages/main/index.js
@@ -49,6 +49,7 @@ import SoakedFunctionApplicationPatcher from './patchers/SoakedFunctionApplicati
 import SoakedMemberAccessOpPatcher from './patchers/SoakedMemberAccessOpPatcher.js';
 import SpreadPatcher from './patchers/SpreadPatcher.js';
 import SuperPatcher from './patchers/SuperPatcher.js';
+import StringPatcher from './patchers/StringPatcher.js';
 import SwitchCasePatcher from './patchers/SwitchCasePatcher.js';
 import SwitchPatcher from './patchers/SwitchPatcher.js';
 import TemplateLiteralPatcher from './patchers/TemplateLiteralPatcher.js';
@@ -74,6 +75,7 @@ export default class MainStage extends TransformCoffeeScriptStage {
         return IdentifierPatcher;
 
       case 'String':
+        return StringPatcher;
       case 'Int':
       case 'Float':
       case 'Null':
@@ -112,16 +114,16 @@ export default class MainStage extends TransformCoffeeScriptStage {
 
       case 'This':
         return ThisPatcher;
-  
+
       case 'Yield':
        return YieldPatcher;
-    
+
       case 'YieldFrom':
        return YieldFromPatcher;
-    
+
       case 'GeneratorFunction':
        return GeneratorFunctionPatcher;
-    
+
       case 'Function':
         return FunctionPatcher;
 

--- a/src/stages/main/patchers/HerestringPatcher.js
+++ b/src/stages/main/patchers/HerestringPatcher.js
@@ -1,5 +1,6 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
 import escape, { escapeTemplateStringContents } from '../../../utils/escape.js';
+import joinMultilineString from '../../../utils/joinMultilineString.js';
 
 const HERESTRING_DELIMITER_LENGTH = 3;
 
@@ -26,5 +27,6 @@ export default class HerestringPatcher extends NodePatcher {
       this.remove(contentEnd + 1, this.contentEnd);
       escape(this.editor, [source[this.contentStart]], contentStart, contentEnd);
     }
+    joinMultilineString(this, this.node.raw, this.contentStart);
   }
 }

--- a/src/stages/main/patchers/StringPatcher.js
+++ b/src/stages/main/patchers/StringPatcher.js
@@ -1,0 +1,23 @@
+import PassthroughPatcher from './../../../patchers/PassthroughPatcher.js';
+import joinMultilineString from '../../../utils/joinMultilineString.js';
+
+export default class StringPatcher extends PassthroughPatcher {
+  patchAsExpression() {
+    joinMultilineString(this, this.node.raw, this.contentStart);
+  }
+
+  patch(options={}) {
+    super.patch(options);
+    // Yuck, this is copied from NodePatcher.js super.super.patch(options)??
+    // To ensure all tests pass we need functionality from both in this class.
+    this.withPrettyErrors(() => {
+      if (this.forcedToPatchAsExpression()) {
+        this.patchAsForcedExpression(options);
+      } else if (this.willPatchAsExpression()) {
+        this.patchAsExpression(options);
+      } else {
+        this.patchAsStatement(options);
+      }
+    });
+  }
+}

--- a/src/stages/main/patchers/TemplateLiteralPatcher.js
+++ b/src/stages/main/patchers/TemplateLiteralPatcher.js
@@ -22,8 +22,8 @@ export default class TemplateLiteralPatcher extends NodePatcher {
     } else {
       this.overwrite(contentStart, contentStart + '"'.length, '`');
       this.overwrite(contentEnd - '"'.length, contentEnd, '`');
-      joinMultilineString(this, this.node.raw, contentStart);
     }
+    joinMultilineString(this, this.node.raw, contentStart);
 
     for (let i = 0; i < quasis.length - 1; i++) {
       let quasi = quasis[i];

--- a/src/stages/main/patchers/TemplateLiteralPatcher.js
+++ b/src/stages/main/patchers/TemplateLiteralPatcher.js
@@ -2,11 +2,12 @@ import NodePatcher from './../../../patchers/NodePatcher.js';
 import replaceTripleQuotes from '../../../utils/replaceTripleQuotes.js';
 import { escapeTemplateStringContents } from '../../../utils/escape.js';
 import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import joinMultilineString from '../../../utils/joinMultilineString.js';
 
 export default class TemplateLiteralPatcher extends NodePatcher {
   quasis: Array<NodePatcher>;
   expressions: Array<NodePatcher>;
-  
+
   constructor(node: Node, context: ParseContext, editor: Editor, quasis: Array<NodePatcher>, expressions: Array<NodePatcher>) {
     super(node, context, editor);
     this.quasis = quasis;
@@ -21,6 +22,7 @@ export default class TemplateLiteralPatcher extends NodePatcher {
     } else {
       this.overwrite(contentStart, contentStart + '"'.length, '`');
       this.overwrite(contentEnd - '"'.length, contentEnd, '`');
+      joinMultilineString(this, this.node.raw, contentStart);
     }
 
     for (let i = 0; i < quasis.length - 1; i++) {

--- a/src/utils/joinMultilineString.js
+++ b/src/utils/joinMultilineString.js
@@ -1,0 +1,37 @@
+/**
+ * multi-line strings in coffeescript are joined together replacing each
+ * new with a space. Replace all new lines and remove any indentation.
+ *
+ */
+export default function joinMultilineString(patcher, characters, start) {
+      let offset = 0;
+      let end = 0;
+      let tripleQuoted = patcher.startsWith('\'\'\'') || patcher.startsWith('"""');
+      while (characters.indexOf('\n', offset) >= 0) {
+          let newLinePosition = characters.indexOf('\n', offset);
+          if (newLinePosition >= 0) {
+              end = nextNonWhiteSpaceChar(characters, newLinePosition + 1);
+              if (tripleQuoted) {
+                  patcher.remove(start + newLinePosition, start + end);
+                  patcher.insert(start + newLinePosition, '\\n');
+              } else {
+                  patcher.remove(start + newLinePosition, start + (end - 1));
+              }
+
+          }
+          offset = newLinePosition + 1;
+       }
+}
+
+/**
+ * locate the next non-whitespace character from 'start', used to help
+ * remove indentation.
+ */
+function nextNonWhiteSpaceChar(characters, start) {
+    for (let i = start; i < characters.length; i++) {
+        if (characters[i] != ' ') {
+            return i;
+        }
+    }
+    return start;
+}

--- a/src/utils/joinMultilineString.js
+++ b/src/utils/joinMultilineString.js
@@ -6,17 +6,18 @@
 export default function joinMultilineString(patcher, characters, start) {
       let offset = 0;
       let end = 0;
-      let tripleQuoted = patcher.startsWith('\'\'\'') || patcher.startsWith('"""');
+      //let tripleQuoted = patcher.startsWith('\'\'\'') || patcher.startsWith('"""');
       while (characters.indexOf('\n', offset) >= 0) {
           let newLinePosition = characters.indexOf('\n', offset);
           if (newLinePosition >= 0) {
               end = nextNonWhiteSpaceChar(characters, newLinePosition + 1);
-              if (tripleQuoted) {
-                  patcher.remove(start + newLinePosition, start + end);
-                  patcher.insert(start + newLinePosition, '\\n');
-              } else {
-                  patcher.remove(start + newLinePosition, start + (end - 1));
-              }
+              //if (tripleQuoted) {
+              //    patcher.remove(start + newLinePosition, start + end);
+              //    patcher.insert(start + newLinePosition, '\\n');
+              //} else {
+              //    patcher.remove(start + newLinePosition, start + (end - 1));
+              //}
+              patcher.remove(start + newLinePosition, start + (end - 1));
 
           }
           offset = newLinePosition + 1;

--- a/src/utils/joinMultilineString.js
+++ b/src/utils/joinMultilineString.js
@@ -6,19 +6,19 @@
 export default function joinMultilineString(patcher, characters, start) {
       let offset = 0;
       let end = 0;
-      //let tripleQuoted = patcher.startsWith('\'\'\'') || patcher.startsWith('"""');
+      let tripleQuoted = patcher.startsWith('\'\'\'') || patcher.startsWith('"""');
       while (characters.indexOf('\n', offset) >= 0) {
           let newLinePosition = characters.indexOf('\n', offset);
           if (newLinePosition >= 0) {
               end = nextNonWhiteSpaceChar(characters, newLinePosition + 1);
-              //if (tripleQuoted) {
-              //    patcher.remove(start + newLinePosition, start + end);
-              //    patcher.insert(start + newLinePosition, '\\n');
-              //} else {
-              //    patcher.remove(start + newLinePosition, start + (end - 1));
-              //}
-              patcher.remove(start + newLinePosition, start + (end - 1));
-
+              if (tripleQuoted) {
+                patcher.remove(start + newLinePosition + 1, start + end);
+              } else {
+                if (newLinePosition != (end - 1)) {
+                    end = end - 1;
+                }
+                patcher.remove(start + newLinePosition, start + end);
+              }
           }
           offset = newLinePosition + 1;
        }
@@ -30,9 +30,12 @@ export default function joinMultilineString(patcher, characters, start) {
  */
 function nextNonWhiteSpaceChar(characters, start) {
     for (let i = start; i < characters.length; i++) {
+        console.log('checking', i, characters[i]);
         if (characters[i] != ' ') {
+            console.log('return', i);
             return i;
         }
     }
+    console.log('found none', start);
     return start;
 }

--- a/test/string_interpolation_test.js
+++ b/test/string_interpolation_test.js
@@ -89,4 +89,24 @@ describe('string interpolation', () => {
       \`\${a} \${b}\`;
     `);
   });
+
+  it('joins multi line doubled quoted strings on new lines and removes indentation with variable interpolation', () => {
+    check(`
+     a = "multi line
+          double\\nquote
+          #{variable}"
+     `, `
+     let a = \`multi line double\\nquote \${variable}\`;
+     `);
+  });
+
+  it('joins multi line single quoted strings on new lines and removes indentation without variable interpolation', () => {
+    check(`
+     a = 'multi line
+          double\\nquote
+          #{variable}'
+     `, `
+     let a = \`multi line double\\nquote \#{variable}\`;
+     `);
+  });
 });

--- a/test/string_interpolation_test.js
+++ b/test/string_interpolation_test.js
@@ -90,7 +90,7 @@ describe('string interpolation', () => {
     `);
   });
 
-  it('joins multi line doubled quoted strings on new lines and removes indentation with variable interpolation', () => {
+  xit('joins multi line doubled quoted strings on new lines and removes indentation with variable interpolation', () => {
     check(`
      a = "multi line
           double\\nquote
@@ -100,7 +100,7 @@ describe('string interpolation', () => {
      `);
   });
 
-  it('joins multi line single quoted strings on new lines and removes indentation without variable interpolation', () => {
+  xit('joins multi line single quoted strings on new lines and removes indentation without variable interpolation', () => {
     check(`
      a = 'multi line
           double\\nquote

--- a/test/string_test.js
+++ b/test/string_test.js
@@ -133,7 +133,9 @@ describe('string integration test', () => {
                     ['\'\'\'', 'triple single quote'],
                     ['"""', 'triple double quote']];
   let newLineTypes = [['', 'without new lines'],
-                      ['\n            ', 'with new lines']];
+                      ['\n            ', 'with new lines'],
+                      ['\n\n           ', 'with new lines, empty lines'],
+                      ['\n             \n           ', 'with new lines, indented empty lines']];
   let interpolations = [['', 'without interpolation'],
                         ['#{testVariable}', 'with string variable interpolation'],
                         ['#{ 22 / 7}', 'with numerical interpolation']];
@@ -148,7 +150,7 @@ describe('string integration test', () => {
           validate(
 `() ->
   testVariable = "only testing!"
-  return ${quoteType}a line of text${newLineType}perhaps some${interpolation}${newLineType}and then${quoteType}
+  return ${quoteType}START a line of text${newLineType}perhaps some${interpolation}${newLineType}and END${quoteType}
 `);
         });
       }

--- a/test/string_test.js
+++ b/test/string_test.js
@@ -1,4 +1,5 @@
 import check from './support/check.js';
+import validate from './support/validate.js';
 
 describe('strings', () => {
   it('changes single-line triple-double-quotes to double-quotes', () => {
@@ -124,4 +125,33 @@ describe('strings', () => {
      let a = \`multi line\\ndouble\\nquote\\nstring\`;
      `);
   });
+});
+
+describe('string integration test', () => {
+  let quoteTypes = [['\'', 'single quote'],
+                    ['"', 'double quote'],
+                    ['\'\'\'', 'triple single quote'],
+                    ['"""', 'triple double quote']];
+  let newLineTypes = [['', 'without new lines'],
+                      ['\n            ', 'with new lines']];
+  let interpolations = [['', 'without interpolation'],
+                        ['#{testVariable}', 'with string variable interpolation'],
+                        ['#{ 22 / 7}', 'with numerical interpolation']];
+
+  for (let quote of quoteTypes) {
+    for (let newLine of newLineTypes) {
+      for (let interp of interpolations) {
+        let [quoteType, quoteTypeFriendly] = quote;
+        let [newLineType, newLineTypeFriendly] = newLine;
+        let [interpolation, interpolationFriendly] = interp;
+        it(quoteTypeFriendly + ' ' + newLineTypeFriendly + ' and ' + interpolationFriendly, () => {
+          validate(
+`() ->
+  testVariable = "only testing!"
+  return ${quoteType}a line of text${newLineType}perhaps some${interpolation}${newLineType}and then${quoteType}
+`);
+        });
+      }
+    }
+  }
 });

--- a/test/string_test.js
+++ b/test/string_test.js
@@ -85,7 +85,7 @@ describe('strings', () => {
     `);
   });
 
-  it('joins multi line doubled quoted strings on new lines and removes indentation', () => {
+  xit('joins multi line doubled quoted strings on new lines and removes indentation', () => {
     check(`
      a = "multi line
           double\\nquote
@@ -95,7 +95,7 @@ describe('strings', () => {
      `);
   });
 
-  it('joins multi line single quoted strings on new lines and removes indentation', () => {
+  xit('joins multi line single quoted strings on new lines and removes indentation', () => {
     check(`
      a = 'multi line
           double\\nquote
@@ -105,7 +105,7 @@ describe('strings', () => {
      `);
   });
 
-  it('joins multi line triple double quoted strings on new lines, removes indentation and adds new line characters', () => {
+  xit('joins multi line triple double quoted strings on new lines, removes indentation and adds new line characters', () => {
     check(`
      a = """multi line
           double\\nquote
@@ -115,7 +115,7 @@ describe('strings', () => {
      `);
   });
 
-  it('joins multi line triple single quoted strings on new lines, removes indentation and adds new line characters', () => {
+  xit('joins multi line triple single quoted strings on new lines, removes indentation and adds new line characters', () => {
     check(`
      a = '''multi line
           double\\nquote

--- a/test/string_test.js
+++ b/test/string_test.js
@@ -84,4 +84,44 @@ describe('strings', () => {
       line2\`);
     `);
   });
+
+  it('joins multi line doubled quoted strings on new lines and removes indentation', () => {
+    check(`
+     a = "multi line
+          double\\nquote
+          string"
+     `, `
+     let a = "multi line double\\nquote string";
+     `);
+  });
+
+  it('joins multi line single quoted strings on new lines and removes indentation', () => {
+    check(`
+     a = 'multi line
+          double\\nquote
+          string'
+     `, `
+     let a = 'multi line double\\nquote string';
+     `);
+  });
+
+  it('joins multi line triple double quoted strings on new lines, removes indentation and adds new line characters', () => {
+    check(`
+     a = """multi line
+          double\\nquote
+          string"""
+     `, `
+     let a = \`multi line\\ndouble\\nquote\\nstring\`;
+     `);
+  });
+
+  it('joins multi line triple single quoted strings on new lines, removes indentation and adds new line characters', () => {
+    check(`
+     a = '''multi line
+          double\\nquote
+          string'''
+     `, `
+     let a = \`multi line\\ndouble\\nquote\\nstring\`;
+     `);
+  });
 });

--- a/test/support/validate.js
+++ b/test/support/validate.js
@@ -1,0 +1,59 @@
+import { convert } from '../../dist/decaffeinate.cjs.js';
+import { strictEqual } from 'assert';
+//import stripSharedIndent from '../../src/utils/stripSharedIndent.js';
+import PatchError from '../../src/utils/PatchError.js';
+import coffee from 'coffee-script';
+import * as babel from 'babel-core';
+import * as vm from 'vm';
+
+/*
+ * validate takes a string that contains a CoffeeScript function as input. It*
+ * runs this string through two code paths and compares the final output.
+ *
+ * The first path is through the main coffee script compiler, the second
+ * path is through decaffeinate, and then babel. The both functions are
+ * then eval'ed and the output compared.
+ *
+ * e.g
+ * validate(
+ * `->
+ *   return "this is the string I want to validate"
+ * `);
+ *
+ */
+export default function validate(source) {
+  try {
+    runValidation(source);
+  } catch (err) {
+    if (PatchError.isA(err)) {
+      console.error(PatchError.prettyPrint(err));
+    }
+    console.error('validate input source:\n', source);
+    throw err;
+  }
+}
+
+function runValidation(source) {
+  let  decaffeinateES6 = convert(source);
+  decaffeinateES6 = decaffeinateES6.code;
+
+  let decaffeinateES5 = babel.transform(decaffeinateES6, {presets: ['es2015']}).code;
+
+  let coffeeOutput = coffee.eval(source);
+  let sandbox = {};
+  vm.createContext(sandbox);
+  let decaffeinateOutput = vm.runInContext(decaffeinateES5, sandbox);
+  if (typeof coffeeOutput != 'function') {
+    throw new Error('validate could not convert source via coffee-script compiler to a function');
+  }
+  if (typeof decaffeinateOutput != 'function') {
+    throw new Error('validate could not convert source via decaffeinate + babel to a function');
+  }
+
+  coffeeOutput = coffeeOutput();
+  decaffeinateOutput = decaffeinateOutput();
+
+  strictEqual(typeof coffeeOutput, 'string');
+  strictEqual(typeof decaffeinateOutput, 'string');
+  strictEqual(coffeeOutput, decaffeinateOutput);
+}


### PR DESCRIPTION
This is a work in progress, looking for a bit of feedback (it has broken tests, though they're of interest).

I started working on a fix for  #220 and discovered that there are some edge cases where decaffeinate does not convert triple quoted strings into template literals correctly or double quoted multi line strings that contain string interpolation (this is in addition to #220).

This PR starts to fix the problem (though its a little rough around the edges), it tries to convert strings correctly but does so at the expense of losing some of the original formatting.

An example 
```coffeescript
() ->
    return """multi line
              triple\nquoted
              string"""
```
Expected javascript
```javascript
(function() {
  return "multi line\ntriple\nquoted\nstring";
});
```
decaffeinate 2.10.0
```es6
() =>
    `multi line
              triple\nquoted
              string`
;
```
decaffeinate on this branch
```
() => `multi line\ntriple\nquoted\nstring`;
```

Based on the above, a few questions.
1. Before going on to fixing the newly broken tests, Is converting the multi line strings in this way sensible?
2. There is some nasty code in the StringPatcher (see patch method) any thoughts on how to make this better? 