### PR TITLE
fix: give a more clear error message on complex conditionals

### DIFF
--- a/src/stages/main/patchers/ConditionalPatcher.js
+++ b/src/stages/main/patchers/ConditionalPatcher.js
@@ -47,7 +47,8 @@ export default class ConditionalPatcher extends NodePatcher {
     return (
       this.prefersToPatchAsExpression() || (
         this.forcedToPatchAsExpression() &&
-        this.consequent.prefersToPatchAsExpression()
+        this.consequent.prefersToPatchAsExpression() &&
+        (!this.alternate || this.alternate.prefersToPatchAsExpression())
       )
     );
   }
@@ -110,9 +111,11 @@ export default class ConditionalPatcher extends NodePatcher {
       // `undefined`, which is ugly (i.e. `if a then b` → `a ? b : undefined`).
       // TODO: Generate a `do` expression instead? (i.e. `do { if (a) { b; } }`)
       this.patchAsExpression();
+    } else if (this.willPatchAsIIFE()) {
+      throw new Error(
+        'Complex conditionals (ones requiring an IIFE) are not supported yet. ' +
+        'See https://github.com/decaffeinate/decaffeinate/issues/388');
     }
-
-    // TODO: IIFE
   }
 
   patchAsStatement() {


### PR DESCRIPTION
Previously, we would just skip patching IIFE-style conditionals, causing a
confusing error later, but now we give a helpful message pointing at a bug.

I also made it so we require both the consequent and the alternate (if present)
to be patchable as an expression before we say that the condition can be a
ternary; otherwise, it was hitting a more opaque error in some cases.