### PR TITLE
fix: always spread `arguments` in `super` call with implicit args

### DIFF
--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.js
@@ -23,6 +23,11 @@ export default class FunctionApplicationPatcher extends NodePatcher {
       return;
     }
 
+    if (this.isImplicitSuper()) {
+      this.insert(this.fn.outerEnd, '(arguments...)');
+      return;
+    }
+
     if (implicitCall) {
       let firstArg = args[0];
       let hasOneArg = args.length === 1;
@@ -48,7 +53,26 @@ export default class FunctionApplicationPatcher extends NodePatcher {
     }
   }
 
-  isImplicitCall() {
+  isImplicitCall(): boolean {
     return !this.fn.hasSourceTokenAfter(CALL_START);
+  }
+
+  isImplicitSuper(): boolean {
+    if (this.fn.node.type !== 'Super') {
+      return false;
+    }
+
+    if (this.args.length !== 1) {
+      return false;
+    }
+
+    let arg = this.args[0].node;
+
+    return (
+      arg.virtual &&
+      arg.type === 'Spread' &&
+      arg.expression.type === 'Identifier' &&
+      arg.expression.data === 'arguments'
+    );
   }
 }

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -360,7 +360,7 @@ describe('classes', () => {
     `, `
       class A extends B {
         a() {
-          return super.a();
+          return super.a(...arguments);
         }
       }
     `);
@@ -388,7 +388,7 @@ describe('classes', () => {
     `, `
       class A extends B {
         static a() {
-          return super.a();
+          return super.a(...arguments);
         }
       }
     `);

--- a/test/super_test.js
+++ b/test/super_test.js
@@ -1,0 +1,39 @@
+import check from './support/check.js';
+
+describe('super', () => {
+  it('spreads `arguments` when no arguments are given', () => {
+    check(`
+      class C extends B
+        constructor: (x) ->
+          super
+
+        fn: (x) ->
+          super
+    `, `
+      class C extends B {
+        constructor(x) {
+          super(...arguments);
+        }
+
+        fn(x) {
+          return super.fn(...arguments);
+        }
+      }
+    `);
+  });
+
+  // https://github.com/decaffeinate/decaffeinate/issues/375
+  it.skip('can be used as an argument to another call', () => {
+    check(`
+      class A
+        b: ->
+          c(super)
+    `, `
+      class A {
+        b() {
+          return c(super.b(...arguments));
+        }
+      }
+    `);
+  });
+});


### PR DESCRIPTION
Fixes #310