### PR TITLE
fix: correctly handle destructure parameters with property assignments

### DIFF
--- a/src/stages/normalize/index.js
+++ b/src/stages/normalize/index.js
@@ -4,6 +4,7 @@ import ForInPatcher from './patchers/ForInPatcher.js';
 import ForOfPatcher from './patchers/ForOfPatcher.js';
 import FunctionApplicationPatcher from './patchers/FunctionApplicationPatcher.js';
 import NodePatcher from '../../patchers/NodePatcher.js';
+import ObjectInitialiserMemberPatcher from './patchers/ObjectInitialiserMemberPatcher.js';
 import PassthroughPatcher from '../../patchers/PassthroughPatcher.js';
 import ProgramPatcher from './patchers/ProgramPatcher.js';
 import TransformCoffeeScriptStage from '../TransformCoffeeScriptStage.js';
@@ -52,6 +53,9 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
 
       case 'DefaultParam':
         return DefaultParamPatcher;
+
+      case 'ObjectInitialiserMember':
+        return ObjectInitialiserMemberPatcher;
       
       default:
         return PassthroughPatcher;

--- a/src/stages/normalize/patchers/MemberAccessOpPatcher.js
+++ b/src/stages/normalize/patchers/MemberAccessOpPatcher.js
@@ -1,5 +1,6 @@
 import PassthroughPatcher from '../../../patchers/PassthroughPatcher.js';
 import DefaultParamPatcher from './DefaultParamPatcher.js';
+import ObjectInitialiserMemberPatcher from './ObjectInitialiserMemberPatcher.js';
 
 export default class MemberAccessOpPatcher extends PassthroughPatcher {
   shouldTrimContentRange() {
@@ -22,9 +23,15 @@ export default class MemberAccessOpPatcher extends PassthroughPatcher {
       if (patcher.addStatementAtScopeHeader) {
         return patcher.addStatementAtScopeHeader;
       }
-      // Don't traverse up the right side of default params.
+      // Don't consider this node if we're on the right side of a default param
+      // (e.g. `(foo = @bar) ->`) or if we're on the left side of an object
+      // destructure (e.g. the logical `a` key in `({@a}) ->`).
       if (patcher.parent instanceof DefaultParamPatcher &&
           patcher.parent.value === patcher) {
+        break;
+      }
+      if (patcher.parent instanceof ObjectInitialiserMemberPatcher &&
+          patcher.parent.key === patcher) {
         break;
       }
       patcher = patcher.parent;

--- a/src/stages/normalize/patchers/ObjectInitialiserMemberPatcher.js
+++ b/src/stages/normalize/patchers/ObjectInitialiserMemberPatcher.js
@@ -1,0 +1,12 @@
+import PassthroughPatcher from '../../../patchers/PassthroughPatcher.js';
+
+export default class ObjectInitialiserMemberPatcher extends PassthroughPatcher {
+  key: NodePatcher;
+  expression: NodePatcher;
+
+  constructor(node: Node, context: ParseContext, editor: Editor, key: NodePatcher, expression: NodePatcher) {
+    super(node, context, editor, key, expression);
+    this.key = key;
+    this.expression = expression;
+  }
+}

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -199,6 +199,26 @@ describe('classes', () => {
       `);
     });
 
+    it('handles destructured property assignment parameters', () => {
+      check(`
+        ({@a}) ->
+      `, `
+        (function({a}) {
+          this.a = a;
+        });
+      `);
+    });
+
+    it('handles named destructured property assignment parameters', () => {
+      check(`
+        ({a: @b}) ->
+      `, `
+        (function({a: b}) {
+          this.b = b;
+        });
+      `);
+    });
+
     it('uses correct value for default param when using another member', () => {
       check(`
         (@a, b = @c) ->


### PR DESCRIPTION
Closes #213.

In a case like `{@a}`, the decaffeinate-parser AST uses the same node for the
key and the value, so while searching for this-assignment nodes we were seeing
`@a` twice (even though conceptually it might be better represented as `{a: @a}`
in the AST, but that causes problems elsewhere). This meant we were adding two
assignment statements when we should have been adding one. There was already a
mechanism to ignore some nodes in parameter bodies (used to ignore usages of `@`
within parameter defaults), so this issue can be fixed by just ignoring object
keys, which always just say the name of the field to be extracted rather than
having any effect on the assignments that are done.