### PR TITLE
fix: treat call_start & call_end tokens as parentheses

### DIFF
--- a/src/stages/main/patchers/WhilePatcher.js
+++ b/src/stages/main/patchers/WhilePatcher.js
@@ -16,7 +16,7 @@ export default class WhilePatcher extends NodePatcher {
   guard: ?NodePatcher;
   body: BlockPatcher;
   yielding: boolean;
-  
+
   constructor(node: Node, context: ParseContext, editor: Editor, condition: NodePatcher, guard: ?NodePatcher, body: BlockPatcher) {
     super(node, context, editor);
     this.condition = condition;
@@ -130,9 +130,9 @@ export default class WhilePatcher extends NodePatcher {
     let resultBinding = this.getResultArrayBinding();
     this.patchAsStatement();
     let prefix = !this.yielding ? '(() =>' : 'yield* (function*()';
-    this.insert(this.contentStart, `${prefix} { ${resultBinding} = []; `);
+    this.insert(this.innerStart, `${prefix} { ${resultBinding} = []; `);
     let suffix = !this.yielding ? '()' : this.referencesArguments() ? '.apply(this, arguments)' : '.call(this)';
-    this.insert(this.contentEnd, ` return ${resultBinding}; })${suffix}`);
+    this.insert(this.innerEnd, ` return ${resultBinding}; })${suffix}`);
   }
 
   yieldController() {

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -236,4 +236,13 @@ describe('function calls', () => {
       x(1);
     `);
   });
+
+  it('places the closing braces for a multi-line function argument', () => {
+    check(`
+      a(() ->
+        0)
+    `, `
+      a(() => 0);
+    `);
+  });
 });

--- a/test/while_test.js
+++ b/test/while_test.js
@@ -104,8 +104,8 @@ describe('while', () => {
             f
       )
     `, `
-      a(
-        (() => { let result = []; while (b) {
+      a((() => { let result = []; 
+        while (b) {
           let item;
           if (c) {
             item = d;
@@ -113,8 +113,8 @@ describe('while', () => {
             item = f;
           }
           result.push(item);
-        } return result; })()
-      );
+
+        } return result; })());
     `);
   });
 
@@ -129,8 +129,8 @@ describe('while', () => {
               f
       )
     `, `
-      a(
-        (() => { let result = []; while (b) {
+      a((() => { let result = []; 
+        while (b) {
           switch (c) {
             case d:
               result.push(e);
@@ -138,8 +138,8 @@ describe('while', () => {
             default:
               result.push(f);
           }
-        } return result; })()
-      );
+
+        } return result; })());
     `);
   });
 


### PR DESCRIPTION
This fixes various things that behave differently based on their surrounding parentheses. Fixes #261. It also causes some things, such as `while` expressions, to be formatted differently. It's not quite as pretty, but I think it's an okay compromise.