### PR TITLE
fix: always use an expression as the argument to a return statement

### DIFF
--- a/src/stages/main/patchers/ReturnPatcher.js
+++ b/src/stages/main/patchers/ReturnPatcher.js
@@ -11,6 +11,9 @@ export default class ReturnPatcher extends NodePatcher {
 
   initialize() {
     this.setExplicitlyReturns();
+    if (this.expression !== null) {
+      this.expression.setRequiresExpression();
+    }
   }
 
   /**

--- a/test/return_test.js
+++ b/test/return_test.js
@@ -16,4 +16,12 @@ describe('return', () => {
       (function() { return; });
     `)
   );
+
+  it('forces the return value to be an expression', () =>
+    check(`
+      -> return if true then null
+    `, `
+      () => true ? null : undefined;
+    `)
+  );
 });


### PR DESCRIPTION
This comes up, for example, when doing `return if ...`.

Closes #271.