### PR TITLE
fix: don't add incorrect parens for new expressions

### DIFF
--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -172,10 +172,6 @@ describe('function calls', () => {
     check(`new Foo 1`, `new Foo(1);`);
   });
 
-  it('adds parens for a new expression without args', () => {
-    check(`new Foo`, `new Foo();`);
-  });
-
   it('adds parens after the properties of a member expression', () => {
     check(`a.b c`, `a.b(c);`);
   });

--- a/test/new_op_test.js
+++ b/test/new_op_test.js
@@ -23,11 +23,19 @@ describe('`new` operator', () => {
     `);
   });
 
-  it('inserts missing parentheses in a call with no arguments', () => {
+  it('leaves missing parentheses off in a call with no arguments', () => {
     check(`
       new Object
     `, `
-      new Object();
+      new Object;
+    `);
+  });
+
+  it('does not add parentheses in complicated `new` expressions where it would be incorrect', () => {
+    check(`
+      new A().B
+    `, `
+      new A().B;
     `);
   });
 


### PR DESCRIPTION
Fixes #391.

The expression `new A().B` was being parsed as `new (A().B)`, so decaffeinate
was treating it as a parens-less constructor invocation and adding parens. In
reality, the behavior in both JavaScript and CoffeeScript is `(new A()).B`, so
it's incorrect to add parentheses.

Unfortunately, it looks like the underlying cause here is a CoffeeScript parser
bug. It seems to parse it as `new (A().B)` ([repl](http://decaffeinate-project.org/repl/#?evaluate=true&stage=coffeescript-parser&code=new%20A().B)),
so decaffeinate sees zero arguments and no parens and assumes that the extra
parens are necessary.

To fix, I just removed the paren-adding from decaffeinate on constructor
invocations with no args. It's still correct in JavaScript to call a
constructor without parens, so the generated code should be correct, even if
it's discouraged by some style guides.

Fortunately, eslint has a rule for this with an auto-fixer:
http://eslint.org/docs/rules/new-parens

So I think for practical purposes, anyone who cares about the parens can run
`eslint --fix`. (It's also run automatically by bulk-decaffeinate.)