### PR TITLE
Improve error reporting when there is a parser error

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -863,7 +863,7 @@ export default class NodePatcher {
    * Generate an error referring to a particular section of the source.
    */
   error(message: string, start: number=this.contentStart, end: number=this.contentEnd, error: ?Error=null): PatcherError {
-    let patcherError = new PatcherError(message, this.context, start, end, error);
+    let patcherError = new PatcherError(message, this.context.source, start, end, error);
     if (error) { patcherError.stack = error.stack; }
     return patcherError;
   }

--- a/src/stages/TransformCoffeeScriptStage.js
+++ b/src/stages/TransformCoffeeScriptStage.js
@@ -102,7 +102,7 @@ export default class TransformCoffeeScriptStage {
       throw new PatchError(
         `no patcher available for node type: ${node.type}` +
         `${props.length ? ` (props: ${props.join(', ')})` : ''}`,
-        this.context,
+        this.context.source,
         ...node.range
       );
     }


### PR DESCRIPTION
This is still sort of work-in-progress in that it copies `lineColumnMapper` from
`decaffeinate-parser`, so let me know if you think it would be better to change
`decaffeinate-parser` first to expose that function (or some other approach).

This is originally based on https://github.com/decaffeinate/decaffeinate/pull/222 ,
but I ended up changing the approach pretty significantly.

Since the `PatchError` class already contains logic to pretty-print an error in
a particular place in a file, with necessary context, I decided to reuse that.
Unfortunately, it relied on having a `ParseContext` from `decaffeinate-parser`,
even though none of the code is CoffeeScript-specific. The main purpose of the
`ParseContext` over just the source code is for the `lineMap`, so for now I
refactored `PatchError` to just take the source code and create its own
`lineMap` by copying the function from `decaffeinate-parser`. But maybe a better
solution is to just break the abstraction a little and expose the
`lineColumnMapper` function from `decaffeinate-parser`? Or maybe there's some
other clever way to reuse this code that I haven't thought of. Since it's just
20 lines, it seems like it's not worth worrying about that much, I think.

This change has been really useful for me to track down the underlying cause of
errors in files I'm trying to decaffeinate, and makes it much easier to change
files to be decaffeinate-friendly. See #269, #270, and #271 for examples of the
output produced after this change.