### PR TITLE
feat: add a `runToStage` option so decaffeinate can return intermediate results

### DIFF
--- a/src/utils/formatCoffeeLexTokens.js
+++ b/src/utils/formatCoffeeLexTokens.js
@@ -1,0 +1,9 @@
+import formatRange from './formatRange.js';
+
+export default function formatCoffeeLexTokens(context): string {
+  let tokens = context.sourceTokens;
+  let resultLines = tokens.map(token =>
+    `${formatRange(token.start, token.end, context)}: ${token.type.name}`
+  );
+  return resultLines.map(line => line + '\n').join('');
+}

--- a/src/utils/formatCoffeeScriptAst.js
+++ b/src/utils/formatCoffeeScriptAst.js
@@ -1,0 +1,77 @@
+import formatRange from './formatRange.js';
+
+export default function formatCoffeeScriptAst(context): string {
+  let resultLines = formatAstNodeLines(context.ast, context);
+  return resultLines.map(line => line + '\n').join('');
+}
+
+function formatAstNodeLines(node, context) {
+  let propLines = [];
+  let blacklistedProps = ['locationData'];
+  // Show the non-node children first.
+  for (let key of Object.keys(node)) {
+    let value = node[key];
+    if (shouldTraverse(value) || blacklistedProps.indexOf(key) !== -1) {
+      continue;
+    }
+    let valueText;
+    try {
+      valueText = JSON.stringify(value);
+    } catch (e) {
+      valueText = '(error)';
+    }
+    propLines.push(`${key}: ${valueText}`);
+  }
+
+  // Then show the node children.
+  for (let key of Object.keys(node)) {
+    let value = node[key];
+    if (!shouldTraverse(value)) {
+      continue;
+    }
+
+    if (Array.isArray(value) && value.length === 0) {
+      propLines.push(`${key}: []`);
+    } else if (Array.isArray(value)) {
+      propLines.push(`${key}: [`);
+      for (let child of value) {
+        propLines.push(...formatAstNodeLines(child, context).map(s => '  ' + s));
+      }
+      propLines.push(`]`);
+    } else {
+      let childLines = formatAstNodeLines(value, context);
+      childLines[0] = `${key}: ${childLines[0]}`;
+      propLines.push(...childLines);
+    }
+  }
+  return [
+    `${node.constructor.name} ${formatLocationData(node, context)} {`,
+    ...propLines.map(s => '  ' + s),
+    '}',
+  ];
+}
+
+function formatLocationData(node, context) {
+  let {first_line, first_column, last_line, last_column} = node.locationData;
+  let firstIndex = context.linesAndColumns.indexForLocation({line: first_line, column: first_column});
+  let lastIndex = context.linesAndColumns.indexForLocation({line: last_line, column: last_column}) + 1;
+  return formatRange(firstIndex, lastIndex, context);
+}
+
+function shouldTraverse(value) {
+  if (Array.isArray(value)) {
+    return value.length === 0 || isNode(value[0]);
+  }
+  return isNode(value);
+}
+
+/**
+ * CoffeeScript AST nodes are always instances of a custom class, so use the
+ * constructor name to distinguish between node children and non-node children.
+ */
+function isNode(value) {
+  if (!value) {
+    return false;
+  }
+  return ['String', 'Number', 'Boolean', 'Array', 'Object'].indexOf(value.constructor.name) === -1;
+}

