### PR TITLE
feat: add a "CoffeeScript lexer" intermediate stage for the repl

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import { tokens } from 'decaffeinate-coffeescript';
 import AddVariableDeclarationsStage from './stages/add-variable-declarations/index.js';
 import SemicolonsStage from './stages/semicolons/index.js';
 import EsnextStage from './stages/esnext/index.js';
@@ -5,6 +6,7 @@ import MainStage from './stages/main/index.js';
 import NormalizeStage from './stages/normalize/index.js';
 import formatCoffeeLexAst from './utils/formatCoffeeLexTokens.js';
 import formatCoffeeScriptAst from './utils/formatCoffeeScriptAst.js';
+import formatCoffeeScriptLexerTokens from './utils/formatCoffeeScriptLexerTokens.js';
 import formatDecaffeinateParserAst from './utils/formatDecaffeinateParserAst.js';
 import parse from './utils/parse.js';
 import PatchError from './utils/PatchError.js';
@@ -88,7 +90,12 @@ function runStage(stage: Stage, content: string, filename: string): { code: stri
 
 function convertCustomStage(source: string, stageName: string): ConversionResult {
   let ast = parse(source);
-  if (stageName === 'coffeescript-parser') {
+  if (stageName === 'coffeescript-lexer') {
+    return {
+      code: formatCoffeeScriptLexerTokens(tokens(source), ast.context),
+      maps: [],
+    };
+  } else if (stageName === 'coffeescript-parser') {
     return {
       code: formatCoffeeScriptAst(ast.context),
       maps: [],

--- a/src/utils/formatCoffeeScriptAst.js
+++ b/src/utils/formatCoffeeScriptAst.js
@@ -1,4 +1,4 @@
-import formatRange from './formatRange.js';
+import formatCoffeeScriptLocationData from './formatCoffeeScriptLocationData.js';
 
 export default function formatCoffeeScriptAst(context): string {
   let resultLines = formatAstNodeLines(context.ast, context);
@@ -45,17 +45,10 @@ function formatAstNodeLines(node, context) {
     }
   }
   return [
-    `${node.constructor.name} ${formatLocationData(node, context)} {`,
+    `${node.constructor.name} ${formatCoffeeScriptLocationData(node.locationData, context)} {`,
     ...propLines.map(s => '  ' + s),
     '}',
   ];
-}
-
-function formatLocationData(node, context) {
-  let {first_line, first_column, last_line, last_column} = node.locationData;
-  let firstIndex = context.linesAndColumns.indexForLocation({line: first_line, column: first_column});
-  let lastIndex = context.linesAndColumns.indexForLocation({line: last_line, column: last_column}) + 1;
-  return formatRange(firstIndex, lastIndex, context);
 }
 
 function shouldTraverse(value) {

--- a/src/utils/formatCoffeeScriptLexerTokens.js
+++ b/src/utils/formatCoffeeScriptLexerTokens.js
@@ -1,0 +1,8 @@
+import formatCoffeeScriptLocationData from './formatCoffeeScriptLocationData.js';
+
+export default function formatCoffeeScriptLexerTokens(tokens, context): string {
+  let resultLines = tokens.map(([tag, value, locationData]) =>
+    `${formatCoffeeScriptLocationData(locationData, context)}: ${tag}: ${JSON.stringify(value)}`
+  );
+  return resultLines.map(line => line + '\n').join('');
+}

--- a/src/utils/formatCoffeeScriptLocationData.js
+++ b/src/utils/formatCoffeeScriptLocationData.js
@@ -1,0 +1,8 @@
+import formatRange from './formatRange.js';
+
+export default function formatCoffeeScriptLocationData(locationData, context) {
+  let {first_line, first_column, last_line, last_column} = locationData;
+  let firstIndex = context.linesAndColumns.indexForLocation({line: first_line, column: first_column});
+  let lastIndex = context.linesAndColumns.indexForLocation({line: last_line, column: last_column}) + 1;
+  return formatRange(firstIndex, lastIndex, context);
+}

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -277,4 +277,26 @@ describe('function calls', () => {
       );
     `);
   });
+
+  it('handles implicit calls across OUTDENT tokens', () => {
+    check(`
+      a {
+        b: ->
+          return c d,
+            if e
+              f
+      }
+      g
+    `, `
+      a({
+        b() {
+          return c(d,
+            e ?
+              f : undefined
+          );
+        }
+      });
+      g;
+    `);
+  });
 });

--- a/test/utils/formatCoffeeScriptLexerTokens_test.js
+++ b/test/utils/formatCoffeeScriptLexerTokens_test.js
@@ -1,0 +1,30 @@
+import { strictEqual } from 'assert';
+import { tokens } from 'decaffeinate-coffeescript';
+import formatCoffeeScriptLexerTokens from '../../src/utils/formatCoffeeScriptLexerTokens.js';
+import parse from '../../src/utils/parse.js';
+import stripSharedIndent from '../../src/utils/stripSharedIndent.js';
+
+describe('formatCoffeeScriptLexerTokens', () => {
+  it('formats tokens for normal CoffeeScript code', () => {
+    let source = stripSharedIndent(`
+      x = for a in b
+        a()
+    `);
+    let context = parse(source).context;
+    let formattedTokens = formatCoffeeScriptLexerTokens(tokens(source), context);
+    strictEqual(formattedTokens, stripSharedIndent(`
+      [1:1(0)-1:2(1)]: IDENTIFIER: "x"
+      [1:3(2)-1:4(3)]: =: "="
+      [1:5(4)-1:8(7)]: FOR: "for"
+      [1:9(8)-1:10(9)]: IDENTIFIER: "a"
+      [1:11(10)-1:13(12)]: FORIN: "in"
+      [1:14(13)-1:15(14)]: IDENTIFIER: "b"
+      [2:1(15)-2:3(17)]: INDENT: 2
+      [2:3(17)-2:4(18)]: IDENTIFIER: "a"
+      [2:4(18)-2:5(19)]: CALL_START: "("
+      [2:5(19)-2:6(20)]: CALL_END: ")"
+      [2:6(20)-2:6(20)]: OUTDENT: 2
+      [2:6(20)-2:6(20)]: TERMINATOR: "\\n"
+    `) + '\n');
+  });
+});


### PR DESCRIPTION
The last CoffeeScript bug was a lexer issue, and it looks like there's another
lexer bug, so it seems nice to be able to look at the location data of each
token produced by the CoffeeScript lexer.

[Live demo](http://www.alangpierce.com/decaffeinate-project.org/repl/#?evaluate=true&stage=coffeescript-lexer&code=SomeArr%20%3D%20%5B%20-%3E%0A%20%20if%20something%0A%20%20%20%20lol%20%3D%0A%20%20%20%20%20%20count%3A%207%0A%5D)

Also sneak in a regression test for #356, since I never got to that earlier.