### PR TITLE
feat: add support for all for loops used as expressions

### DIFF
--- a/src/stages/main/patchers/LoopPatcher.js
+++ b/src/stages/main/patchers/LoopPatcher.js
@@ -1,0 +1,228 @@
+import NodePatcher from './../../../patchers/NodePatcher.js';
+import traverse from '../../../utils/traverse.js';
+import { isFunction } from '../../../utils/types.js';
+
+export default class LoopPatcher extends NodePatcher {
+  body: BlockPatcher;
+  yielding: boolean;
+
+  constructor(node: Node, context: ParseContext, editor: Editor, body: BlockPatcher) {
+    super(node, context, editor);
+    this.body = body;
+  }
+
+  patchAsExpression() {
+    // We're only patched as an expression due to a parent instructing us to,
+    // and the indent level is more logically the indent level of our parent.
+    let baseIndent = this.parent.getIndent(0);
+    let iifeBodyIndent = this.getLoopIndent();
+    this.body.setShouldPatchInline(false);
+    this.body.setImplicitlyReturns();
+    this.body.setIndent(this.getLoopBodyIndent());
+    let resultBinding = this.getResultArrayBinding();
+    let prefix = !this.yielding ? '(() =>' : 'yield* (function*()';
+    this.insert(this.innerStart, `${prefix} {\n${iifeBodyIndent}${resultBinding} = [];\n${iifeBodyIndent}`);
+    this.patchAsStatement();
+    let suffix = !this.yielding ? '()' : this.referencesArguments() ? '.apply(this, arguments)' : '.call(this)';
+    this.insert(this.innerEnd, `\n${iifeBodyIndent}return ${resultBinding};\n${baseIndent}})${suffix}`);
+  }
+
+  /**
+   * The first of three meaningful indentation levels for where we might want to
+   * insert code.
+   *
+   * As an example, in this code:
+   * a((() => {
+   *   for (let i = 0; i < b.length; i++) {
+   *     let val = b[i];
+   *     if (val) {
+   *       c;
+   *     }
+   *   )
+   * })())
+   *
+   * - `getLoopIndent` returns the indentation of the `for`.
+   * - `getOuterLoopBodyIndent` returns the indentation of the `if`.
+   * - `getLoopBodyIndent` returns the indentation of `c`.
+   *
+   * However, these levels may change based on whether the loop has a condition,
+   * and whether the loop is being formatted as an IIFE or as a regular loop
+   * statement.
+   *
+   * We need to be especially careful about when to actually set the indentation
+   * of existing code, since doing that too much can confuse magic-string. The
+   * only code that actually is adjusted is the loop body (but only when it's
+   * not an inline body), and this is done relatively early on in all cases.
+   */
+  getLoopIndent() {
+    if (this.willPatchAsExpression()) {
+      return this.parent.getIndent(1);
+    } else {
+      return this.getIndent();
+    }
+  }
+
+  /**
+   * @see getLoopIndent.
+   */
+  getOuterLoopBodyIndent() {
+    return this.getLoopIndent() + this.getProgramIndentString();
+  }
+
+  /**
+   * @see getLoopIndent.
+   */
+  getLoopBodyIndent() {
+    throw this.error(`'getLoopBodyIndent' must be overridden in subclasses`);
+  }
+
+  yieldController() {
+    this.yielding = true;
+    this.yields();
+  }
+
+  /**
+   * IIFE-style loop expressions should always be multi-line, even if the loop
+   * body in CoffeeScript is inline. This means we need to use a different
+   * patching strategy where we insert a newline in the proper place before
+   * generating code around the body, then we need to directly create the
+   * indentation just before patching the body.
+   */
+  patchPossibleNewlineAfterLoopHeader(loopHeaderEndIndex: number) {
+    if (this.shouldConvertInlineBodyToNonInline()) {
+      this.overwrite(loopHeaderEndIndex, this.body.contentStart, `\n`);
+    }
+  }
+
+  patchBodyWithPossibleItemVariable() {
+    if (this.shouldConvertInlineBodyToNonInline()) {
+      this.body.insert(this.body.outerStart, this.getLoopBodyIndent());
+    }
+
+    if (this.willPatchAsExpression() && !this.allBodyCodePathsPresent()) {
+      let itemBinding = this.getResultArrayElementBinding();
+      this.body.insertStatementsAtIndex([`var ${itemBinding}`], 0);
+      this.body.patch({ leftBrace: false, rightBrace: false });
+      this.body.insertStatementsAtIndex(
+        [`${this.getResultArrayBinding()}.push(${itemBinding})`],
+        this.body.statements.length
+      );
+    } else {
+      this.body.patch({ leftBrace: false, rightBrace: false });
+    }
+  }
+
+  shouldConvertInlineBodyToNonInline() {
+    return this.willPatchAsExpression() && this.body.node.inline;
+  }
+
+  /**
+   * Most implicit returns cause program flow to break by using a `return`
+   * statement, but we don't do that since we're just collecting values in
+   * an array. This allows descendants who care about this to adjust their
+   * behavior accordingly.
+   */
+  implicitReturnWillBreak(): boolean {
+    if (this.willPatchAsExpression()) {
+      return false;
+    } else {
+      return super.implicitReturnWillBreak();
+    }
+  }
+
+  /**
+   * We decide how statements in implicit return positions are patched, if
+   * we're being used as an expression. This is because we don't want to return
+   * them, but add them to an array.
+   */
+  implicitReturnPatcher(): NodePatcher {
+    if (this.willPatchAsExpression()) {
+      return this;
+    } else {
+      return super.implicitReturnPatcher();
+    }
+  }
+
+  /**
+   * If this loop is used as an expression, then we need to collect all the
+   * values of the statements in implicit-return position. If all the code paths
+   * in our body are present, we can just add `result.push(…)` to all
+   * implicit-return position statements. If not, we want those code paths to
+   * result in adding `undefined` to the resulting array. The way we do that is
+   * by creating an `item` local variable that we set in each code path, and
+   * when the code exits through a missing code path (i.e. `if false then b`)
+   * then `item` will naturally have the value `undefined` which we then push
+   * at the end of the loop body.
+   */
+  patchImplicitReturnStart(patcher: NodePatcher) {
+    patcher.setRequiresExpression();
+    if (this.allBodyCodePathsPresent()) {
+      // `a + b` → `result.push(a + b`
+      //            ^^^^^^^^^^^^
+      this.insert(patcher.outerStart, `${this.getResultArrayBinding()}.push(`);
+    } else {
+      // `a + b` → `item = a + b`
+      //            ^^^^^^^
+      this.insert(patcher.outerStart, `${this.getResultArrayElementBinding()} = `);
+    }
+  }
+
+  /**
+   * @see patchImplicitReturnStart
+   */
+  patchImplicitReturnEnd(patcher: NodePatcher) {
+    if (this.allBodyCodePathsPresent()) {
+      this.insert(patcher.outerEnd, `)`);
+    }
+  }
+
+  allBodyCodePathsPresent(): boolean {
+    if (this._allBodyCodePathsPresent === undefined) {
+      this._allBodyCodePathsPresent = this.body.allCodePathsPresent();
+    }
+    return this._allBodyCodePathsPresent;
+  }
+
+  /**
+   * @private
+   */
+  getResultArrayBinding(): string {
+    if (!this._resultArrayBinding) {
+      this._resultArrayBinding = this.claimFreeBinding('result');
+    }
+    return this._resultArrayBinding;
+  }
+
+  /**
+   * @private
+   */
+  getResultArrayElementBinding(): string {
+    if (!this._resultArrayElementBinding) {
+      this._resultArrayElementBinding = this.claimFreeBinding('item');
+    }
+    return this._resultArrayElementBinding;
+  }
+
+  statementNeedsSemicolon() {
+    return false;
+  }
+
+  /**
+   * @private
+   */
+  referencesArguments() {
+    let result = false;
+
+    traverse(this.node, node => {
+      if (result || isFunction(node)) {
+        return false;
+      }
+
+      if (node.type === 'Identifier' && node.data === 'arguments') {
+        result = true;
+      }
+    });
+
+    return result;
+  }
+}

