### PR TITLE
Improve support for multi line strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   ],
   "devDependencies": {
     "babel": "^6.5.2",
+    "babel-core": "^6.9.1",
     "babel-eslint": "^6.0.4",
     "babel-plugin-syntax-class-properties": "^6.5.0",
     "babel-plugin-syntax-flow": "^6.5.0",
@@ -56,6 +57,7 @@
     "babel-preset-es2015-rollup": "^1.1.1",
     "babel-register": "^6.7.2",
     "browserify": "^13.0.0",
+    "coffee-script": "^1.10.0",
     "eslint": "^2.10.1",
     "eslint-plugin-babel": "^3.2.0",
     "eslint-plugin-decaffeinate": "file:eslint-rules",

--- a/src/stages/main/index.js
+++ b/src/stages/main/index.js
@@ -48,6 +48,7 @@ import SlicePatcher from './patchers/SlicePatcher.js';
 import SoakedFunctionApplicationPatcher from './patchers/SoakedFunctionApplicationPatcher.js';
 import SoakedMemberAccessOpPatcher from './patchers/SoakedMemberAccessOpPatcher.js';
 import SpreadPatcher from './patchers/SpreadPatcher.js';
+import StringPatcher from './patchers/StringPatcher.js';
 import SuperPatcher from './patchers/SuperPatcher.js';
 import SwitchCasePatcher from './patchers/SwitchCasePatcher.js';
 import SwitchPatcher from './patchers/SwitchPatcher.js';
@@ -74,6 +75,7 @@ export default class MainStage extends TransformCoffeeScriptStage {
         return IdentifierPatcher;
 
       case 'String':
+        return StringPatcher;
       case 'Int':
       case 'Float':
       case 'Null':

--- a/src/stages/main/patchers/StringPatcher.js
+++ b/src/stages/main/patchers/StringPatcher.js
@@ -1,0 +1,67 @@
+import PassthroughPatcher from './../../../patchers/PassthroughPatcher.js';
+import { parseMultilineString } from '../../../utils/parseMultilineString.js';
+
+export default class StringPatcher extends PassthroughPatcher {
+  patchAsExpression() {
+    if (this.node.raw.indexOf('\n') >= 0) {
+        patchMultilineString(this, this.node.raw, this.contentStart);
+    }
+  }
+
+  patch(options={}) {
+    super.patch(options);
+    // This is copied from NodePatcher.js, we need functionality from
+    // both PassthroughPatcherr and NodePatcher for this patcher to work.
+    this.withPrettyErrors(() => {
+      if (this.forcedToPatchAsExpression()) {
+        this.patchAsForcedExpression(options);
+      } else if (this.willPatchAsExpression()) {
+        this.patchAsExpression(options);
+      } else {
+        this.patchAsStatement(options);
+      }
+    });
+  }
+}
+
+/* convert a multi line string encosed in single or double quotes (not
+ * triple quoted) to es6 ensuring that the string produced will be 
+ * identical to the es5 output produced by coffee-script.
+ */
+function patchMultilineString(patcher, characters, start) {
+  let lines = parseMultilineString(characters, start, 1);
+
+  for (let line of lines) {
+    if (line.first) {
+      if (line.empty == false && line.next.empty == false) {
+        patcher.overwrite(line.textEnd + 1, line.end, ' ');
+      } else if (line.empty == false && line.next.empty == true) {
+        patcher.remove(line.textEnd + 1, line.end);
+      } else if (line.empty == true) {
+        patcher.remove(line.start, line.end);
+      } 
+    } else if (line.last) {
+      if (line.textStart != null && line.textStart != line.start) {
+        patcher.remove(line.start, line.textStart);
+      } else if (line.textStart == null && line.textEnd == null && (line.length != 0)) {
+        patcher.remove(line.start - 1, line.end);
+      }
+    } else {
+      if (line.empty == false && line.next.empty == false) {
+        patcher.overwrite(line.textEnd + 1, line.end, ' ');
+        patcher.remove(line.start, line.textStart);
+      } else if (line.empty == false && line.next.empty == true) {
+        patcher.remove(line.textEnd + 1, line.end);
+        patcher.remove(line.start, line.textStart);
+      } else if (line.empty == true && line.next.empty == true) {
+        patcher.remove(line.start, line.end);
+      } else if (line.empty == true && line.next.empty == false) {
+        if (line.prev.empty == true) {
+          patcher.remove(line.start, line.end);
+        } else {
+          patcher.overwrite(line.start, line.end, ' ');
+        }
+      }
+    }
+  }
+}

--- a/src/utils/parseMultilineString.js
+++ b/src/utils/parseMultilineString.js
@@ -1,0 +1,74 @@
+/* parseMutlilineString takes a raw string as input and returns 
+ * an array of 'line' objects representing each line of the string.
+ * These can then be used to patch a string ensuring the output
+ * is identical to coffee script.
+ */
+export function parseMultilineString(string, offsetStart, quoteLen) {
+  let output = [];
+  let offset = offsetStart + quoteLen;
+  string = string.slice(quoteLen, string.length - quoteLen);
+
+  for (let line of string.split('\n')) {
+    let textStartOffset = getTextStartOffset(line);
+    let textEndOffset = getTextEndOffset(line);
+    let empty = textStartOffset == null && textEndOffset == null;
+
+    output.push({
+      content: line,
+      length: line.length,
+      indent: textStartOffset,
+      start: offset,
+      end: offset + line.length + 1,
+      textStart: (textStartOffset == null) ? null: offset + textStartOffset,
+      textEnd: (textEndOffset == null) ? null: offset + textEndOffset,
+      prev: null,
+      next: null,
+      empty,
+      first: false,
+      last: false
+    });
+    offset = offset + line.length + '\n'.length; 
+  } 
+
+  for (let i = 0; i < output.length - 1; i++) {
+    if (i > 0) {
+      output[i].prev = output[i - 1];
+    }
+    if (i < output.length - 1) {
+      output[i].next = output[i + 1];
+    }
+  }
+    
+  output[0].first = true;
+  output[output.length -1].last = true;
+  output[output.length -1].end = output[output.length -1].end - '\n'.length;
+  return output;
+}
+
+/* return the offset within the string of the 
+ * first non white space character, returns
+ * null if the string is 0 length or if the line
+ * is all white space.
+ */
+function getTextStartOffset(line) {
+  for (let i = 0; i < line.length; i++) {
+    if (line[i] != ' ') {
+      return i;
+    }
+  }
+  return null;
+}
+
+/* return the offset within the string of the last
+ * non white space character, returns null if the
+ * string is 0 length or if the line is all white
+ * space.
+ */
+function getTextEndOffset(line) {
+  for (let i = line.length - 1; i >= 0; i--) {
+    if (line[i] != ' ') {
+      return i;
+    }
+  }
+  return null;
+}

--- a/test/string_integration_test.js
+++ b/test/string_integration_test.js
@@ -1,0 +1,76 @@
+import validate from './support/validate.js';
+
+function generateTwoLineTests(strings) {
+  let output = [];
+  for (let line1 of strings) {
+    for (let line2 of strings) {
+      output.push(line1 + '\n' + line2);
+    }
+  }
+  return output;
+}
+
+function generateThreeLineTests(strings) {
+  let output = [];
+  for (let line1 of strings) {
+    for (let line2 of strings) {
+      for (let line3 of strings) {
+        output.push(line1 + '\n' + line2 + '\n' + line3);
+      }
+    }
+  }
+  return output;
+}
+
+function runAssignmentTest(quote, string) {
+  validate(
+`testVariable = "test variable"
+o=${quote}${string}${quote}`);
+}
+
+function runFunctionTest(quote, string) {
+  validate(
+`runTest = () ->
+  testVariable = "test variable"
+  return ${quote}${string}${quote}
+output = runTest()`);
+}
+
+describe('string integration', function () {
+  this.timeout(60000);
+  let strings = ['', '   ', 'word', '   leading indent', 'trailing indent   ', 
+                 '    leading and trailing indent    '];
+  let quotes = [
+    ['\'', 'single quote (\')'],
+    ['"', 'double quote (\")']];
+
+  let twoLineTests = generateTwoLineTests(strings);
+  let threeLineTests = generateThreeLineTests(strings);
+
+  for (let quoteTest of quotes) {
+    let [quote, quoteName] = quoteTest;
+    it(quoteName + ' two line assignment test (' + twoLineTests.length + ' permutations)', function () {
+      for (let string of twoLineTests) {
+        runAssignmentTest(quote, string);
+      }
+    });
+
+    it(quoteName + ' two line function test (' + twoLineTests.length + ' permutations)', function () {
+      for (let string of twoLineTests) {
+        runFunctionTest(quote, string);
+      }
+    });
+
+    it(quoteName + ' three line assignment test (' + threeLineTests.length + ' permutations)', function () {
+      for (let string of threeLineTests) {
+        runAssignmentTest(quote, string);
+      }
+    });
+
+    it(quoteName + ' three line function test (' + threeLineTests.length + ' permutations)', function () {
+      for (let string of threeLineTests) {
+        runFunctionTest(quote, string);
+      }
+    });
+  }
+});

--- a/test/string_test.js
+++ b/test/string_test.js
@@ -84,4 +84,23 @@ describe('strings', () => {
       line2\`);
     `);
   });
+
+  it('converts multi line string assignment', () => {
+    check(`
+      a = "this is a 
+           multi line
+           string"
+      `, `
+      let a = "this is a multi line string";
+    `);
+  });
+  it('converts multi line string in function call', () => {
+    check(`
+      fn("this is a 
+          multi line
+          string")
+      `, `
+      fn("this is a multi line string");
+    `);
+  });
 });

