### PR TITLE
fix: allow valid inconsistent indentation

### DIFF
--- a/src/stages/normalize/index.js
+++ b/src/stages/normalize/index.js
@@ -1,3 +1,4 @@
+import BlockPatcher from './patchers/BlockPatcher.js';
 import ConditionalPatcher from './patchers/ConditionalPatcher.js';
 import ForInPatcher from './patchers/ForInPatcher.js';
 import ForOfPatcher from './patchers/ForOfPatcher.js';
@@ -21,6 +22,9 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
     switch (node.type) {
       case 'MemberAccessOp':
         return MemberAccessOpPatcher;
+
+      case 'Block':
+        return BlockPatcher;
 
       case 'BoundFunction':
       case 'Function':

--- a/src/stages/normalize/patchers/BlockPatcher.js
+++ b/src/stages/normalize/patchers/BlockPatcher.js
@@ -1,0 +1,66 @@
+import NodePatcher from './../../../patchers/NodePatcher.js';
+import getStartOfLine from './../../../utils/getStartOfLine.js';
+
+import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+
+export default class BlockPatcher extends NodePatcher {
+  statements: Array<NodePatcher>;
+
+  constructor(node: Node, context: ParseContext, editor: Editor, statements: Array<NodePatcher>) {
+    super(node, context, editor);
+    this.statements = statements;
+  }
+
+  patchAsExpression() {
+    this.patchAsStatement();
+  }
+
+  patchAsStatement() {
+    if (this.node.inline) {
+      for (let statement of this.statements) {
+        statement.patch();
+      }
+      return;
+    }
+
+    // Having inconsistent indentation within a block is allowed in some cases
+    // when there are implicit function calls, but when function call parens are
+    // added, the inconsistent indentation can make the CoffeeScript invalid. So
+    // we need to correct any inconsistent indentation in the normalize step so
+    // that the result CoffeeScript will always be valid.
+    let blockIndentLength = null;
+    for (let statement of this.statements) {
+      let indentLength = this.getIndentLength(statement);
+      if (indentLength !== null) {
+        if (blockIndentLength === null) {
+          blockIndentLength = indentLength;
+        } else {
+          let charsToRemove = indentLength - blockIndentLength;
+          if (charsToRemove < 0) {
+            throw this.error(
+              'Unexpected statement at an earlier indentation level than an ' +
+              'earlier statement in the block.');
+          }
+          if (charsToRemove > 0) {
+            this.remove(statement.outerStart - charsToRemove, statement.outerStart);
+          }
+        }
+      }
+      statement.patch();
+    }
+  }
+
+  /**
+   * If this statement starts immediately after its line's initial indentation,
+   * return the length of that indentation. Otherwise, return null.
+   */
+  getIndentLength(statement) {
+    let startOfLine = getStartOfLine(this.context.source, statement.outerStart);
+    let indentText = this.context.source.slice(startOfLine, statement.outerStart);
+    if (/^[ \t]*$/.test(indentText)) {
+      return indentText.length;
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/utils/getIndent.js
+++ b/src/utils/getIndent.js
@@ -1,4 +1,5 @@
 /* @flow */
+import getStartOfLine from './getStartOfLine.js';
 
 /**
  * Gets the indent string for the line containing offset.
@@ -23,23 +24,4 @@ export default function getIndent(source: string, offset: number): string {
   }
 
   return source.slice(startOfLine, indentOffset);
-}
-
-/**
- * Finds the start of the line for the character at offset.
- */
-function getStartOfLine(source: string, offset: number): number {
-  let lfIndex = source.lastIndexOf('\n', offset - 1);
-
-  if (lfIndex < 0) {
-    let crIndex = source.lastIndexOf('\r', offset - 1);
-
-    if (crIndex < 0) {
-      return 0;
-    }
-
-    return crIndex + 1;
-  }
-
-  return lfIndex + 1;
 }

--- a/src/utils/getStartOfLine.js
+++ b/src/utils/getStartOfLine.js
@@ -1,0 +1,20 @@
+/* @flow */
+
+/**
+ * Finds the start of the line for the character at offset.
+ */
+export default function getStartOfLine(source: string, offset: number): number {
+  let lfIndex = source.lastIndexOf('\n', offset - 1);
+
+  if (lfIndex < 0) {
+    let crIndex = source.lastIndexOf('\r', offset - 1);
+
+    if (crIndex < 0) {
+      return 0;
+    }
+
+    return crIndex + 1;
+  }
+
+  return lfIndex + 1;
+}

--- a/test/indentation_test.js
+++ b/test/indentation_test.js
@@ -20,4 +20,36 @@ describe('indentation', () => {
   it.skip('matches indentation when adding standalone lines', () => {
     check(`if a\n\tswitch b\n\t\twhen c\n\t\t\td`, `if (a) {\n\tswitch (b) {\n\t\tcase c:\n\t\t\td;\n\t\t\tbreak;\n\t}\n}`);
   });
+
+  it('handles valid inconsistent indentation', () => {
+    check(`
+      a ->
+        return
+       b
+    `, `
+      a(function() {
+        
+      });
+      b;
+    `);
+  });
+
+  it('handles deeply nested inconsistent indentation', () => {
+    check(`
+      ->
+        a
+          .b =>
+            return
+          return 3
+    `, `
+      (function() {
+        a
+          .b(() => {
+            
+          }
+        );
+        return 3;
+      });
+    `);
+  });
 });


### PR DESCRIPTION
The paren-adding step of NormalizeStage can sometimes create invalid
CoffeeScript because CoffeeScript is more strict about indentation in some cases
than others. This adds a step to NormalizeStage that ensures that all statements
within blocks have the same indentation level, which should avoid this error.

Closes #394.