### PR TITLE
feat: handle some "for in" loop expressions using filter and map

### DIFF
--- a/src/stages/main/patchers/ForOfPatcher.js
+++ b/src/stages/main/patchers/ForOfPatcher.js
@@ -1,6 +1,13 @@
 import ForPatcher from './ForPatcher.js';
 
 export default class ForOfPatcher extends ForPatcher {
+  patchAsExpression() {
+    throw this.error(
+      `'for of' loops used as expressions are not yet supported ` +
+      `(https://github.com/decaffeinate/decaffeinate/issues/156)`
+    );
+  }
+
   patchAsStatement() {
     if (this.node.isOwn) {
       throw this.error(

--- a/src/stages/main/patchers/ForPatcher.js
+++ b/src/stages/main/patchers/ForPatcher.js
@@ -89,16 +89,9 @@ export default class ForPatcher extends NodePatcher {
     this.body.patch({ leftBrace: false });
   }
 
-  patchAsExpression() {
-    throw this.error(
-      `'for' loops used as expressions are not yet supported ` +
-      `(https://github.com/decaffeinate/decaffeinate/issues/156)`
-    );
-  }
-
   getRelationToken(): SourceToken {
     let tokenIndex = this.indexOfSourceTokenBetweenPatchersMatching(
-      this.keyAssignee, this.target,
+      this.keyAssignee || this.valAssignee, this.target,
       token => token.type === RELATION
     );
     if (!tokenIndex) {

--- a/test/support/validate.js
+++ b/test/support/validate.js
@@ -14,10 +14,13 @@ import { strictEqual } from 'assert';
  * The ES5 from both paths is run in a sandbox and then the 'o' variable
  * from the scope of each sandbox is compared. If the output is the same
  * then the test has passed.
+ *
+ * Optionally, expectedOutput can be specified. If it is, the the result of the
+ * 'o' variable must be equal to that value.
  */
-export default function validate(source: string) {
+export default function validate(source: string, expectedOutput: ?any) {
   try {
-    runValidation(source);
+    runValidation(source, expectedOutput);
   } catch (err) {
     if (PatchError.detect(err)) {
       console.error(PatchError.prettyPrint(err));
@@ -37,7 +40,7 @@ function runCodeAndExtract(source: string) {
   return sandbox.o;
 }
 
-function runValidation(source: string) {
+function runValidation(source: string, expectedOutput: ?any) {
   let coffeeES5 = compile(source, { bare: true });
   let decaffeinateES6 = convert(source).code;
   let decaffeinateES5 = babel.transform(decaffeinateES6, { presets: ['es2015'] }).code;
@@ -64,5 +67,9 @@ ${decaffeinateES5}
 COFFEE-SCRIPT ES5 compared to DECAFFEINATE/BABEL ES5
 ${err.message}`;
     throw err;
+  }
+
+  if (expectedOutput !== undefined) {
+    strictEqual(decaffeinateOutput, expectedOutput);
   }
 }


### PR DESCRIPTION
Partial fix for #156.

This commit handles "for in" using the strategy of transforming it to
`a.filter(...).map(...)`. This works in the most common cases, but there are some
edge cases that it doesn't handle (where I throw an error):
* Loop expressions using a `by` clause.
* Loop expressions where the body cannot be patched as an expression. In
  particular, I don't think there's a great way to handle `break`, `continue`,
  and `return` within loop expressions using `map` and a lambda.
* Expressions that use a filter and also assign the index to a variable. In this
  case, the code would be incorrect, because the filter step changes the size of
  the array and thus the indexes.

This technically could change behavior when looping over array-like objects,
like `{length: 2, "0": "hello", "1", "world"}`. But I think that's obscure
enough that it's unlikely to come up in practice, and if it does, it's better to
generate the nice code by default and the 100% correct code as an option.

I also added some skipped tests for cases that this commit doesn't support.

Out of the 180 files in the codebase I'm working with that were failing due to
for loop expressions, this commit fixes 159 of them. Of the remaining 21 of
them, 11 of them fail due to a non-expression body (about half of which had
`continue` statements), 4 of them fail due to a "for of" expression, 4 of them
fail because they use a "by" clause, and 2 of them fail because they use
"for own".