### PR TITLE
fix: traverse into "else" cases in the normalize stage

### DIFF
--- a/src/stages/normalize/patchers/ConditionalPatcher.js
+++ b/src/stages/normalize/patchers/ConditionalPatcher.js
@@ -28,6 +28,9 @@ export default class ConditionalPatcher extends NodePatcher {
     } else {
       this.condition.patch();
       this.consequent.patch();
+      if (this.alternate !== null) {
+        this.alternate.patch();
+      }
     }
   }
 

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -329,4 +329,19 @@ describe('conditionals', () => {
       let r = (f === 0.5) ? a : b;
     `);
   });
+
+  it('handles implicit function calls in the else clause', () =>
+    check(`
+      if a
+        b
+      else
+        c d
+    `, `
+      if (a) {
+        b;
+      } else {
+        c(d);
+      }
+    `)
+  );
 });


### PR DESCRIPTION
The ConditionalPatcher code had a mistake where it was skipping the else case.
Now that implicit function call parens are added in the normalize stage, this
was causing some errors where parens wouldn't get added.