### PR TITLE
Better `in` handling

### DIFF
--- a/src/stages/main/patchers/InOpPatcher.js
+++ b/src/stages/main/patchers/InOpPatcher.js
@@ -1,3 +1,4 @@
+import ArrayInitialiserPatcher from './ArrayInitialiserPatcher.js';
 import BinaryOpPatcher from './BinaryOpPatcher.js';
 import type NodePatcher from './../../../patchers/NodePatcher.js';
 import type { SourceToken, Editor, Node, ParseContext } from './../../../patchers/types.js';
@@ -34,10 +35,60 @@ export default class InOpPatcher extends BinaryOpPatcher {
    * LEFT 'in' RIGHT
    */
   patchAsExpression() {
+    if (this.right instanceof ArrayInitialiserPatcher && this.right.members.length > 0) {
+      this.patchAsLogicalOperators(this.right.members);
+    } else {
+      this.patchAsIndexLookup();
+    }
+  }
+
+  /**
+   * LEFT 'in' '[' ELEMENT, … ']'
+   *
+   * @private
+   */
+  patchAsLogicalOperators(elements: Array<NodePatcher>) {
+    let comparison = this.negated ? '!==' : '===';
+    let operator = this.negated ? '&&' : '||';
+    let leftAgain = this.left.makeRepeatable(true);
+    this.left.patch();
+
+    // `a in [b, c]` → `a === b, c]`
+    //    ^^^^            ^^^^^
+    this.overwrite(this.left.outerEnd, elements[0].outerStart, ` ${comparison} `);
+
+    for (let i = 0; i < elements.length - 1; i++) {
+      let element = elements[i];
+      element.patch({ needsParens: true });
+
+      // `a === b, c]` → `a === b || a === c]`
+      //         ^^               ^^^^^^^^^^
+      this.overwrite(
+        element.outerEnd,
+        elements[i + 1].outerStart,
+        ` ${operator} ${leftAgain} ${comparison} `
+      );
+    }
+
+    let lastElement = elements[elements.length - 1];
+    lastElement.patch({ needsParens: true });
+
+    // `a === b || a === c]` → `a === b || a === c`
+    //                     ^
+    this.remove(lastElement.outerEnd, this.right.outerEnd);
+  }
+
+  /**
+   * LEFT 'in' RIGHT
+   *
+   * @private
+   */
+  patchAsIndexLookup() {
     let helper = this.registerHelper('__in__', IN_HELPER);
 
     if (this.negated) {
       // `a in b` → `!a in b`
+      //             ^
       this.insert(this.left.outerStart, '!');
     }
 

--- a/src/stages/main/patchers/LogicalOpPatcher.js
+++ b/src/stages/main/patchers/LogicalOpPatcher.js
@@ -25,18 +25,13 @@ export default class LogicalOpPatcher extends BinaryOpPatcher {
     this.right = right;
   }
 
-  /**
-   * LEFT OP RIGHT
-   */
-  patchAsExpression() {
-    this.left.patch();
+  patchOperator() {
     let operatorToken = this.getOperatorToken();
     this.overwrite(
       operatorToken.start,
       operatorToken.end,
       this.getOperator()
     );
-    this.right.patch();
   }
 
   /**

--- a/test/binary_operator_test.js
+++ b/test/binary_operator_test.js
@@ -30,8 +30,8 @@ describe('binary operators', () => {
       a - b & c
       a & b - c
     `, `
-      a - b & c;
-      a & b - c;
+      (a - b) & c;
+      a & (b - c);
     `);
   });
 
@@ -40,8 +40,8 @@ describe('binary operators', () => {
       a - b | c
       a | b - c
     `, `
-      a - b | c;
-      a | b - c;
+      (a - b) | c;
+      a | (b - c);
     `);
   });
 
@@ -130,7 +130,7 @@ describe('binary operators', () => {
     check(`
       value = object.id << 8 | object.type
     `, `
-      let value = object.id << 8 | object.type;
+      let value = (object.id << 8) | object.type;
     `);
   });
 

--- a/test/in_test.js
+++ b/test/in_test.js
@@ -133,4 +133,74 @@ describe('in operator', () => {
       }
     `);
   });
+
+  it('turns into comparisons joined by logical operators for literal arrays', () => {
+    check(`
+      if a in [yes, no]
+        b
+    `, `
+      if (a === true || a === false) {
+        b;
+      }
+    `);
+  });
+
+  it('turns into comparisons joined by logical operators for literal arrays with negation', () => {
+    check(`
+      if a not in [yes, no]
+        b
+    `, `
+      if (a !== true && a !== false) {
+        b;
+      }
+    `);
+  });
+
+  it('turns into a single comparison literal arrays with a single element', () => {
+    check(`
+      if a in [yes]
+        b
+    `, `
+      if (a === true) {
+        b;
+      }
+    `);
+  });
+
+  it('turns into comparisons joined by logical operators for literal arrays with not-safe-to-repeat element', () => {
+    check(`
+      if a() in [yes, no]
+        b
+    `, `
+      let ref;
+      if ((ref = a()) === true || ref === false) {
+        b;
+      }
+    `);
+  });
+
+  it('adds parens around elements that would be ambiguous', () => {
+    check(`
+      if a in [b and c, +d]
+        e
+    `, `
+      if (a === (b && c) || a === +d) {
+        e;
+      }
+    `);
+  });
+
+  it('uses the indexOf approach for empty arrays', () => {
+    check(`
+      if a in []
+        b
+    `, `
+      if (__in__(a, [])) {
+        b;
+      }
+      function __in__(needle, haystack) {
+        return haystack.indexOf(needle) >= 0;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
CoffeeScript converts `a in [b, c]` to `a === b || a === c` rather than using `indexOf` on the array. This follows suit and handles negation better than CoffeeScript.