### PR TITLE
fix: don't pretty-print with out-of-range indexes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,9 @@ function runStage(stage: Stage, content: string, filename: string): { code: stri
   } catch (err) {
     if (err instanceof SyntaxError) {
       let { pos } = err;
+      if (pos === content.length) {
+        pos--;
+      }
       throw new PatchError(
         `${stage.name} failed to parse: ${err.message}`,
         content,


### PR DESCRIPTION
The code I added to catch ParseErrors from JS code was using (`pos`, `pos + 1`) as
the range, but if the position was at the very end of the string (e.g. due to
unbalanced parens), it would cause a crash because the end position would be
null. To fix, I changed it to instead just use the last character in the code in
that case rather than one after the last.