### PR TITLE
chore: remove browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "babel-preset-es2015-rollup": "^1.1.1",
     "babel-register": "^6.9.0",
     "babelrc-rollup": "^2.0.0",
-    "browserify": "^13.0.1",
     "coffee-script": "^1.10.0",
     "cz-conventional-changelog": "^1.1.6",
     "eslint": "^3.0.1",


### PR DESCRIPTION
browserify is no longer needed in this repo since now the decaffeinate-project.org repo does the browser build.