### PR TITLE
feat: strip trailing `return` statements without an argument

### DIFF
--- a/src/stages/main/patchers/BlockPatcher.js
+++ b/src/stages/main/patchers/BlockPatcher.js
@@ -1,4 +1,6 @@
+import FunctionPatcher from './FunctionPatcher.js';
 import NodePatcher from './../../../patchers/NodePatcher.js';
+import ReturnPatcher from './ReturnPatcher.js';
 import type { SourceToken, Node, ParseContext, Editor } from './../../../patchers/types.js';
 import { NEWLINE, SEMICOLON } from 'coffee-lex';
 
@@ -33,7 +35,18 @@ export default class BlockPatcher extends NodePatcher {
     }
 
     this.statements.forEach(
-      statement => {
+      (statement, i, statements) => {
+        if (i === statements.length - 1 && this.parent instanceof FunctionPatcher) {
+          let previousStatement = statements[i - 1];
+          if (statement instanceof ReturnPatcher && !statement.expression) {
+            this.remove(
+              previousStatement ?
+                previousStatement.outerEnd :
+                statement.outerStart,
+              statement.outerEnd
+            );
+          }
+        }
         if (statement.isSurroundedByParentheses()) {
           statement.setRequiresExpression();
         }

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -121,22 +121,20 @@ describe('classes', () => {
         }
       `);
     });
-    
+
     it('constructor with function body', () => {
       check(`
         class A
           constructor: (@a) ->
-            return
       `, `
         class A {
           constructor(a) {
             this.a = a;
-            return;
           }
         }
       `);
     });
-    
+
     it('method', () => {
       check(`
         class A
@@ -145,7 +143,6 @@ describe('classes', () => {
         class A {
           method(a) {
             this.a = a;
-            return;
           }
         }
       `);
@@ -163,7 +160,6 @@ describe('classes', () => {
         
           method(a) {
             this.a = a;
-            return;
           }
         }
       `);
@@ -199,7 +195,6 @@ describe('classes', () => {
       `, `
         (function(a, b = this.c) {
           this.a = a;
-          return;
         });
       `);
     });
@@ -210,7 +205,6 @@ describe('classes', () => {
       `, `
         (function(a, b = a) {
           this.a = a;
-          return;
         });
       `);
     });

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -8,30 +8,34 @@ describe('functions', () => {
   it('put the closing curly brace on a new line', () => {
     check(`
       ->
-        return
+        0
+        return 0
     `, `
       (function() {
-        return;
+        0;
+        return 0;
       });
     `);
   });
 
   it('put the closing curly brace on the same line if the original is a single line', () => {
     check(`
-      -> return
+      -> 0; return 0
     `, `
-      (function() { return; });
+      (function() { 0; return 0; });
     `);
   });
 
   it('puts the closing curly brace before any trailing comments on the last statement in the body', () => {
     check(`
       ->
-        return # hey
+        0
+        return 0 # hey
       b
     `, `
       (function() {
-        return; // hey
+        0;
+        return 0; // hey
       });
       b;
     `);
@@ -39,19 +43,21 @@ describe('functions', () => {
 
   it('puts the closing punctuation before trailing comments for one-line functions', () => {
     check(`
-      -> return # b
+      -> 0; return 0 # b
     `, `
-      (function() { return; }); // b
+      (function() { 0; return 0; }); // b
     `);
   });
 
   it('puts the closing punctuation before trailing comments for parentheses-wrapped functions', () => {
     check(`
       (->
-        return) # b
+        0
+        return 0) # b
     `, `
       (function() {
-        return;}); // b
+        0;
+        return 0;}); // b
     `);
   });
 

--- a/test/return_test.js
+++ b/test/return_test.js
@@ -11,9 +11,12 @@ describe('return', () => {
 
   it('works without a return value', () =>
     check(`
-      -> return
+      ->
+        return if a
     `, `
-      (function() { return; });
+      (function() {
+        if (a) { return; }
+      });
     `)
   );
 });


### PR DESCRIPTION
The NormalizeStage sometimes adds them to prevent inserted statements from being implicitly returned unintentionally. This has the side effect of stripping empty trailing return statements that were in the original source code, but those were probably also there to prevent an implicit return and so would not normally be in the JavaScript version of the code anyway.

Closes #193.