### PR TITLE
test: enable a test that was disabled waiting on another PR to land

### DIFF
--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -281,8 +281,7 @@ describe('conditionals', () => {
     `);
   });
 
-  // TODO: Enable once https://github.com/Rich-Harris/magic-string/pull/89 lands.
-  it.skip('works with nested POST-`if` with implicit calls', () => {
+  it('works with nested POST-`if` with implicit calls', () => {
     check(`
       a b if c d unless e f
     `, `


### PR DESCRIPTION
Now that magic-string has been updated, the test works.