### PR TITLE
Don't remove trailing commas that are past the end of the function call

### DIFF
--- a/src/stages/main/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/main/patchers/FunctionApplicationPatcher.js
@@ -20,7 +20,7 @@ export default class FunctionApplicationPatcher extends NodePatcher {
 
   patchAsExpression() {
     let implicitCall = this.isImplicitCall();
-    let { args } = this;
+    let { args, outerEndTokenIndex } = this;
 
     this.fn.patch();
 
@@ -49,6 +49,10 @@ export default class FunctionApplicationPatcher extends NodePatcher {
         COMMA,
         isSemanticToken
       );
+      // Ignore commas after the end of the function call.
+      if (commaTokenIndex && commaTokenIndex.compare(outerEndTokenIndex) <= 0) {
+        commaTokenIndex = null;
+      }
       let commaToken = commaTokenIndex && this.sourceTokenAtIndex(commaTokenIndex);
       if (isLast && commaToken) {
         this.remove(arg.outerEnd, commaToken.end);

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -245,4 +245,12 @@ describe('function calls', () => {
       a(() => 0);
     `);
   });
+
+  it('keeps commas immediately after function applications', () => {
+    check(`
+      a(b(c), d)
+    `, `
+      a(b(c), d);
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #266.

In ac594494dfecc1bc907add06ea32df4801b61013 , some of the logic was changed so
that function call parens are treated as normal parens, at least in more cases.
This was confusing some existing logic that tried to remove any trailing commas
in function arguments. In a case like `a(b(c), d)`, the transformation code
would start from the end of the `c` expression, move until the next token, see
if it's a comma, and if so, remove it. But after changing the interpretation of
parens, the end of the `c` expression is now the close-paren, so it finds a
comma outside of the argument list and removes it.

To fix this issue, we can just add an additional check that the found comma is
actually within the function call, so the logic is now "move until the next
token to see if it's a comma, but no further than the end of the function
arguments", which seems a little more correct anyway.