### PR TITLE
Show the full context when reporting errors in the repl

### DIFF
--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -200,7 +200,11 @@
     try {
       transformed = decaffeinate.convert(code).code;
     } catch (err) {
-      this.printError(err.message);
+      if (decaffeinate.PatchError.isA(err)) {
+        this.printError(decaffeinate.PatchError.prettyPrint(err));
+      } else {
+        this.printError(err.message);
+      }
       throw err;
     }
 


### PR DESCRIPTION
Closes #278 . Note that this depends on #279, so you'll need to merge that and rebuild gh-pages before merging this.

This makes it much easier to figure out what's going on when opening a large
file with a few decaffeinate errors in it.

Live demo: http://www.alangpierce.com/decaffeinate/repl/#?evaluate=true&code='hello%0A%20world%27
