### PR TITLE
fix: only add demo-code in case of no query-string or localstate is present

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -2364,3 +2364,5 @@ h1:target::before, .h1:target::before, h2:target::before, .h2:target::before, h3
 .decaffeinate-repl-errors { left: 0; border-right: 1px solid #e2e2e2; }
 
 .decaffeinate-repl-console { right: 0; }
+
+.decaffeinate-repl-demo-code { display:none; }

--- a/repl/index.html
+++ b/repl/index.html
@@ -29,24 +29,8 @@
   <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/js/bootstrap.min.js"></script>
 </head>
 <body>
-<nav role="navigation" id="header" class="navbar navbar-default navbar-fixed-top">
-  <div class="container">
-    <div class="navbar-header">
-      <a href="." class="navbar-brand logo">decaffeinate</a>
-    </div>
-  </div>
-</nav>
-<div class="decaffeinate-repl">
-  <form class="form decaffeinate-repl-toolbar">
-    <div class="pull-left">
-      <div class="form-group">
-        <label for="option-evaluate">
-          <input id="option-evaluate" type="checkbox"> Evaluate
-        </label>
-      </div>
-    </div>
-  </form>
-  <div class="decaffeinate-repl-editor decaffeinate-repl-input"><div class="ace_editor">###
+<textarea class="decaffeinate-repl-demo-code">
+###
 # Examples taken from coffeescript.org
 ###
 
@@ -75,7 +59,25 @@ race = (winner, runners...) ->
 
 # Existence:
 alert "I knew it!" if elvis?
-  </div></div>
+</textarea>
+<nav role="navigation" id="header" class="navbar navbar-default navbar-fixed-top">
+  <div class="container">
+    <div class="navbar-header">
+      <a href="." class="navbar-brand logo">decaffeinate</a>
+    </div>
+  </div>
+</nav>
+<div class="decaffeinate-repl">
+  <form class="form decaffeinate-repl-toolbar">
+    <div class="pull-left">
+      <div class="form-group">
+        <label for="option-evaluate">
+          <input id="option-evaluate" type="checkbox"> Evaluate
+        </label>
+      </div>
+    </div>
+  </form>
+  <div class="decaffeinate-repl-editor decaffeinate-repl-input"><div class="ace_editor"></div></div>
   <div class="decaffeinate-repl-editor decaffeinate-repl-output"><div class="ace_editor"></div></div>
   <div class="decaffeinate-repl-reporter decaffeinate-repl-errors"></div>
   <div class="decaffeinate-repl-reporter decaffeinate-repl-console"></div>

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -149,7 +149,16 @@
   function REPL () {
     this.storage = new StorageService();
     var state = this.storage.get('replState') || {};
-    _.assign(state, UriUtils.parseQuery());
+    var parsedQuery = UriUtils.parseQuery()
+    if(parsedQuery && parsedQuery.code || state.code) {
+      _.assign(state, UriUtils.parseQuery());
+    } else {
+      var demoCode = $(".decaffeinate-repl-demo-code").text();
+      _.assign(state, {
+        "evaluate": true,
+        "code": demoCode
+      });
+    }
 
     this.options = _.assign(new Options(), state);
 


### PR DESCRIPTION
Fixes the issue mentioned in #285

The demo-code is kept in a hidden text-field until it is decided whether or not it should be used as it seemed like the most sane solution.