### PR TITLE
Fix PatchError.prettyPrint when the file doesn't end in a newline

### DIFF
--- a/src/utils/PatchError.js
+++ b/src/utils/PatchError.js
@@ -52,8 +52,8 @@ export default class PatchError extends Error {
     for (let line = displayStartLine; line <= displayEndLine; line++) {
       let startOfLine = lineMap.indexForLocation({ line, column: 0 });
       let endOfLine = lineMap.indexForLocation({ line: line + 1, column: 0 });
-      if (endOfLine == null) {
-        if (startOfLine == null) {
+      if (endOfLine === null) {
+        if (startOfLine === null) {
           break;
         } else {
           endOfLine = source.length;

--- a/src/utils/PatchError.js
+++ b/src/utils/PatchError.js
@@ -52,8 +52,8 @@ export default class PatchError extends Error {
     for (let line = displayStartLine; line <= displayEndLine; line++) {
       let startOfLine = lineMap.indexForLocation({ line, column: 0 });
       let endOfLine = lineMap.indexForLocation({ line: line + 1, column: 0 });
-      if (isNaN(endOfLine)) {
-        if (isNaN(startOfLine)) {
+      if (endOfLine == null) {
+        if (startOfLine == null) {
           break;
         } else {
           endOfLine = source.length;

--- a/test/utils/PatchError_test.js
+++ b/test/utils/PatchError_test.js
@@ -1,0 +1,15 @@
+import { strictEqual } from 'assert';
+import PatchError from '../../src/utils/PatchError.js';
+import stripSharedIndent from '../../src/utils/stripSharedIndent.js';
+
+describe('PatchError', function() {
+  it('handles files not ending in newlines', () => {
+    let error = new PatchError('Sample error', 'abcdefg', 2, 4);
+    let expected = stripSharedIndent(`
+      Sample error
+      > 1 | abcdefg
+          |   ^^
+    `) + '\n';
+    strictEqual(PatchError.prettyPrint(error), expected);
+  });
+});


### PR DESCRIPTION
The code was using `isNaN` to determine if the line/column pair was valid, but
`isNaN(null)` is `false` in JS, so this was always returning false. This caused
the repl to sometimes not display the last line in the error, e.g.:
http://decaffeinate.github.io/decaffeinate/repl/#?evaluate=true&code=a%3F.b