### PR TITLE
fix: allow parameter property assignments with defaults

### DIFF
--- a/src/stages/normalize/patchers/DefaultParamPatcher.js
+++ b/src/stages/normalize/patchers/DefaultParamPatcher.js
@@ -1,3 +1,12 @@
 import PassthroughPatcher from '../../../patchers/PassthroughPatcher.js';
 
-export default class DefaultParamPatcher extends PassthroughPatcher {}
+export default class DefaultParamPatcher extends PassthroughPatcher {
+  param: NodePatcher;
+  value: NodePatcher;
+
+  constructor(node: Node, context: ParseContext, editor: Editor, param: NodePatcher, value: NodePatcher) {
+    super(node, context, editor, param, value);
+    this.param = param;
+    this.value = value;
+  }
+}

--- a/src/stages/normalize/patchers/MemberAccessOpPatcher.js
+++ b/src/stages/normalize/patchers/MemberAccessOpPatcher.js
@@ -16,11 +16,19 @@ export default class MemberAccessOpPatcher extends PassthroughPatcher {
   }
 
   findAddStatementCallback() {
-    let patcher = this.parent;
-    // if we traverse up through DefaultParam, we're on the right hand side
-    while (patcher && !(patcher instanceof DefaultParamPatcher)) {
-      if (patcher.addStatementAtScopeHeader) return patcher.addStatementAtScopeHeader;
+    let patcher = this;
+
+    while (patcher) {
+      if (patcher.addStatementAtScopeHeader) {
+        return patcher.addStatementAtScopeHeader;
+      }
+      // Don't traverse up the right side of default params.
+      if (patcher.parent instanceof DefaultParamPatcher &&
+          patcher.parent.value === patcher) {
+        break;
+      }
       patcher = patcher.parent;
     }
+    return null;
   }
 }

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -53,7 +53,7 @@ describe('classes', () => {
       ;
     `);
   });
-  it('preservces class body generator functions as generator method definitions', () => {
+  it('preserves class body generator functions as generator method definitions', () => {
     check(`
       class A
         'a a': ->
@@ -186,6 +186,16 @@ describe('classes', () => {
         class A {
           member(a) { this.a = a; return console.log(this.a); }
         }
+      `);
+    });
+
+    it('handles property assignment parameter with default', () => {
+      check(`
+        (@a = 1) ->
+      `, `
+        (function(a = 1) {
+          this.a = a;
+        });
       `);
     });
 


### PR DESCRIPTION
Fixes #232.

The code for handling `@` in params already had a check to make sure it doesn't
traverse up the right side of a default param assignment (otherwise `(a = @b) ->`
would get converted incorrectly), but it also skipped the valid case where we
traversed up the left side. To fix, I just needed to see which of the parent's
children the current patcher is when traversing up.