### PR TITLE
fix: make shorthand-candidate properties work with nothing around the colon

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "coffee-lex": "^1.4.4",
     "decaffeinate-parser": "^2.0.1",
     "detect-indent": "^4.0.0",
-    "esnext": "^2.1.1",
+    "esnext": "^2.1.3",
     "lines-and-columns": "^1.1.5",
     "magic-string": "^0.15.2",
     "repeating": "^2.0.0"


### PR DESCRIPTION
Fixes #325.