--- a/src/utils/formatDecaffeinateParserAst.js
+++ b/src/utils/formatDecaffeinateParserAst.js
@@ -10,7 +10,7 @@ function formatAstNodeLines(node, context) {
   let propLines = [];
   let childPropNames = childPropertyNames(node);
   let blacklistedProps = childPropNames.concat(
-    ['raw', 'line', 'column', 'type', 'range', 'scope', 'parentNode', 'context']
+    ['raw', 'line', 'column', 'type', 'range', 'virtual', 'scope', 'parentNode', 'context']
   );
   for (let key of Object.keys(node)) {
     if (blacklistedProps.indexOf(key) !== -1) {
@@ -43,8 +43,14 @@ function formatAstNodeLines(node, context) {
       propLines.push(...childLines);
     }
   }
+  let rangeStr;
+  if (node.virtual) {
+    rangeStr = '(virtual)';
+  } else {
+    rangeStr = formatRange(node.range[0], node.range[1], context);
+  }
   return [
-    `${node.type} ${formatRange(node.range[0], node.range[1], context)} {`,
+    `${node.type} ${rangeStr} {`,
     ...propLines.map(s => '  ' + s),
     '}',
   ];

--- a/src/utils/formatDecaffeinateParserAst.js
+++ b/src/utils/formatDecaffeinateParserAst.js
@@ -1,0 +1,51 @@
+import formatRange from './formatRange.js';
+import {childPropertyNames} from './traverse.js';
+
+export default function formatDecaffeinateParserAst(ast): string {
+  let resultLines = formatAstNodeLines(ast, ast.context);
+  return resultLines.map(line => line + '\n').join('');
+}
+
+function formatAstNodeLines(node, context) {
+  let propLines = [];
+  let childPropNames = childPropertyNames(node);
+  let blacklistedProps = childPropNames.concat(
+    ['raw', 'line', 'column', 'type', 'range', 'scope', 'parentNode', 'context']
+  );
+  for (let key of Object.keys(node)) {
+    if (blacklistedProps.indexOf(key) !== -1) {
+      continue;
+    }
+    let valueText;
+    try {
+      valueText = JSON.stringify(node[key]);
+    } catch (e) {
+      valueText = '(error)';
+    }
+    propLines.push(`${key}: ${valueText}`);
+  }
+
+  for (let childProp of childPropNames) {
+    let value = node[childProp];
+    if (value === null) {
+      propLines.push(`${childProp}: null`);
+    } else if (Array.isArray(value) && value.length === 0) {
+      propLines.push(`${childProp}: []`);
+    } else if (Array.isArray(value)) {
+      propLines.push(`${childProp}: [`);
+      for (let child of value) {
+        propLines.push(...formatAstNodeLines(child, context).map(s => '  ' + s));
+      }
+      propLines.push(`]`);
+    } else {
+      let childLines = formatAstNodeLines(value, context);
+      childLines[0] = `${childProp}: ${childLines[0]}`;
+      propLines.push(...childLines);
+    }
+  }
+  return [
+    `${node.type} ${formatRange(node.range[0], node.range[1], context)} {`,
+    ...propLines.map(s => '  ' + s),
+    '}',
+  ];
+}

--- a/src/utils/formatRange.js
+++ b/src/utils/formatRange.js
@@ -1,0 +1,20 @@
+/**
+ * Display a range of code, e.g. for a token or an AST node.
+ *
+ * The line and column are displayed as 1-indexed, to agree with most editors,
+ * and the actual 0-indexed code index is also displayed.
+ *
+ * For example, if a program is just "foo", then the "foo" token has this range:
+ * [1:1(0)-1:4(3)]
+ */
+export default function formatRange(startIndex: number, endIndex: number, context) {
+  return `[${formatIndex(startIndex, context)}-${formatIndex(endIndex, context)}]`;
+}
+
+function formatIndex(index: number, context) {
+  if (index > context.source.length) {
+    index = context.source.length;
+  }
+  let {line, column} = context.linesAndColumns.locationForIndex(index);
+  return `${line + 1}:${column + 1}(${index})`;
+}

--- a/test/utils/formatCoffeeLexTokens_test.js
+++ b/test/utils/formatCoffeeLexTokens_test.js
@@ -1,0 +1,27 @@
+import { strictEqual } from 'assert';
+import formatCoffeeLexTokens from '../../src/utils/formatCoffeeLexTokens.js';
+import stripSharedIndent from '../../src/utils/stripSharedIndent.js';
+import parse from '../../src/utils/parse.js';
+
+describe('formatCoffeeLexTokens', () => {
+  it('formats tokens for normal CoffeeScript code', () => {
+    let source = stripSharedIndent(`
+      x = for a in b
+        a()
+    `);
+    let context = parse(source).context;
+    let formattedTokens = formatCoffeeLexTokens(context);
+    strictEqual(formattedTokens, stripSharedIndent(`
+      [1:1(0)-1:2(1)]: IDENTIFIER
+      [1:3(2)-1:4(3)]: OPERATOR
+      [1:5(4)-1:8(7)]: FOR
+      [1:9(8)-1:10(9)]: IDENTIFIER
+      [1:11(10)-1:13(12)]: RELATION
+      [1:14(13)-1:15(14)]: IDENTIFIER
+      [1:15(14)-2:1(15)]: NEWLINE
+      [2:3(17)-2:4(18)]: IDENTIFIER
+      [2:4(18)-2:5(19)]: CALL_START
+      [2:5(19)-2:6(20)]: CALL_END
+    `) + '\n');
+  });
+});

--- a/test/utils/formatCoffeeScriptAst_test.js
+++ b/test/utils/formatCoffeeScriptAst_test.js
@@ -1,0 +1,44 @@
+import { strictEqual } from 'assert';
+import formatCoffeeScriptAst from '../../src/utils/formatCoffeeScriptAst.js';
+import stripSharedIndent from '../../src/utils/stripSharedIndent.js';
+import parse from '../../src/utils/parse.js';
+
+describe('formatCoffeeScriptAst', () => {
+  it('formats an AST for normal CoffeeScript code', () => {
+    let source = stripSharedIndent(`
+      x = a()
+    `);
+    let context = parse(source).context;
+    let formattedTokens = formatCoffeeScriptAst(context);
+    strictEqual(formattedTokens, stripSharedIndent(`
+      Block [1:1(0)-1:8(7)] {
+        expressions: [
+          Assign [1:1(0)-1:8(7)] {
+            context: undefined
+            param: undefined
+            subpattern: undefined
+            operatorToken: undefined
+            variable: Value [1:1(0)-1:2(1)] {
+              base: Literal [1:1(0)-1:2(1)] {
+                value: "x"
+              }
+              properties: []
+            }
+            value: Call [1:5(4)-1:8(7)] {
+              soak: false
+              isNew: false
+              isSuper: false
+              args: []
+              variable: Value [1:5(4)-1:6(5)] {
+                base: Literal [1:5(4)-1:6(5)] {
+                  value: "a"
+                }
+                properties: []
+              }
+            }
+          }
+        ]
+      }
+    `) + '\n');
+  });
+});

--- a/test/utils/formatDecaffeinateParserAst_test.js
+++ b/test/utils/formatDecaffeinateParserAst_test.js
@@ -1,0 +1,33 @@
+import { strictEqual } from 'assert';
+import formatDecaffeinateParserAst from '../../src/utils/formatDecaffeinateParserAst.js';
+import stripSharedIndent from '../../src/utils/stripSharedIndent.js';
+import parse from '../../src/utils/parse.js';
+
+describe('formatDecaffeinateParserAst', () => {
+  it('formats an AST for normal CoffeeScript code', () => {
+    let source = stripSharedIndent(`
+      x = a()
+    `);
+    let ast = parse(source);
+    let formattedTokens = formatDecaffeinateParserAst(ast);
+    strictEqual(formattedTokens, stripSharedIndent(`
+      Program [1:1(0)-1:8(7)] {
+        body: Block [1:1(0)-1:8(7)] {
+          statements: [
+            AssignOp [1:1(0)-1:8(7)] {
+              assignee: Identifier [1:1(0)-1:2(1)] {
+                data: "x"
+              }
+              expression: FunctionApplication [1:5(4)-1:8(7)] {
+                function: Identifier [1:5(4)-1:6(5)] {
+                  data: "a"
+                }
+                arguments: []
+              }
+            }
+          ]
+        }
+      }
+    `) + '\n');
+  });
+});

--- a/test/utils/formatDecaffeinateParserAst_test.js
+++ b/test/utils/formatDecaffeinateParserAst_test.js
@@ -6,23 +6,40 @@ import parse from '../../src/utils/parse.js';
 describe('formatDecaffeinateParserAst', () => {
   it('formats an AST for normal CoffeeScript code', () => {
     let source = stripSharedIndent(`
-      x = a()
+      loop
+        x = a()
+        break
     `);
     let ast = parse(source);
     let formattedTokens = formatDecaffeinateParserAst(ast);
     strictEqual(formattedTokens, stripSharedIndent(`
-      Program [1:1(0)-1:8(7)] {
-        body: Block [1:1(0)-1:8(7)] {
+      Program [1:1(0)-3:8(22)] {
+        body: Block [1:1(0)-3:8(22)] {
           statements: [
-            AssignOp [1:1(0)-1:8(7)] {
-              assignee: Identifier [1:1(0)-1:2(1)] {
-                data: "x"
+            While [1:1(0)-3:8(22)] {
+              isUntil: false
+              condition: Bool (virtual) {
+                data: true
               }
-              expression: FunctionApplication [1:5(4)-1:8(7)] {
-                function: Identifier [1:5(4)-1:6(5)] {
-                  data: "a"
-                }
-                arguments: []
+              guard: null
+              body: Block [2:3(7)-3:8(22)] {
+                inline: false
+                statements: [
+                  AssignOp [2:3(7)-2:10(14)] {
+                    assignee: Identifier [2:3(7)-2:4(8)] {
+                      data: "x"
+                    }
+                    expression: FunctionApplication [2:7(11)-2:10(14)] {
+                      function: Identifier [2:7(11)-2:8(12)] {
+                        data: "a"
+                      }
+                      arguments: []
+                    }
+                  }
+                  Identifier [3:3(17)-3:8(22)] {
+                    data: "break"
+                  }
+                ]
               }
             }
           ]


### PR DESCRIPTION
This is the decaffeinate side of a change to the repl that makes it possible to
run some but not all stages of decaffeinate and inspect the intermediate
results. In addition to supporting the normal stages, I also allow inspecting
the results produced by the CoffeeScript parser, coffee-lex, and
decaffeinate-parser. In all three of these cases, there wasn't (to my knowledge)
an existing nice way of printing out these formats, so I wrote pretty-printers
for each of them, which use a consistent format for naming positions in code.

There are certainly some similarities between the pretty-printers, but there are
enough differences that it seems best to keep the code mostly separate.

The main use case here is to make it easier to figure out what went wrong when
decaffeinate crashes, e.g. whether the problem happened due to a bug in the
parser or at the normalize step or in the main stage. It may also make it easier
for future contributors to learn the internals of decaffeinate.

Here's a live demo:
http://www.alangpierce.com/decaffeinate-project.org/repl/#?evaluate=false&stage=full&code=x%20%3D%20a%20%22%23%7Bb%20%2B%20c%7D%22