### PR TITLE
fix: don't crash when formatting an error with an invalid range

### DIFF
--- a/src/utils/PatchError.js
+++ b/src/utils/PatchError.js
@@ -76,9 +76,10 @@ export default class PatchError extends Error {
           );
         }
       } else if (line === startLoc.line) {
+        let highlightLength = Math.max(endLoc.column - startLoc.column, 1);
         rows.push(
           [`>`, `${line + 1} |`, lineSource],
-          [``, `|`, repeat(' ', startLoc.column) + repeat('^', endLoc.column - startLoc.column)]
+          [``, `|`, repeat(' ', startLoc.column) + repeat('^', highlightLength)]
         );
       } else {
         rows.push(

--- a/test/utils/PatchError_test.js
+++ b/test/utils/PatchError_test.js
@@ -12,4 +12,14 @@ describe('PatchError', function() {
     `) + '\n';
     strictEqual(PatchError.prettyPrint(error), expected);
   });
+
+  it('does not crash on an out-of-order range', () => {
+    let error = new PatchError('Sample error', 'abcdefg', 4, 2);
+    let expected = stripSharedIndent(`
+      Sample error
+      > 1 | abcdefg
+          |     ^
+    `) + '\n';
+    strictEqual(PatchError.prettyPrint(error), expected);
+  });
 });


### PR DESCRIPTION
Closes #385.