### PR TITLE
fix: don't double-patch the right side of a compound logical assignment

### DIFF
--- a/src/stages/main/patchers/LogicalOpCompoundAssignOpPatcher.js
+++ b/src/stages/main/patchers/LogicalOpCompoundAssignOpPatcher.js
@@ -44,8 +44,6 @@ export default class LogicalOpCompoundAssignOpPatcher extends CompoundAssignOpPa
     
     this.expression.patch();
 
-    this.expression.patch();
-
     // `if (a) { a = b` → `if (a) { a = b }`
     //                                   ^^
     this.insert(this.expression.outerEnd, ' }');

--- a/test/compound_assignment_test.js
+++ b/test/compound_assignment_test.js
@@ -468,5 +468,13 @@ describe('compound assignment', () => {
         if (!this.a) { this.a = 0; }
       `);
     });
+
+    it('handles logical operators with a function on the right side', () => {
+      check(`
+        a or= -> b
+      `, `
+        if (!a) { var a = () => b; }
+      `);
+    });
   });
 });


### PR DESCRIPTION
Closes #439.

Looks like this was just added by mistake at one point, and in simple cases it
doesn't matter, but when patching functions it was causing strange results.