### PR TITLE
feat: handle expansions in array assignment

### DIFF
--- a/src/stages/main/index.js
+++ b/src/stages/main/index.js
@@ -17,6 +17,7 @@ import EqualityPatcher from './patchers/EqualityPatcher.js';
 import ExpOpPatcher from './patchers/ExpOpPatcher.js';
 import ExistsOpCompoundAssignOpPatcher from './patchers/ExistsOpCompoundAssignOpPatcher.js';
 import ExistsOpPatcher from './patchers/ExistsOpPatcher.js';
+import ExpansionPatcher from './patchers/ExpansionPatcher.js';
 import ExtendsOpPatcher from './patchers/ExtendsOpPatcher.js';
 import FloorDivideOpPatcher from './patchers/FloorDivideOpPatcher.js';
 import ForInPatcher from './patchers/ForInPatcher.js';
@@ -220,6 +221,9 @@ export default class MainStage extends TransformCoffeeScriptStage {
 
       case 'Slice':
         return SlicePatcher;
+
+      case 'Expansion':
+        return ExpansionPatcher;
 
       case 'Rest':
         return RestPatcher;

--- a/src/stages/main/patchers/AssignOpPatcher.js
+++ b/src/stages/main/patchers/AssignOpPatcher.js
@@ -1,3 +1,5 @@
+import ArrayInitialiserPatcher from './ArrayInitialiserPatcher.js';
+import ExpansionPatcher from './ExpansionPatcher.js';
 import NodePatcher from './../../../patchers/NodePatcher.js';
 import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
 
@@ -17,14 +19,123 @@ export default class AssignOpPatcher extends NodePatcher {
   }
 
   patchAsExpression() {
-    this.assignee.patch();
-    this.expression.patch();
+    if (this.isExpansionAssignment()) {
+      this.patchExpansionAssignment();
+    } else {
+      this.assignee.patch();
+      this.expression.patch();
+    }
+  }
+
+  statementNeedsParens(): boolean {
+    if (this.isExpansionAssignment()) {
+      return this.expansionAssignmentNeedsParens();
+    } else {
+      // The assignment needs parentheses when the LHS needs parens.
+      return this.assignee.statementShouldAddParens();
+    }
+  }
+
+  expansionAssignmentNeedsParens(): boolean {
+    if (!this.expression.isRepeatable()) {
+      // The left side will be an "array" variable.
+      return false;
+    }
+    let expansionIndex = this.getExpansionIndex();
+    if (expansionIndex === this.assignee.members.length - 1) {
+      // Simple case where we leave the array assignment mostly intact.
+      return this.assignee.statementShouldAddParens();
+    } else if (expansionIndex === 0) {
+      // The first non-expansion assignee will end up on the left side.
+      return this.assignee.members[1].statementShouldAddParens();
+    } else {
+      return this.assignee.members[0].statementShouldAddParens();
+    }
+  }
+
+  isExpansionAssignment(): boolean {
+    return this.getExpansionIndex() !== -1;
   }
 
   /**
-   * The assignment needs parentheses when the LHS needs parens.
+   * If there is an expansion assignment, return the index of the expansion node.
+   * Otherwise, return -1.
    */
-  statementNeedsParens(): boolean {
-    return this.assignee.statementShouldAddParens();
+  getExpansionIndex(): number {
+    if (!(this.assignee instanceof ArrayInitialiserPatcher)) {
+      return -1;
+    }
+    for (let i = 0; i < this.assignee.members.length; i++) {
+      if (this.assignee.members[i] instanceof ExpansionPatcher) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  patchExpansionAssignment() {
+    let expansionIndex = this.getExpansionIndex();
+    let assignees = this.assignee.members;
+    let expansionNode = assignees[expansionIndex];
+
+    assignees.forEach((assignee, i) => {
+      // Patch everything but the expansion node, since expansion nodes expect
+      // to not be patched.
+      if (i !== expansionIndex) {
+        assignee.patch();
+      }
+    });
+    this.expression.patch();
+    let expressionCode = this.slice(this.expression.contentStart, this.expression.contentEnd);
+
+    // Easy case: [a, b, ...] = c  ->  [a, b] = c
+    if (expansionIndex === assignees.length - 1) {
+      let assigneeBeforeExpansion = assignees[assignees.length - 2];
+      this.remove(assigneeBeforeExpansion.outerEnd, expansionNode.outerEnd);
+      return;
+    }
+
+    // Split into independent assignments. For example, the transformation from
+    // [a, ..., b, c] = d()
+    // to
+    // array = d(), a = array[0], b = array[array.length - 2], c = array[array.length - 1];
+    //
+    // takes these steps:
+    // * Remove the "...,".
+    // * Insert "array = d(), " on the left.
+    // * Remove "["
+    // * Insert " = array[index]" after each assignment (the comma is already there).
+    // * Remove "] = d()"
+
+    // Remove "...,". We know there's an assignee after the expansion because
+    // otherwise we would have returned above.
+    this.remove(expansionNode.outerStart, assignees[expansionIndex + 1].outerStart);
+
+    let arrReference;
+    if (this.expression.isRepeatable()) {
+      arrReference = expressionCode;
+    } else {
+      arrReference = this.claimFreeBinding('array');
+      this.insert(this.outerStart, `${arrReference} = ${expressionCode}, `);
+    }
+
+    // Remove opening "[".
+    this.remove(this.contentStart, assignees[0].outerStart);
+
+    assignees.forEach((assignee, i) => {
+      if (i === expansionIndex) {
+        return;
+      }
+      let key;
+      if (i < expansionIndex) {
+        key = `${i}`;
+      } else {
+        key = `${arrReference}.length - ${assignees.length - i}`;
+      }
+      this.insert(assignee.outerEnd, ` = ${arrReference}[${key}]`);
+    });
+
+    // Remove closing "]" and right-side expression.
+    this.remove(assignees[assignees.length - 1].outerEnd, this.contentEnd);
   }
 }

--- a/src/stages/main/patchers/ExpansionPatcher.js
+++ b/src/stages/main/patchers/ExpansionPatcher.js
@@ -1,0 +1,13 @@
+import NodePatcher from './../../../patchers/NodePatcher.js';
+
+export default class ExpansionPatcher extends NodePatcher {
+  patchAsExpression() {
+    // Any code handling expansions should process them without calling patch.
+    // If patch ends up being called, then that means that we've hit an
+    // unsupported case that's trying to treat this node as a normal expression.
+    throw this.error(
+      'expansions (e.g. `[a, ..., b] = c`) are not supported yet in all ' +
+      'cases, see https://github.com/decaffeinate/decaffeinate/issues/268'
+    );
+  }
+}

--- a/src/utils/Scope.js
+++ b/src/utils/Scope.js
@@ -139,6 +139,7 @@ function getBindingsForNode(node: Node): Array<Node> {
     case 'Rest':
       return getBindingsForNode(node.expression);
 
+    case 'Expansion':
     case 'MemberAccessOp':
       return [];
 

--- a/src/utils/traverse.js
+++ b/src/utils/traverse.js
@@ -62,6 +62,7 @@ const ORDER = {
   DynamicMemberAccessOp: ['expression', 'indexingExpr'],
   EQOp: ['left', 'right'],
   ExistsOp: ['left', 'right'],
+  Expansion: [],
   ExpOp: ['left', 'right'],
   ExtendsOp: ['left', 'right'],
   Float: [],

--- a/test/expansion_test.js
+++ b/test/expansion_test.js
@@ -1,20 +1,20 @@
 import check from './support/check.js';
 
-describe.skip('expansion', () => {
+describe('expansion', () => {
   it('allows getting the last elements of an array', () => {
     check(`
       [..., a, b] = arr
     `, `
-      var a = arr[arr.length - 2], b = arr[arr.length - 1];
+      let a = arr[arr.length - 2], b = arr[arr.length - 1];
     `);
   });
 
-  it('allows getting the last elements of a parameter list', () => {
+  it.skip('allows getting the last elements of a parameter list', () => {
     check(`
       (..., a, b) ->
     `, `
       (function() {
-        var a = arguments[arguments.length - 2], b = arguments[arguments.length - 1];
+        let a = arguments[arguments.length - 2], b = arguments[arguments.length - 1];
       });
     `);
   });
@@ -23,11 +23,11 @@ describe.skip('expansion', () => {
     check(`
       [a, b, ...] = arr
     `, `
-      var [a, b] = arr;
+      let [a, b] = arr;
     `);
   });
 
-  it('is removed at the end of a parameter list', () => {
+  it.skip('is removed at the end of a parameter list', () => {
     check(`
       (a, b, ...) ->
     `, `
@@ -39,26 +39,26 @@ describe.skip('expansion', () => {
     check(`
       [a, b, ..., c, d] = arr
     `, `
-      var a = arr[0], b = arr[1], c = arr[arr.length - 2], d = arr[arr.length - 1];
+      let a = arr[0], b = arr[1], c = arr[arr.length - 2], d = arr[arr.length - 1];
     `);
   });
 
-  it('allows getting the first and last elements of a parameter list', () => {
+  it.skip('allows getting the first and last elements of a parameter list', () => {
     check(`
       (a, b, ..., c, d) ->
     `, `
       (function(a, b, ...rest) {
-        var c = rest[rest.length - 2], d = rest[rest.length - 1];
+        let c = rest[rest.length - 2], d = rest[rest.length - 1];
       });
     `);
   });
 
-  it('allows getting the first and last elements of a parameter list in a bound function', () => {
+  it.skip('allows getting the first and last elements of a parameter list in a bound function', () => {
     check(`
       (a, b, ..., c, d) =>
     `, `
       ((a, b, ...rest) => {
-        var c = rest[rest.length - 2], d = rest[rest.length - 1];
+        let c = rest[rest.length - 2], d = rest[rest.length - 1];
       });
     `);
   });
@@ -67,7 +67,15 @@ describe.skip('expansion', () => {
     check(`
       [a, b, ..., c, d] = getArray()
     `, `
-      var array = getArray(), a = array[0], b = array[1], c = array[array.length - 2], d = array[array.length - 1];
+      let array = getArray(), a = array[0], b = array[1], c = array[array.length - 2], d = array[array.length - 1];
+    `);
+  });
+
+  it('handles expansions over destructures', () => {
+    check(`
+      [..., {a, b}] = arr
+    `, `
+      let {a, b} = arr[arr.length - 1];
     `);
   });
 });


### PR DESCRIPTION
This is a partial implementation of expansions, which handles them for array
assignment and destructuring, but not for function parameters or nested within
more complicated assignments. For those unsupported cases, I throw an error
linking to #268 when the expansion node is traversed.

Currently the only special case is `[a, b, ...]`. Every other case just turns
into a series of assignments that do array lookups.