### PR TITLE
Expose the PatchError class as a decaffeinate export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import MainStage from './stages/main/index.js';
 import NormalizeStage from './stages/normalize/index.js';
 import PatchError from './utils/PatchError.js';
 
+export { default as PatchError } from './utils/PatchError.js';
 export { default as run } from './cli';
 
 type Options = {

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,8 @@ import MainStage from './stages/main/index.js';
 import NormalizeStage from './stages/normalize/index.js';
 import PatchError from './utils/PatchError.js';
 
-export { default as PatchError } from './utils/PatchError.js';
 export { default as run } from './cli';
+export { PatchError };
 
 type Options = {
   filename?: string


### PR DESCRIPTION
Step 1 of 2 for #278.

This is useful so that the repl can call `PatchError.prettyPrint` on errors thrown
by `convert`.

This is the best I could come up with to both import `PatchError` for use in
`index.js` and also export it from `index.js`. If there's a way to do it that doesn't
involve typing `./utils/PatchError.js` twice, I'm happy to go with that.