### PR TITLE
feat: implement "for own" in a statement context

### DIFF
--- a/src/stages/main/patchers/ForPatcher.js
+++ b/src/stages/main/patchers/ForPatcher.js
@@ -121,4 +121,22 @@ export default class ForPatcher extends NodePatcher {
       this.remove(thenToken.start, nextToken.start);
     }
   }
+
+  getTargetCode(): string {
+    // Trigger patching the reference.
+    this.getTargetReference();
+    return this.slice(this.target.contentStart, this.target.contentEnd);
+  }
+
+  getTargetReference(): string {
+    if (!this._targetReference) {
+      this.target.patch();
+      if (this.requiresExtractingTarget()) {
+        this._targetReference = this.claimFreeBinding(this.targetBindingCandidate());
+      } else {
+        this._targetReference = this.slice(this.target.contentStart, this.target.contentEnd);
+      }
+    }
+    return this._targetReference;
+  }
 }

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -475,67 +475,58 @@ describe('for loops', () => {
     `);
   });
 
-  it.skip('handles `for own`', () => {
+  it('handles `for own`', () => {
     check(`
       for own key of list
         console.log key
     `, `
-      for (let key in list) {
-        if (Object.prototype.hasOwnProperty.call(list, key)) {
-          console.log(key);
-        }
+      for (let key of Object.keys(list)) {
+        console.log(key);
       }
     `);
   });
 
-  it.skip('handles `for own` with an unsafe-to-repeat iterable', () => {
+  it('handles `for own` with an unsafe-to-repeat iterable', () => {
     check(`
       for own key of getList()
         console.log key
     `, `
-      let iterable;
-      for (let key in (iterable = getList())) {
-        if (Object.prototype.hasOwnProperty.call(iterable, key)) {
+      for (let key of Object.keys(getList())) {
+        console.log(key);
+      }
+    `);
+  });
+
+  it('handles `for own` with both key and value', () => {
+    check(`
+      for own key, value of list
+        console.log key, value
+    `, `
+      for (let key of Object.keys(list)) {
+        let value = list[key];
+        console.log(key, value);
+      }
+    `);
+  });
+
+  it('handles `for own` with a filter', () => {
+    check(`
+      for own key of list when key[0] is '_'
+        console.log key
+    `, `
+      for (let key of Object.keys(list)) {
+        if (key[0] === '_') {
           console.log(key);
         }
       }
     `);
   });
 
-  it.skip('handles `for own` with both key and value', () => {
-    check(`
-      for own key, value of list
-        console.log key, value
-    `, `
-      for (let key in list) {
-        if (Object.prototype.hasOwnProperty.call(list, key)) {
-          let value = list[key];
-          console.log(key, value);
-        }
-      }
-    `);
-  });
-
-  it.skip('handles `for own` with a filter', () => {
-    check(`
-      for own key of list when key[0] is '_'
-        console.log key
-    `, `
-      for (let key in list) {
-        if (Object.prototype.hasOwnProperty.call(list, key)) {
-          if (key[0] === '_') {
-            console.log(key);
-          }
-        }
-      }
-    `);
-  });
-
-  it.skip('handles single-line `for own`', () => {
+  it('handles single-line `for own`', () => {
     check(`
       for own a of b then a
     `, `
-      for (let a in b) { if (Object.prototype.hasOwnProperty.call(b, a)) { a; } }
+      for (let a of Object.keys(b)) { a; }
     `);
   });
 

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -27,12 +27,12 @@ describe('for loops', () => {
 
   it('transforms for-of loops with both key and value plus unsafe-to-repeat target by saving a reference', () => {
     check(`
-      for k, v of object()
+      for k, v of getObject()
         k
     `, `
-      let iterable;
-      for (let k in (iterable = object())) {
-        let v = iterable[k];
+      let object = getObject();
+      for (let k in object) {
+        let v = object[k];
         k;
       }
     `);
@@ -52,12 +52,12 @@ describe('for loops', () => {
 
   it('transforms for-of loops with destructured value plus unsafe-to-repeat target', () => {
     check(`
-      for key, {x, y} of object()
+      for key, {x, y} of getObject()
         key + x
     `, `
-      let iterable;
-      for (let key in (iterable = object())) {
-        let {x, y} = iterable[key];
+      let object = getObject();
+      for (let key in object) {
+        let {x, y} = object[key];
         key + x;
       }
     `);
@@ -488,10 +488,10 @@ describe('for loops', () => {
 
   it('handles `for own` with an unsafe-to-repeat iterable', () => {
     check(`
-      for own key of getList()
+      for own key of getObject()
         console.log key
     `, `
-      for (let key of Object.keys(getList())) {
+      for (let key of Object.keys(getObject())) {
         console.log(key);
       }
     `);
@@ -504,6 +504,19 @@ describe('for loops', () => {
     `, `
       for (let key of Object.keys(list)) {
         let value = list[key];
+        console.log(key, value);
+      }
+    `);
+  });
+
+  it('handles `for own` with unsafe-to-repeat iterable with both key and value', () => {
+    check(`
+      for own key, value of getObject()
+        console.log key, value
+    `, `
+      let object = getObject();
+      for (let key of Object.keys(object)) {
+        let value = object[key];
         console.log(key, value);
       }
     `);


### PR DESCRIPTION
We can just use a JS for-of loop on `Object.keys`, which is defined to iterate
through the own properties in the same order that JS for-in would.

Closes #157.