### PR TITLE
fix: ensure implicit functions as conditions in post-IF works

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -439,6 +439,28 @@ export default class NodePatcher {
   }
 
   /**
+   * Moves content in a range to another index.
+   */
+  move(start: number, end: number, index: number) {
+    if (typeof start !== 'number' || typeof end !== 'number') {
+      throw this.error(
+        `cannot remove non-numeric range [${start}, ${end})`
+      );
+    }
+    if (typeof index !== 'number') {
+      throw this.error(
+        `cannot move to non-numeric index: ${index}`
+      );
+    }
+    this.log(
+      'MOVE', `[${start}, ${end}) → ${index}`,
+      JSON.stringify(this.context.source.slice(start, end)),
+      'BEFORE', JSON.stringify(this.context.source.slice(index, index + 8))
+    );
+    this.editor.move(start, end, index);
+  }
+
+  /**
    * Get the current content between the start and end indexes.
    */
   slice(start: number, end: number): string {

--- a/src/patchers/types.js
+++ b/src/patchers/types.js
@@ -16,12 +16,13 @@ export type ParseContext = {
 };
 
 export type Editor = {
-  insertLeft: (index: number, content: string) => void,
-  insertRight: (index: number, content: string) => void,
-  overwrite: (start: number, end: number, content: string) => void,
-  remove: (start: number, end: number) => void,
-  slice: (start: number, end: number) => string,
-  append: (content: string) => void,
+  insertLeft: (index: number, content: string) => Editor;
+  insertRight: (index: number, content: string) => Editor;
+  overwrite: (start: number, end: number, content: string) => Editor;
+  remove: (start: number, end: number) => Editor;
+  slice: (start: number, end: number) => string;
+  append: (content: string) => Editor;
+  move: (start: number, end: number, index: number) => Editor;
 };
 
 export type SourceType = {

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -221,6 +221,14 @@ describe('conditionals', () => {
     `);
   });
 
+  it('keeps single-line POST-`if` with implicit call as the condition', () => {
+    check(`
+      a if b c
+    `, `
+      if (b(c)) { a; }
+    `);
+  });
+
   it('keeps single-line POST-`unless`', () => {
     check(`a unless b`, `if (!b) { a; }`);
   });


### PR DESCRIPTION
Uses `move` instead of overwriting the whole node, which works better with magic-string.

Fixes #327.