### PR TITLE
fix: improve formatting in IIFE-style while loop expressions

### DIFF
--- a/src/stages/main/patchers/BlockPatcher.js
+++ b/src/stages/main/patchers/BlockPatcher.js
@@ -6,10 +6,12 @@ import { NEWLINE, SEMICOLON } from 'coffee-lex';
 
 export default class BlockPatcher extends NodePatcher {
   statements: Array<NodePatcher>;
+  shouldPatchInline: ?boolean;
 
   constructor(node: Node, context: ParseContext, editor: Editor, statements: Array<NodePatcher>) {
     super(node, context, editor);
     this.statements = statements;
+    this.shouldPatchInline = null;
   }
 
   canPatchAsExpression(): boolean {
@@ -27,6 +29,14 @@ export default class BlockPatcher extends NodePatcher {
 
   setImplicitlyReturns() {
     this.statements[this.statements.length - 1].setImplicitlyReturns();
+  }
+
+  /**
+   * Force the patcher to treat the block as inline (semicolon-separated
+   * statements) or not (newline-separated statements).
+   */
+  setShouldPatchInline(shouldPatchInline: boolean) {
+    this.shouldPatchInline = shouldPatchInline;
   }
 
   patchAsStatement({ leftBrace=true, rightBrace=true }={}) {
@@ -155,6 +165,9 @@ export default class BlockPatcher extends NodePatcher {
    * that contains it) or not.
    */
   inline(): boolean {
+    if (this.shouldPatchInline !== null) {
+      return this.shouldPatchInline;
+    }
     return this.node.inline;
   }
 

--- a/test/while_test.js
+++ b/test/while_test.js
@@ -82,7 +82,13 @@ describe('while', () => {
     check(`
       a(b while c)
     `, `
-      a((() => { let result = []; while (c) { result.push(b); } return result; })());
+      a((() => {
+        let result = [];
+        while (c) {
+          result.push(b);
+        }
+        return result;
+      })());
     `);
   });
 
@@ -90,7 +96,15 @@ describe('while', () => {
     check(`
       a(b while c when d)
     `, `
-      a((() => { let result = []; while (c) { if (d) { result.push(b); } } return result; })());
+      a((() => {
+        let result = [];
+        while (c) {
+          if (d) {
+            result.push(b);
+          }
+        }
+        return result;
+      })());
     `);
   });
 
@@ -104,7 +118,9 @@ describe('while', () => {
             f
       )
     `, `
-      a((() => { let result = []; 
+      a((() => {
+        let result = [];
+        
         while (b) {
           let item;
           if (c) {
@@ -114,7 +130,9 @@ describe('while', () => {
           }
           result.push(item);
 
-        } return result; })());
+        }
+        return result;
+      })());
     `);
   });
 
@@ -129,7 +147,9 @@ describe('while', () => {
               f
       )
     `, `
-      a((() => { let result = []; 
+      a((() => {
+        let result = [];
+        
         while (b) {
           switch (c) {
             case d:
@@ -139,7 +159,9 @@ describe('while', () => {
               result.push(f);
           }
 
-        } return result; })());
+        }
+        return result;
+      })());
     `);
   });
 
@@ -164,9 +186,13 @@ describe('while', () => {
           -> return a
     `, `
       () =>
-        (() => { let result = []; while (true) {
-          result.push(() => a);
-        } return result; })()
+        (() => {
+          let result = [];
+          while (true) {
+            result.push(() => a);
+          }
+          return result;
+        })()
       ;
     `);
   });
@@ -233,9 +259,19 @@ describe('while', () => {
       -> while false
         yield a while true
     `, `
-      (function*() { return yield* (function*() { let result = []; while (false) {
-        result.push(yield* (function*() { let result1 = []; while (true) { result1.push(yield a); } return result1; }).call(this));
-      } return result; }).call(this); });
+      (function*() { return yield* (function*() {
+        let result = [];
+        while (false) {
+          result.push(  yield* (function*() {
+            let result1 = [];
+            while (true) {
+              result1.push(yield a);
+            }
+            return result1;
+          }).call(this));
+        }
+        return result;
+      }).call(this); });
     `);
   });
 
@@ -246,9 +282,19 @@ describe('while', () => {
           yield arguments.length while true
     `, `
       (function*() {
-        return yield* (function*() { let result = []; while (false) {
-          result.push(yield* (function*() { let result1 = []; while (true) { result1.push(yield arguments.length); } return result1; }).apply(this, arguments));
-        } return result; }).apply(this, arguments);
+        return   yield* (function*() {
+          let result = [];
+          while (false) {
+            result.push(  yield* (function*() {
+              let result1 = [];
+              while (true) {
+                result1.push(yield arguments.length);
+              }
+              return result1;
+            }).apply(this, arguments));
+          }
+          return result;
+        }).apply(this, arguments);
       });
     `);
   });
@@ -260,9 +306,19 @@ describe('while', () => {
           yield (-> arguments.length) while true
     `, `
       (function*() {
-        return yield* (function*() { let result = []; while (false) {
-          result.push(yield* (function*() { let result1 = []; while (true) { result1.push(yield (function() { return arguments.length; })); } return result1; }).call(this));
-        } return result; }).call(this);
+        return   yield* (function*() {
+          let result = [];
+          while (false) {
+            result.push(  yield* (function*() {
+              let result1 = [];
+              while (true) {
+                result1.push(yield (function() { return arguments.length; }));
+              }
+              return result1;
+            }).call(this));
+          }
+          return result;
+        }).call(this);
       });
     `);
   });


### PR DESCRIPTION
Progress toward #156.

The existing while loop IIFE code was trying to cram all of the generated code
on one line, which looked kind of bad in longer cases. Since I'm going to be
extending this code to all types of loops soon, I figured it would be good to
improve the formatting first.

The new rule is that if a loop is formatted within an IIFE, we never treat it
as an inline node. To help support this type of case, I added a `setIndent`
method that forces the indentation level to a certain value, which helps ensure
that the generated code is nicely nested regardless of the details of how the
original code was formatted.

Unfortunately, the new indentation caused some excessive whitespace in some
`yield` examples, and there are some cases where newlines in the original
CoffeeScript cause blank lines in the generated JS. But I think those issues are
all relatively minor, and can be fixed later.