### PR TITLE
fix: allow a space in logical OR assignments

### DIFF
--- a/src/stages/main/patchers/LogicalOpCompoundAssignOpPatcher.js
+++ b/src/stages/main/patchers/LogicalOpCompoundAssignOpPatcher.js
@@ -57,7 +57,10 @@ export default class LogicalOpCompoundAssignOpPatcher extends CompoundAssignOpPa
   isOrOp(): boolean {
     let operator = this.getOperatorToken();
     let op = this.sourceOfToken(operator);
-    return op === '||=' || op === 'or=';
+    // There could be a space in the middle of the operator, like `or =` or
+    // `|| =`, and "op" will just be the first token in that case. So just check
+    // the start of the operator.
+    return op.substr(0, 2) === '||' || op.substr(0, 2) === 'or';
   }
 
   /**

--- a/test/compound_assignment_test.js
+++ b/test/compound_assignment_test.js
@@ -251,6 +251,14 @@ describe('compound assignment', () => {
       `);
     });
 
+    it('supports logical OR containing a space', () => {
+      check(`
+        a or = b
+      `, `
+        if (!a) { var a = b; }
+      `);
+    });
+
     it('supports LHS identifiers in logical AND', () => {
       check(`
         a &&= b


### PR DESCRIPTION
Closes #423.

CoffeeScript allows things like `or =` and `|| =` and treats them as compound
assignments (even though in general it doesn't allow spaces in operators; for
example, `? =` is NOT a valid assignment operator). Our check wasn't handling
that case, so `isOrOp` was returning `false` and the assignment was being
treated as a logical AND. To fix, I just looked at the start of the operator
rather than the whole operator.