### PR TITLE
fix: improve the pacement of the close-paren for implicit function calls

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -668,6 +668,13 @@ export default class NodePatcher {
   }
 
   /**
+   * Gets the last token in the content of this node.
+   */
+  lastToken() {
+    return this.sourceTokenAtIndex(this.contentEndTokenIndex);
+  }
+
+  /**
    * Gets the original source of this patcher's node.
    */
   getOriginalSource(): string {

--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.js
@@ -41,9 +41,9 @@ export default class FunctionApplicationPatcher extends NodePatcher {
     if (implicitCall) {
       let lastArg = args[args.length - 1];
       if (lastArg.isMultiline() && lastTokenType !== RBRACE && lastTokenType !== RBRACKET) {
-        this.insert(this.innerEnd, `\n${this.getIndent()})`);
+        this.insert(this.contentEnd, `\n${this.getIndent()})`);
       } else {
-        this.insert(this.innerEnd, ')');
+        this.insert(this.contentEnd, ')');
       }
     }
   }

--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.js
@@ -1,6 +1,6 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
 import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
-import { CALL_START } from 'coffee-lex';
+import { CALL_START, RBRACE, RBRACKET } from 'coffee-lex';
 
 export default class FunctionApplicationPatcher extends NodePatcher {
   fn: NodePatcher;
@@ -37,10 +37,11 @@ export default class FunctionApplicationPatcher extends NodePatcher {
 
     args.forEach(arg => arg.patch());
 
+    let lastTokenType = this.lastToken().type;
     if (implicitCall) {
       let lastArg = args[args.length - 1];
-      if (lastArg.isMultiline()) {
-        this.appendLineAfter(')');
+      if (lastArg.isMultiline() && lastTokenType !== RBRACE && lastTokenType !== RBRACKET) {
+        this.insert(this.innerEnd, `\n${this.getIndent()})`);
       } else {
         this.insert(this.innerEnd, ')');
       }

--- a/test/array_test.js
+++ b/test/array_test.js
@@ -110,4 +110,14 @@ describe('arrays', () => {
       ];
     `);
   });
+
+  it('handles arrays containing implicit function calls', () => {
+    check(`
+      [a(b, c {
+      })]
+    `, `
+      [a(b, c({
+      }))];
+    `);
+  });
 });

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -91,8 +91,8 @@ describe('function calls', () => {
     `, `
       promise.then(function() {
         a();
-        return b; // c
-      });
+        return b;
+      }); // c
       d;
     `);
   });
@@ -251,6 +251,16 @@ describe('function calls', () => {
       a(b(c), d)
     `, `
       a(b(c), d);
+    `);
+  });
+
+  it('puts the close-paren in a nice place for implicit calls on objects', () => {
+    check(`
+      a {
+      }
+    `, `
+      a({
+      });
     `);
   });
 });

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -263,4 +263,18 @@ describe('function calls', () => {
       });
     `);
   });
+
+  it('handles implicit calls nested in another function call', () => {
+    check(`
+      a(
+        b {
+        }
+      )
+    `, `
+      a(
+        b({
+        })
+      );
+    `);
+  });
 });


### PR DESCRIPTION
This fixes a crash where a close-paren was being placed in the wrong place.
[(repl)](http://decaffeinate-project.org/repl/#?evaluate=true&code=%5Ba(b%2C%20c%20%7B%0A%7D)%5D)

The previous code was using `appendLineAfter`, which was using
`getBoundingPatcher` as a way of determining where it's safe to place the
paren. However, `getBoundingPatcher` doesn't seem to always do that, for example
when the node is an argument to a function taking multiple arguments. Instead, I
now just always place the close-paren in the function call's `innerEnd`. Also,
when deciding whether to put the close-paren on a new line or right after the
end of the call, I now put it right at the end if the call ends with a `}` or a
`]`, which fixes a bunch of ugly newlines that I was seeing.

Unfortunately, this causes a comment to be placed one line below the ideal spot
in one place (since the newline is now before the comment rather than after),
but that seems acceptable for now, especially since the comment is still preserved.

Maybe a longer-term approach would be to improve `getBoundingPatcher` and
`appendLineAfter`, but at least, for now, I think this change makes the code
look better and makes it less likely for mismatched parens to pop up.