### PR TITLE
feat: implement IIFE-style conditionals

### DIFF
--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -352,4 +352,60 @@ describe('conditionals', () => {
       }
     `)
   );
+
+  it('creates an IIFE when a complicated condition is used in an expression context', () =>
+    check(`
+      a = if b
+          c
+        else if d
+          e
+    `, `
+      let a = (() => {
+        if (b) {
+          return c;
+        } else if (d) {
+          return e;
+        }
+      })();
+    `)
+  );
+
+  it('creates a properly-formatted IIFE for nested `if`s in a function body', () =>
+    check(`
+      a(if b
+          if c
+            null)
+    `, `
+      a((() => {
+        if (b) {
+          if (c) {
+            return null;
+          }
+        }
+      })());
+    `)
+  );
+
+  it('creates a properly-formatted IIFE with the `if` on the next line', () =>
+    check(`
+      c =
+        if a
+          x = 0
+          x = x + 1 if b
+          x
+        else
+          1
+    `, `
+      let c =
+        (() => {
+        if (a) {
+          let x = 0;
+          if (b) { x = x + 1; }
+          return x;
+        } else {
+          return 1;
+        }
+      })();
+    `)
+  );
 });


### PR DESCRIPTION
Closes #388.

When an `if` expression is complicated enough, we can't reasonable turn it into
a ternary; it's cleaner (and sometimes necessary) to use an IIFE instead.
We already have IIFE code working for loops, so this borrows most of the
implementation details from that.

I didn't focus as much on formatting as for the loop case, so it's certainly
possible that there are some situations where the indentation looks wrong, but
in the few examples I tried it looks pretty good. If there are formatting
problems, those can be fixed as lower-priority follow-up issues.

I also made it so we require both the consequent and the alternate (if present)
to be patchable as an expression before we say that the condition can be a
ternary; otherwise we would sometimes attempt a ternary patch that would then
fail.