### PR TITLE
fix: handle `unless` with binary operator conditions

### DIFF
--- a/src/stages/main/patchers/AssignOpPatcher.js
+++ b/src/stages/main/patchers/AssignOpPatcher.js
@@ -18,6 +18,15 @@ export default class AssignOpPatcher extends NodePatcher {
     this.expression.setRequiresExpression();
   }
 
+  /**
+   * Assignment operators have lower precedence than negation, so we need to add
+   * parens.
+   */
+  negate() {
+    this.insert(this.innerStart, '!(');
+    this.insert(this.innerEnd, ')');
+  }
+
   patchAsExpression() {
     if (this.isExpansionAssignment()) {
       this.patchExpansionAssignment();

--- a/src/stages/main/patchers/BinaryOpPatcher.js
+++ b/src/stages/main/patchers/BinaryOpPatcher.js
@@ -18,6 +18,15 @@ export default class BinaryOpPatcher extends NodePatcher {
   }
 
   /**
+   * Binary operators have lower precedence than negation, so we need to add
+   * parens.
+   */
+  negate() {
+    this.insert(this.innerStart, '!(');
+    this.insert(this.innerEnd, ')');
+  }
+
+  /**
    * LEFT OP RIGHT
    */
   patchAsExpression({ needsParens=false }={}) {

--- a/src/stages/main/patchers/NegatableBinaryOpPatcher.js
+++ b/src/stages/main/patchers/NegatableBinaryOpPatcher.js
@@ -26,40 +26,25 @@ export default class NegatableBinaryOpPatcher extends BinaryOpPatcher {
    */
   patchAsExpression() {
     let { negated } = this;
-    let needsParens = negated && !this.isSurroundedByParentheses();
-
     if (negated) {
-      // `a not instanceof b` → `!a not instanceof b`
-      //                         ^
-      this.insert(this.outerStart, '!');
-    }
-
-    if (needsParens) {
-      // `!a not instanceof b` → `!(a not instanceof b`
-      //                           ^
-      this.insert(this.contentStart, '(');
+      // `a not instanceof b` → `!(a not instanceof b`
+      //                         ^^
+      this.insert(this.innerStart, '!(');
     }
 
     // Patch LEFT and RIGHT.
     super.patchAsExpression();
 
-    if (needsParens) {
+    if (negated) {
       // `!(a not instanceof b` → `!(a not instanceof b)`
       //                                               ^
-      this.insert(this.contentEnd, ')');
+      this.insert(this.innerEnd, ')');
     }
 
     // `!(a not instanceof b)` → `!(a instanceof b)`
     //      ^^^^^^^^^^^^^^            ^^^^^^^^^^
     let token = this.getOperatorToken();
     this.overwrite(token.start, token.end, this.javaScriptOperator());
-  }
-
-  /**
-   * This is here so we can add the `!` outside any existing parens.
-   */
-  allowPatchingOuterBounds(): boolean {
-    return true;
   }
 
   /**

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -77,6 +77,52 @@ describe('conditionals', () => {
     `);
   });
 
+  it('adds parentheses when `unless` is used with an assignment', () => {
+    check(`
+      unless a = b
+        c
+    `, `
+      let a;
+      if (!(a = b)) {
+        c;
+      }
+    `);
+  });
+
+  it('keeps parentheses when `unless` is used with an assignment', () => {
+    check(`
+      unless (a = b)
+        c
+    `, `
+      let a;
+      if (!(a = b)) {
+        c;
+      }
+    `);
+  });
+
+  it('adds parentheses when `unless` is used with a normal binary operator', () => {
+    check(`
+      unless a + b
+        c
+    `, `
+      if (!(a + b)) {
+        c;
+      }
+    `);
+  });
+
+  it('keeps parentheses when `unless` is used with a normal binary operator', () => {
+    check(`
+      unless (a + b)
+        c
+    `, `
+      if (!(a + b)) {
+        c;
+      }
+    `);
+  });
+
   it('handles indented `if` statements correctly', () => {
     check(`
       if a

--- a/test/instanceof_test.js
+++ b/test/instanceof_test.js
@@ -13,8 +13,10 @@ describe('instanceof', () => {
     check(`a not instanceof b`, `!(a instanceof b);`);
   });
 
-  it('does not add parentheses if they are already there', () => {
-    check(`(a not instanceof b)`, `!(a instanceof b);`);
+  // Ideally we wouldn't have redundant parens here, but it makes the
+  // implementation simpler.
+  it('handles negated `instanceof` when there are already parens', () => {
+    check(`(a not instanceof b)`, `(!(a instanceof b));`);
   });
 
   it('works with double-negated `instanceof`', () => {
@@ -23,6 +25,17 @@ describe('instanceof', () => {
         c
     `, `
       if (a instanceof b) {
+        c;
+      }
+    `);
+  });
+
+  it('works with instanceof that already has parens', () => {
+    check(`
+      if (a not instanceof b)
+        c
+    `, `
+      if (!(a instanceof b)) {
         c;
       }
     `);


### PR DESCRIPTION
Closes #434.

For many binary operators (including assignment operators), the previous behavior
of just prepending `!` for negation wasn't correct; we need to add parens in
some cases. For simplicity, I made it so we add parens in ALL cases, even if
parens already exist. I also made it add the `!` at `innerStart` rather than
`outerStart`, since otherwise I was seeing some cases like `if !(a = b)` in the
generated JS, which doesn't work. In general, it seems safest to avoid writing
code outside an expression's enclosing parens as much as possible.

I also fixed a related issue in `NegatableBinaryOpPatcher`.

Since the [no-extra-parens](http://eslint.org/docs/rules/no-extra-parens) eslint
rule has an auto-fixer, it's probably reasonable to care a bit less about
generating unnecessary parens and focus more on correctness and implementation
simplicity, and even after this commit, the cases with extra parens are
relatively rare.