--- a/test/support/validate.js
+++ b/test/support/validate.js
@@ -1,0 +1,65 @@
+import { convert } from '../../dist/decaffeinate.cjs.js';
+import { strictEqual } from 'assert';
+import PatchError from '../../src/utils/PatchError.js';
+import coffee from 'coffee-script';
+import * as babel from 'babel-core';
+import * as vm from 'vm';
+
+/*
+ * validate takes coffee-script as input with code that sets the variable
+ * 'o'. The coffee-script is run through two different transform paths:
+ * 
+ * 1) source input -> coffee-script -> ES5
+ * 2) source input -> decaffeinate -> ES6 -> babel -> ES5
+ * 
+ * The ES5 from both paths is run in a sandbox and then the 'o' variable
+ * from the scope of each sandbox is compared. If the output is the same
+ * then the test has passed.
+ */
+export default function validate(source) {
+  try {
+    runValidation(source);
+  } catch (err) {
+    if (PatchError.isA(err)) {
+      console.error(PatchError.prettyPrint(err));
+    }
+    throw err;
+  }
+}
+
+function runCodeAndExtract(source) {
+  let sandbox = {o: null};
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox); 
+  return sandbox.o;
+}
+
+function runValidation(source) {
+  let coffeeES5 = coffee.compile(source, {bare: true});
+  let decaffeinateES6 = convert(source).code;
+  let decaffeinateES5 = babel.transform(decaffeinateES6, {presets: ['es2015']}).code;
+
+  let coffeeOutput = runCodeAndExtract(coffeeES5);
+  let decaffeinateOutput = runCodeAndExtract(decaffeinateES5);
+  try { 
+    strictEqual(decaffeinateOutput, coffeeOutput);
+  } catch (err) {
+    // add some additional context for debugging 
+    err.message = `Additional Debug:
+SOURCE
+${source}
+********************
+INPUT -> COFFEE-SCRIPT -> ES5
+${coffeeES5}
+********************
+INPUT -> DECAFFEINATE -> ES6
+${decaffeinateES6}
+********************
+INPUT -> DECAFFEINATE -> ES6 -> BABEL -> ES5
+${decaffeinateES5}
+********************
+COFFEE-SCRIPT ES5 compared to DECAFFEINATE/BABEL ES5
+${err.message}`;
+    throw err;
+  }
+}


### PR DESCRIPTION
Correctly handling multi line strings, here strings and both types that contain interpolation has a surprising number of edge cases. Because of this I've only added support for the most basic type of multi line string in this PR. It does not include support for here strings or any multi line string that contains interpolation.

Probably the most useful part of this PR is the inclusion of what I've called a 'string integration test' that compares the strings after being run through both decaffeinate + babel and coffee-script by evaluating the resulting es5 code and comparing the output. This technique was invaluable (though the tests are a little slow) as manually constructing test cases becomes very difficult. It also found many edge cases I hadn't considered, which is why the patchMultilineString function is so complicated.

If you add in here string quotes and interpolation test strings into the string_integration_test you'll find there are quite a few failure scenarios which decaffeinate currently doesn't handle correctly.