### PR TITLE
fix: handle for-of statements with a filter

### DIFF
--- a/src/stages/main/patchers/ForInPatcher.js
+++ b/src/stages/main/patchers/ForInPatcher.js
@@ -127,31 +127,8 @@ export default class ForInPatcher extends ForPatcher {
     if (this.valAssignee.statementNeedsParens()) {
       valueAssignment = `(${valueAssignment})`;
     }
-
-    let { filter, body } = this;
-
-    body.insertStatementsAtIndex([valueAssignment], 0);
-    if (filter) {
-      body.insertStatementsAtIndex([`if (${this.getFilterCode()}) {`], 0);
-      body.patch({ leftBrace: false, rightBrace: false });
-      body.indent();
-      body.appendLineAfter('}', -1);
-      body.appendLineAfter('}', -2);
-    } else {
-      body.patch({ leftBrace: false });
-    }
-  }
-
-  getFilterCode(): ?string {
-    let filter = this.filter;
-    if (!filter) {
-      return null;
-    }
-    if (!this._filterCode) {
-      filter.patch();
-      this._filterCode = this.slice(filter.contentStart, filter.contentEnd);
-    }
-    return this._filterCode;
+    this.body.insertStatementsAtIndex([valueAssignment], 0);
+    this.patchBodyAndFilter();
   }
 
   getInitCode(): string {

--- a/src/stages/main/patchers/ForOfPatcher.js
+++ b/src/stages/main/patchers/ForOfPatcher.js
@@ -19,6 +19,12 @@ export default class ForOfPatcher extends ForPatcher {
     let bodyLinesToPrepend = [];
     let { keyAssignee } = this;
 
+    // Save the filter code and remove if it it's there.
+    this.getFilterCode();
+    if (this.filter) {
+      this.remove(this.target.outerEnd, this.filter.outerEnd);
+    }
+
     let keyBinding = this.getIndexBinding();
     this.insert(keyAssignee.outerStart, '(');
 
@@ -56,7 +62,7 @@ export default class ForOfPatcher extends ForPatcher {
 
     this.removeThenToken();
     this.body.insertStatementsAtIndex(bodyLinesToPrepend, 0);
-    this.body.patch({ leftBrace: false });
+    this.patchBodyAndFilter();
   }
 
   indexBindingCandidates(): Array<string> {

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -63,6 +63,20 @@ describe('for loops', () => {
     `);
   });
 
+  it('handles for-of statements with a filter', () => {
+    check(`
+      for k, v of obj when k == v
+        console.log v
+    `, `
+      for (let k in obj) {
+        let v = obj[k];
+        if (k === v) {
+          console.log(v);
+        }
+      }
+    `);
+  });
+
   it('transforms for-in loops to typical `for` loops', () => {
     check(`
       for a in b


### PR DESCRIPTION
Previously, it would leave the `when` clause alone, resulting in invalid JS.
Now, it uses the same strategy that for-in loops use: after handling any initial
assignment, wrap the normal body in an `if` statement.

Also, `ForPatcher.patchAsStatement` was unused (both `ForInPatcher` and
`ForOfPatcher` explicitly override it and never use super), so I just removed
it.