--- a/test/while_test.js
+++ b/test/while_test.js
@@ -129,8 +129,8 @@ describe('while', () => {
             item = f;
           }
           result.push(item);
-
         }
+
         return result;
       })());
     `);
@@ -158,8 +158,8 @@ describe('while', () => {
             default:
               result.push(f);
           }
-
         }
+
         return result;
       })());
     `);
@@ -241,6 +241,32 @@ describe('while', () => {
     `);
   });
 
+  it('handles a deeply-indented loop body in an expression context', () => {
+    check(`
+      longName(while a when b
+                  if c
+                    d
+                  else if e
+                    f)
+    `, `
+      longName((() => {
+        let result = [];
+        while (a) {
+          if (b) {
+            let item;
+            if (c) {
+              item = d;
+            } else if (e) {
+              item = f;
+            }
+            result.push(item);
+          }
+        }
+        return result;
+      })());
+    `);
+  });
+
   it('causes the condition not to add parentheses even if it normally would', () => {
     check(`
       a = b
@@ -262,7 +288,7 @@ describe('while', () => {
       (function*() { return yield* (function*() {
         let result = [];
         while (false) {
-          result.push(  yield* (function*() {
+          result.push(yield* (function*() {
             let result1 = [];
             while (true) {
               result1.push(yield a);
@@ -282,10 +308,10 @@ describe('while', () => {
           yield arguments.length while true
     `, `
       (function*() {
-        return   yield* (function*() {
+        return yield* (function*() {
           let result = [];
           while (false) {
-            result.push(  yield* (function*() {
+            result.push(yield* (function*() {
               let result1 = [];
               while (true) {
                 result1.push(yield arguments.length);
@@ -306,10 +332,10 @@ describe('while', () => {
           yield (-> arguments.length) while true
     `, `
       (function*() {
-        return   yield* (function*() {
+        return yield* (function*() {
           let result = [];
           while (false) {
-            result.push(  yield* (function*() {
+            result.push(yield* (function*() {
               let result1 = [];
               while (true) {
                 result1.push(yield (function() { return arguments.length; }));


### PR DESCRIPTION
This changes `for` loops used as expressions to use a statement-style loop
within an IIFE, unless we already have a better way to transform the expression.

Conceptually, this was fairly easy since we already do this type of thing for
`while` loops, so it was mostly a matter of pulling that logic into a shared
`LoopPatcher` class. However, getting the formatting right in all cases ended up
being a huge pain, so I ended up reworking how a lot of that stuff works.

There are two main things that I introduced:
* All styles of loops now use common terminology for three indentation levels:
  the top-level loop where the `for` or `while` goes, the first level of the
  loop body, where we often generate an assignment statement, and the "main"
  loop body, which might be indented one more level to be wrapped in a generated
  `if` statement. Various code paths can now reference those logical indentation
  levels.
* To handle the three different cases of prepending a line to the front of a
  block, I added a new `insertLineBefore` method. In particular, this handles
  both the awkward inline-to-non-inline case, and also allows prepending lines
  that are at a lower indentation level than the block itself. A similar `insertLineAfter`
  method also ended up being useful.

One important property of the implementation here is that the only indentation
is in the loop body, and the indentation happens exactly once. I tried lots of
approaches involving indenting twice or indenting two different nodes, and all
of those seemed to confuse magic-string in various edge cases. Fewer operations
is better in this case, it seems.

Closes #156.