### PR TITLE
fix: allow for-in expressions with an object literal body

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -748,6 +748,13 @@ export default class NodePatcher {
     return rparen === afterToken;
   }
 
+  surroundInParens() {
+    if (!this.isSurroundedByParentheses()) {
+      this.insert(this.outerStart, '(');
+      this.insert(this.outerEnd, ')');
+    }
+  }
+
   getBoundingPatcher(): ?NodePatcher {
     if (this.isSurroundedByParentheses()) {
       return this;

--- a/src/stages/main/patchers/BoundFunctionPatcher.js
+++ b/src/stages/main/patchers/BoundFunctionPatcher.js
@@ -1,9 +1,8 @@
-import BlockPatcher from './BlockPatcher.js';
 import FunctionPatcher from './FunctionPatcher.js';
 import IdentifierPatcher from './IdentifierPatcher.js';
 import ManuallyBoundFunctionPatcher from './ManuallyBoundFunctionPatcher.js';
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import ObjectInitialiserPatcher from './ObjectInitialiserPatcher.js';
+import isObjectInitialiserBlock from '../../../utils/isObjectInitialiserBlock.js';
 import traverse from '../../../utils/traverse.js';
 import type { Node } from './../../../patchers/types.js';
 import { isFunction } from '../../../utils/types.js';
@@ -84,8 +83,8 @@ export default class BoundFunctionPatcher extends FunctionPatcher {
       if (!this.willPatchBodyInline()) {
         this.body.patch({ leftBrace: false });
       } else {
-        if (this.isBodyObjectInitializer()) {
-          this.surroundBodyInParens();
+        if (isObjectInitialiserBlock(this.body)) {
+          this.body.surroundInParens();
         }
         this.body.patch();
       }
@@ -101,19 +100,6 @@ export default class BoundFunctionPatcher extends FunctionPatcher {
 
   willPatchBodyInline(): boolean {
     return this.body ? this.body.willPatchAsExpression() : false;
-  }
-
-  isBodyObjectInitializer(): boolean {
-    return this.body instanceof BlockPatcher &&
-        this.body.statements.length === 1 &&
-        this.body.statements[0] instanceof ObjectInitialiserPatcher;
-  }
-
-  surroundBodyInParens() {
-    if (!this.body.isSurroundedByParentheses()) {
-      this.insert(this.body.outerStart, '(');
-      this.insert(this.body.outerEnd, ')');
-    }
   }
 
   hasInlineBody(): boolean {

--- a/src/stages/main/patchers/ForInPatcher.js
+++ b/src/stages/main/patchers/ForInPatcher.js
@@ -1,4 +1,5 @@
 import ForPatcher from './ForPatcher.js';
+import isObjectInitialiserBlock from '../../../utils/isObjectInitialiserBlock.js';
 import type BlockPatcher from './BlockPatcher.js';
 import type NodePatcher from './../../../patchers/NodePatcher.js';
 import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
@@ -72,6 +73,9 @@ export default class ForInPatcher extends ForPatcher {
     } else {
       // b d  ->  b.map((a) => d
       this.insert(this.target.outerEnd, `.map((${assigneeCode}) =>`);
+    }
+    if (isObjectInitialiserBlock(this.body)) {
+      this.body.surroundInParens();
     }
     // b.filter((a) => c).map((a) => d  ->  b.filter((a) => c).map((a) => d)
     this.insert(this.body.outerEnd, ')');

--- a/src/utils/isObjectInitialiserBlock.js
+++ b/src/utils/isObjectInitialiserBlock.js
@@ -1,0 +1,14 @@
+/* @flow */
+import BlockPatcher from '../stages/main/patchers/BlockPatcher.js';
+import ObjectInitialiserPatcher from '../stages/main/patchers/ObjectInitialiserPatcher.js';
+
+import type NodePatcher from '../patchers/NodePatcher.js';
+
+/**
+ * Determine if this is a block where the only contents are an object literal.
+ */
+export default function isObjectInitialiserBlock(patcher: NodePatcher): boolean {
+  return patcher instanceof BlockPatcher &&
+    patcher.statements.length === 1 &&
+    patcher.statements[0] instanceof ObjectInitialiserPatcher;
+}

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -352,6 +352,14 @@ describe('for loops', () => {
     `);
   });
 
+  it('handles for-in loop expressions with an object literal body', () => {
+    check(`
+      f({a: c, b: c} for c in d)
+    `, `
+      f(d.map((c) => ({a: c, b: c})));
+    `);
+  });
+
   it('correctly uses map with an index in for-in loop expressions', () => {
     validate(`
       sum = (arr) ->


### PR DESCRIPTION
Just like when creating arrow functions in `BoundFunctionPatcher`, we need to
put parens around the body if it's just an object literal so that JS can parse
it correctly.