### PR TITLE
feat: add support for ModuloOp

### DIFF
--- a/src/stages/main/index.js
+++ b/src/stages/main/index.js
@@ -32,6 +32,7 @@ import LogicalNotOpPatcher from './patchers/LogicalNotOpPatcher.js';
 import LogicalOpCompoundAssignOpPatcher from './patchers/LogicalOpCompoundAssignOpPatcher.js';
 import LogicalOpPatcher from './patchers/LogicalOpPatcher.js';
 import MemberAccessOpPatcher from './patchers/MemberAccessOpPatcher.js';
+import ModuloOpPatcher from './patchers/ModuloOpPatcher.js';
 import NewOpPatcher from './patchers/NewOpPatcher.js';
 import ObjectInitialiserMemberPatcher from './patchers/ObjectInitialiserMemberPatcher.js';
 import ObjectInitialiserPatcher from './patchers/ObjectInitialiserPatcher.js';
@@ -176,6 +177,9 @@ export default class MainStage extends TransformCoffeeScriptStage {
       case 'SignedRightShiftOp':
       case 'UnsignedRightShiftOp':
         return BinaryOpPatcher;
+
+      case 'ModuloOp':
+        return ModuloOpPatcher;
 
       case 'RegExp':
         return RegExpPatcher;

--- a/src/stages/main/patchers/ModuloOpPatcher.js
+++ b/src/stages/main/patchers/ModuloOpPatcher.js
@@ -1,0 +1,49 @@
+import BinaryOpPatcher from './BinaryOpPatcher.js';
+import type NodePatcher from './../../../patchers/NodePatcher.js';
+import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+
+const MOD_HELPER =
+  `function __mod__(a, b) {
+  a = +a;
+  b = +b;
+  return (a % b + b) % b;
+}`;
+
+/**
+ * Handles modulo operator, e.g. `a %% b`.
+ */
+export default class ModuloOpPatcher extends BinaryOpPatcher {
+  /**
+   * `node` is of type `ModuloOp`.
+   */
+  constructor(node: Node, context: ParseContext, editor: Editor, left: NodePatcher, right: NodePatcher) {
+    super(node, context, editor, left, right);
+  }
+
+  patchAsExpression() {
+    let helper = this.registerHelper('__mod__', MOD_HELPER);
+
+    // `a %% b` → `__mod__(a %% b`
+    //             ^^^^^^^^
+    this.insert(this.left.outerStart, `${helper}(`);
+
+    this.left.patch();
+
+    // `__mod__(a %% b` → `__mod__(a, b`
+    //           ^^^^               ^^
+    this.overwrite(this.left.outerEnd, this.right.outerStart, ', ');
+
+    this.right.patch();
+
+    // `__mod__(a, b` → `__mod__(a, b)`
+    //                               ^
+    this.insert(this.right.outerEnd, ')');
+  }
+
+  /**
+   * We always prefix with `__mod__` so no parens needed.
+   */
+  statementNeedsParens(): boolean {
+    return false;
+  }
+}

--- a/src/utils/traverse.js
+++ b/src/utils/traverse.js
@@ -86,6 +86,7 @@ const ORDER = {
   LogicalNotOp: ['expression'],
   LogicalOrOp: ['left', 'right'],
   MemberAccessOp: ['expression'],
+  ModuloOp: ['left', 'right'],
   MultiplyOp: ['left', 'right'],
   NEQOp: ['left', 'right'],
   NewOp: ['ctor', 'arguments'],

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -142,6 +142,7 @@ export function isBinaryOperator(node: Node): boolean {
     case 'LeftShiftOp':
     case 'LogicalAndOp':
     case 'LogicalOrOp':
+    case 'ModuloOp':
     case 'MultiplyOp':
     case 'NEQOp':
     case 'OfOp':

--- a/test/binary_operator_test.js
+++ b/test/binary_operator_test.js
@@ -134,6 +134,32 @@ describe('binary operators', () => {
     `);
   });
 
+  it('handles modulo operator', () => {
+    check(`
+      a %% b
+    `, `
+      __mod__(a, b);
+      function __mod__(a, b) {
+        a = +a;
+        b = +b;
+        return (a % b + b) % b;
+      }
+    `);
+  });
+
+  it('handles modulo operator applied multiple times', () => {
+    check(`
+      a(b() %% c(d) %% e + f)
+    `, `
+      a(__mod__(__mod__(b(), c(d)), e) + f);
+      function __mod__(a, b) {
+        a = +a;
+        b = +b;
+        return (a % b + b) % b;
+      }
+    `);
+  });
+
   it('handles `extends` operator', () => {
     check(`
       a extends b


### PR DESCRIPTION
As suggested in #303, this works by registring a function, `__mod__`, that behaves
like the `%%` operator. I based the code off of `InOpPatcher`.

Closes #303.