### PR TITLE
fix: handle soaked implicit function calls

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -642,16 +642,23 @@ export default class NodePatcher {
    * a predicate function.
    */
   indexOfSourceTokenBetweenPatchersMatching(left: NodePatcher, right: NodePatcher, predicate: (token: SourceToken) => boolean): ?SourceTokenListIndex {
-    let start = left.outerEnd;
-    let end = right.outerStart;
+    return this.indexOfSourceTokenBetweenSourceIndicesMatching(left.outerEnd, right.outerStart, predicate);
+  }
+
+  /**
+   * Gets the index of the token between source locations that matches a
+   * predicate function.
+   */
+  indexOfSourceTokenBetweenSourceIndicesMatching(left: number, right: number, predicate: (token: SourceToken) => boolean): ?SourceTokenListIndex {
     return this.getProgramSourceTokens().indexOfTokenMatchingPredicate(token => {
       return (
-        token.start >= start &&
-        token.start <= end &&
+        token.start >= left &&
+        token.start <= right &&
         predicate(token)
       );
     });
   }
+
 
   /**
    * Gets the token at a particular index.

--- a/src/stages/normalize/index.js
+++ b/src/stages/normalize/index.js
@@ -37,6 +37,7 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
 
       case 'FunctionApplication':
       case 'NewOp':
+      case 'SoakedFunctionApplication':
         return FunctionApplicationPatcher;
 
       case 'While':

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -299,4 +299,26 @@ describe('function calls', () => {
       g;
     `);
   });
+
+  it('handles soaked implicit function calls', () => {
+    check(`
+      a? b
+    `, `
+      __guardFunc__(a, f => f(b));
+      function __guardFunc__(func, transform) {
+        return typeof func === 'function' ? transform(func) : undefined;
+      }
+    `);
+  });
+
+  it.skip('handles soaked implicit new expressions', () => {
+    check(`
+      new A? b
+    `, `
+      __guardFunc__(A, f => new f(b));
+      function __guardFunc__(func, transform) {
+        return typeof func === 'function' ? transform(func) : undefined;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
This was a matter of changing the normalize stage to included soaked function
calls for `FunctionApplicationPatcher`, then updating the logic to be more
careful about the possibility of a `?` between the function and the args.

Closes #382.