### PR TITLE
chore: add failing test for #356

### DIFF
--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -277,4 +277,26 @@ describe('function calls', () => {
       );
     `);
   });
+
+  it.skip('handles implicit calls across OUTDENT tokens', () => {
+    check(`
+      a {
+        b: ->
+          return c d,
+            if e
+              f
+      }
+      g
+    `, `
+      a({
+        b() {
+          return c(d,
+            e ?
+              f : undefined
+          );
+        }
+      });
+      g;
+    `);
+  });
 });


### PR DESCRIPTION
This will be fixed when updating to the first decaffeinate-coffeescript patch.