### PR TITLE
add a warning about how to test against an unreleased decaffeinate-parser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import EsnextStage from './stages/esnext/index.js';
 import MainStage from './stages/main/index.js';
 import NormalizeStage from './stages/normalize/index.js';
 import PatchError from './utils/PatchError.js';
+import verifyCoffeeLexLoadedOnce from './utils/verifyCoffeeLexLoadedOnce.js';
 
 export { default as run } from './cli';
 export { PatchError };
@@ -27,6 +28,7 @@ type Stage = {
  * and formatting.
  */
 export function convert(source: string, options: ?Options={}): ConversionResult {
+  verifyCoffeeLexLoadedOnce();
   return runStages(source, options.filename || 'input.coffee', [
     NormalizeStage,
     MainStage,

--- a/src/utils/verifyCoffeeLexLoadedOnce.js
+++ b/src/utils/verifyCoffeeLexLoadedOnce.js
@@ -1,0 +1,28 @@
+/* @flow */
+
+import { IDENTIFIER } from 'coffee-lex';
+import { parse } from 'decaffeinate-parser';
+import stripSharedIndent from './stripSharedIndent.js';
+
+let verified = false;
+
+export default function verifyCoffeeLexLoadedOnce() {
+  if (verified) {
+    return;
+  }
+  let sourceTokenList = parse('a').context.sourceTokens;
+  let firstIndex = sourceTokenList.indexOfTokenContainingSourceIndex(0);
+  let token = sourceTokenList.tokenAtIndex(firstIndex);
+  if (token.type !== IDENTIFIER) {
+    throw new Error(stripSharedIndent(`
+      decaffeinate and decaffeinate-parser appear to be using different
+      instances of coffee-lex. coffee-lex uses singleton token types that must
+      be identity-equal, so the same copy must be used everywhere. Note that
+      this means that "npm link" does not work to test decaffeinate against an
+      unreleased version of decaffeinate-parser; you must build a
+      decaffeinate-parser package by setting a version and using "npm pack",
+      then install it for decaffeinate using "npm install".
+    `));
+  }
+  verified = true;
+}


### PR DESCRIPTION
I recently tried using `npm link` to test decaffeinate against a local
decaffeinate-parser, and ran into really confusing behavior that took quite a
while to figure out. Rather than failing in an obvious way, it would put extra
parens in confusing places and other random-seeming problems like that. The
problem ended up being that decaffeinate and decaffeinate-parser were using
different instances of coffee-lex, so comparisons between token types, like
`token.type === IDENTIFIER` would always be false (since it's an identity
equality check on singletons).

To make this case more visible, this commit adds an up-front check with an
explanation of the issue and a suggestion for how to properly set things up.

To test this, I verified that no warning is shown under a normal configuration,
and that if you use `npm link` to hook up decaffeinate-parser, all tests fail with
this error. (I had to mess with some recently-introduced flow settings to get
flow to pass after running npm link.)

Note that this could come up in an actual build, I think, since there's no
guarantee that decaffeinate and decaffeinate-parser pull in the same version.
Maybe that would be fixed using a peer dependency or something like that?

Also, if there's a better workflow for testing unreleased versions, I would be
happy to hear it.