### PR TITLE
fix: show context information for coffeescript parse errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import formatCoffeeScriptLexerTokens from './utils/formatCoffeeScriptLexerTokens
 import formatDecaffeinateParserAst from './utils/formatDecaffeinateParserAst.js';
 import parse from './utils/parse.js';
 import PatchError from './utils/PatchError.js';
+import resolveToPatchError from './utils/resolveToPatchError.js';
 
 export { default as run } from './cli';
 export { PatchError };
@@ -72,17 +73,9 @@ function runStage(stage: Stage, content: string, filename: string): { code: stri
   try {
     return stage.run(content, filename);
   } catch (err) {
-    if (err instanceof SyntaxError) {
-      let { pos } = err;
-      if (pos === content.length) {
-        pos--;
-      }
-      throw new PatchError(
-        `${stage.name} failed to parse: ${err.message}`,
-        content,
-        pos,
-        pos + 1
-      );
+    let patchError = resolveToPatchError(err, content, stage.name);
+    if (patchError !== null) {
+      throw patchError;
     }
     throw err;
   }

--- a/src/utils/resolveToPatchError.js
+++ b/src/utils/resolveToPatchError.js
@@ -1,0 +1,36 @@
+/* @flow */
+import LinesAndColumns from 'lines-and-columns';
+import PatchError from './PatchError.js';
+
+/**
+ * If the given exception is an error with code location information, extract
+ * its start and end position and return a PatchError to use in its place.
+ * Otherwise, return null.
+ */
+export default function resolveToPatchError(err: any, content: string , stageName: string): ?PatchError {
+  let makePatchError = (start, end) => new PatchError(
+    `${stageName} failed to parse: ${err.message}`,
+    content,
+    start,
+    end
+  );
+
+  if (err.pos) {
+    // Handle JavaScript parse errors.
+    let { pos } = err;
+    if (pos === content.length) {
+      pos--;
+    }
+    return makePatchError(pos, pos + 1);
+  } else if (err.syntaxError) {
+    // Handle CoffeeScript parse errors.
+    let { first_line, first_column, last_line, last_column } = err.syntaxError.location;
+    let lineMap = new LinesAndColumns(content);
+    let firstIndex = lineMap.indexForLocation({line: first_line, column: first_column});
+    let lastIndex = lineMap.indexForLocation({line: last_line, column: last_column}) + 1;
+    if (firstIndex !== null && firstIndex !== undefined && lastIndex !== null && lastIndex !== undefined) {
+      return makePatchError(firstIndex, lastIndex);
+    }
+  }
+  return null;
+}

--- a/test/utils/resolveToPatchError_test.js
+++ b/test/utils/resolveToPatchError_test.js
@@ -1,0 +1,51 @@
+import addVariableDeclarations from 'add-variable-declarations';
+import { strictEqual } from 'assert';
+import MagicString from 'magic-string';
+import parse from '../../src/utils/parse.js';
+import PatchError from '../../src/utils/PatchError.js';
+import resolveToPatchError from '../../src/utils/resolveToPatchError.js';
+import stripSharedIndent from '../../src/utils/stripSharedIndent.js';
+
+describe('resolveToPatchError', () => {
+  it('handles syntax errors in JavaScript code', () => {
+    let content = stripSharedIndent(`
+        let x = 3;
+        f())
+        console.log('test');`);
+    try {
+      addVariableDeclarations(content, new MagicString(content));
+    } catch (e) {
+      let patchError = resolveToPatchError(e, content, 'testStage');
+      strictEqual(PatchError.prettyPrint(patchError), stripSharedIndent(`
+        testStage failed to parse: Unexpected token (2:3)
+          1 | let x = 3;
+        > 2 | f())
+            |    ^
+          3 | console.log('test');`) + '\n');
+    }
+  });
+
+  it('handles syntax errors in CoffeeScript code', () => {
+    let content = stripSharedIndent(`
+        x = 3
+          f()
+        console.log 'test'`);
+    try {
+      parse(content);
+    } catch (e) {
+      let patchError = resolveToPatchError(e, content, 'testStage');
+      strictEqual(PatchError.prettyPrint(patchError), stripSharedIndent(`
+        testStage failed to parse: unexpected indentation
+          1 | x = 3
+        > 2 |   f()
+            | ^^
+          3 | console.log 'test'`) + '\n');
+    }
+  });
+
+  it('returns null for other errors', () => {
+    let patchError = resolveToPatchError(
+      new Error('a normal error'), 'test content', 'test stage name');
+    strictEqual(patchError, null);
+  });
+});


### PR DESCRIPTION
Fixes #413.

This is particularly useful for cases where the NormalizeStage generates invalid
code, but also helps for actual invalid CoffeeScript.

Since we handle two kinds of errors, I moved that code into a separate tested
area where we can add additional error conversion as it comes up.

Demo: http://www.alangpierce.com/decaffeinate-project.org/repl/#?evaluate=true&stage=full&code=%7B%0A%20%20a%3A%20-%3E%0A%20%20%20%20return%20b%20c%2C%0A%20%20%20%20%20%20d%20e%2C%0A%20%20%20%20%20%20%20%20f%0A%20%20%20%20%20%20g%20h%2C%20i%2C%0A%7D