### PR TITLE
fix: force dynamic member access indices to be expressions

### DIFF
--- a/src/stages/main/patchers/DynamicMemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/DynamicMemberAccessOpPatcher.js
@@ -11,6 +11,11 @@ export default class DynamicMemberAccessOpPatcher extends NodePatcher {
     this.indexingExpr = indexingExpr;
   }
 
+  initialize() {
+    this.expression.setRequiresExpression();
+    this.indexingExpr.setRequiresExpression();
+  }
+
   patchAsExpression() {
     this.expression.patch();
     this.indexingExpr.patch();

--- a/test/member_access_test.js
+++ b/test/member_access_test.js
@@ -68,4 +68,12 @@ describe('member access', () => {
       a[b]();
     `);
   });
+
+  it('forces expressions in dynamic member access', () => {
+    check(`
+      a[if b then c else d]
+    `, `
+      a[b ? c : d];
+    `);
+  });
 });


### PR DESCRIPTION
This was breaking code like `a[if b then c else d]`.