### PR TITLE
feat: implement soaked member access, dynamic member access, and function application

### DIFF
--- a/src/stages/main/index.js
+++ b/src/stages/main/index.js
@@ -47,6 +47,7 @@ import RestPatcher from './patchers/RestPatcher.js';
 import ReturnPatcher from './patchers/ReturnPatcher.js';
 import SeqOpPatcher from './patchers/SeqOpPatcher.js';
 import SlicePatcher from './patchers/SlicePatcher.js';
+import SoakedDynamicMemberAccessOpPatcher from './patchers/SoakedDynamicMemberAccessOpPatcher.js';
 import SoakedFunctionApplicationPatcher from './patchers/SoakedFunctionApplicationPatcher.js';
 import SoakedMemberAccessOpPatcher from './patchers/SoakedMemberAccessOpPatcher.js';
 import SpreadPatcher from './patchers/SpreadPatcher.js';
@@ -200,6 +201,9 @@ export default class MainStage extends TransformCoffeeScriptStage {
 
       case 'SoakedMemberAccessOp':
         return SoakedMemberAccessOpPatcher;
+
+      case 'SoakedDynamicMemberAccessOp':
+        return SoakedDynamicMemberAccessOpPatcher;
 
       case 'Herestring':
         return HerestringPatcher;

--- a/src/stages/main/patchers/SoakedFunctionApplicationPatcher.js
+++ b/src/stages/main/patchers/SoakedFunctionApplicationPatcher.js
@@ -1,10 +1,34 @@
 import FunctionApplicationPatcher from './FunctionApplicationPatcher.js';
+import findSoakContainer from '../../../utils/findSoakContainer.js';
+import { CALL_START } from 'coffee-lex';
+
+const GUARD_FUNC_HELPER =
+  `function __guardFunc__(func, transform) {
+  return typeof func === 'function' ? transform(func) : undefined;
+}`;
 
 export default class SoakedFunctionApplicationPatcher extends FunctionApplicationPatcher {
   patchAsExpression() {
-    throw this.error(
-      'cannot patch soaked function calls (e.g. `a?()`) yet, ' +
-      'see https://github.com/decaffeinate/decaffeinate/issues/176'
+    this.registerHelper('__guardFunc__', GUARD_FUNC_HELPER);
+    let callStartToken = this.getCallStartToken();
+    let soakContainer = findSoakContainer(this);
+    let varName = soakContainer.claimFreeBinding('f');
+    this.overwrite(this.fn.outerEnd, callStartToken.end, `, ${varName} => ${varName}(`);
+    soakContainer.insert(soakContainer.contentStart, '__guardFunc__(');
+    soakContainer.insert(soakContainer.contentEnd, ')');
+
+    super.patchAsExpression();
+  }
+
+  getCallStartToken(): SourceToken {
+    let tokens = this.context.sourceTokens;
+    let index = tokens.indexOfTokenMatchingPredicate(
+      token => token.type === CALL_START,
+      this.fn.outerEndTokenIndex
     );
+    if (!index || index.isAfter(this.contentEndTokenIndex)) {
+      throw this.error(`unable to find open-paren for function call`);
+    }
+    return tokens.tokenAtIndex(index);
   }
 }

--- a/src/utils/findSoakContainer.js
+++ b/src/utils/findSoakContainer.js
@@ -1,0 +1,63 @@
+/* @flow */
+import AssignOpPatcher from '../stages/main/patchers/AssignOpPatcher.js';
+import FunctionApplicationPatcher from '../stages/main/patchers/FunctionApplicationPatcher.js';
+import MemberAccessOpPatcher from '../stages/main/patchers/MemberAccessOpPatcher.js';
+import DynamicMemberAccessOpPatcher from '../stages/main/patchers/DynamicMemberAccessOpPatcher.js';
+import SoakedDynamicMemberAccessOpPatcher from '../stages/main/patchers/SoakedDynamicMemberAccessOpPatcher.js';
+import SoakedFunctionApplicationPatcher from '../stages/main/patchers/SoakedFunctionApplicationPatcher.js';
+import SoakedMemberAccessOpPatcher from '../stages/main/patchers/SoakedMemberAccessOpPatcher.js';
+
+import type NodePatcher from '../patchers/NodePatcher.js';
+
+/**
+ * Find the enclosing node defining the "soak range" for a given soak operation.
+ * For example, in the expression `a(b?.c.d())`, returns the `b?.c.d()` node,
+ * since that's the chain of operations that will be skipped if `b` is null or
+ * undefined.
+ */
+export default function findSoakContainer(patcher: NodePatcher): NodePatcher {
+  let result = patcher;
+  while (canParentHandleSoak(result)) {
+    result = result.parent;
+  }
+  return result;
+}
+
+/**
+ * Determine if this "soak range" can be expanded outward.
+ */
+function canParentHandleSoak(patcher: NodePatcher): boolean {
+  if (patcher.parent === null) {
+    return false;
+  }
+  if (patcher.isSurroundedByParentheses()) {
+    return false;
+  }
+  if (patcher.parent instanceof MemberAccessOpPatcher
+      && !(patcher.parent instanceof SoakedMemberAccessOpPatcher)) {
+    return true;
+  }
+  if (patcher.parent instanceof DynamicMemberAccessOpPatcher
+      && !(patcher.parent instanceof SoakedDynamicMemberAccessOpPatcher)
+      && patcher.parent.expression === patcher) {
+    return true;
+  }
+  if (patcher.parent instanceof FunctionApplicationPatcher
+      && !(patcher.parent instanceof SoakedFunctionApplicationPatcher)
+      && patcher.parent.fn === patcher) {
+    return true;
+  }
+  if (patcher.parent instanceof AssignOpPatcher
+      && patcher.parent.assignee === patcher) {
+    return true;
+  }
+  if (['PostIncrementOp', 'PostDecrementOp'].indexOf(patcher.parent.node.type) >= 0) {
+    return true;
+  }
+  if (['PreIncrementOp', 'PreDecrementOp', 'DeleteOp'].indexOf(patcher.parent.node.type) >= 0) {
+    throw patcher.parent.error(
+      'Expressions like `++a?.b`, `--a?.b`, and `delete a?.b` are not supported yet.'
+    );
+  }
+  return false;
+}


### PR DESCRIPTION
This is a first pass that I think should correctly handle nearly every case for
all soak operations. For now, the generated JavaScript always uses a helper
function, but in the future it probably makes sense to do something
simpler/shorter when we can get away with it.

Some details:
* In order to handle chained soaked operations, like `a?.b.c = d()`, I walk up
  the AST and stop when I get to the last soak-friendly node. That node's start
  and end define the "soak range" for the `__guard__` function.
* To handle nested soaks correctly, we also stop traversing up if we hit another
  soak operation.
* Since function application soaks have a different condition (they only pass if
  left side is really a function), I had to make a separate `__guardFunc__`
  helper for that case.
* I named the functions `__guard__` and `__guardFunc__` for now, since
  `registerHelper` doesn't ensure that the name is unique. Maybe in the future
  they could just be `guard` and `guardFunc`, or maybe something shorter.
* I process the nodes from the outside in. This makes sure that the guard
  functions are written in the right order, which is necessary for the last
  test.
* CoffeeScript also handles prefix and postfix ++ and -- and the delete
  operation. The prefix operators don't work with our strategy of appending code
  to the right, but it can probably be made to work. For now, though, I just
  throw an error.

Before this change, out of 1330 files in the codebase I'm working in, 235 of
them failed due to this error, and this commit completely fixes 166 of those
files, and the rest now fail due to other errors.

Closes #176.
Closes #216.