### PR TITLE
fix: correctly pass `this` in soaked function applications

### DIFF
--- a/src/stages/main/patchers/MemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/MemberAccessOpPatcher.js
@@ -4,14 +4,20 @@ import { AT, DOT, IDENTIFIER, PROTO } from 'coffee-lex';
 
 export default class MemberAccessOpPatcher extends NodePatcher {
   expression: NodePatcher;
+  _skipImplicitDotCreation: boolean;
 
   constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher) {
     super(node, context, editor);
     this.expression = expression;
+    this._skipImplicitDotCreation = false;
   }
 
   initialize() {
     this.expression.setRequiresExpression();
+  }
+
+  setSkipImplicitDotCreation() {
+    this._skipImplicitDotCreation = true;
   }
 
   patchAsExpression() {
@@ -22,7 +28,7 @@ export default class MemberAccessOpPatcher extends NodePatcher {
       let operator = this.getMemberOperatorSourceToken();
       this.overwrite(operator.start, operator.end, '.prototype');
     }
-    if (this.hasImplicitOperator()) {
+    if (this.hasImplicitOperator() && !this._skipImplicitDotCreation) {
       // `@a` → `@.a`
       //          ^
       this.insert(this.expression.outerEnd, '.');

--- a/src/stages/main/patchers/SoakedDynamicMemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/SoakedDynamicMemberAccessOpPatcher.js
@@ -7,15 +7,28 @@ const GUARD_HELPER =
 }`;
 
 export default class SoakedDynamicMemberAccessOpPatcher extends DynamicMemberAccessOpPatcher {
+  _shouldSkipSoakPatch: boolean;
+
+  constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher, indexingExpr: NodePatcher) {
+    super(node, context, editor, expression, indexingExpr);
+    this._shouldSkipSoakPatch = false;
+  }
+
   patchAsExpression() {
-    this.registerHelper('__guard__', GUARD_HELPER);
-    let soakContainer = findSoakContainer(this);
-    let varName = soakContainer.claimFreeBinding('x');
-    this.overwrite(this.expression.outerEnd, this.indexingExpr.outerStart, `, ${varName} => ${varName}[`);
-    soakContainer.insert(soakContainer.contentStart, '__guard__(');
-    soakContainer.insert(soakContainer.contentEnd, ')');
+    if (!this._shouldSkipSoakPatch) {
+      this.registerHelper('__guard__', GUARD_HELPER);
+      let soakContainer = findSoakContainer(this);
+      let varName = soakContainer.claimFreeBinding('x');
+      this.overwrite(this.expression.outerEnd, this.indexingExpr.outerStart, `, ${varName} => ${varName}[`);
+      soakContainer.insert(soakContainer.contentStart, '__guard__(');
+      soakContainer.insert(soakContainer.contentEnd, ')');
+    }
 
     this.expression.patch();
     this.indexingExpr.patch();
+  }
+
+  setShouldSkipSoakPatch() {
+    this._shouldSkipSoakPatch = true;
   }
 }


### PR DESCRIPTION
Closes #462.

This fixes the JS output for code like `a().b?()` and `a()[b()]?()`, where the
`this` value needs to be set properly for the function call. The solution is
among the same lines as `__guard__`/`__guardFunc__`, but even uglier. Rather
than using a function to eager-evaluate the base and optionally call a lambda,
we eagerly evaluate both the object and the method name and then optionally pass
both into the lambda. There were also some details in handling cases like
`@a?()`, `a?.b?()`, and `a?.b.c?()`.

As before, this (mostly) handles the crazy cases, and #336 is the task for making
the output nicer in the non-crazy cases. In the meantime, I always just manually
fix up the generated JS code to never use `__guard__`-type things.

One decision I made is that I treat `a.b?()` as `a?.b?()`, which means generated
code could potentially succeed when it would crash in CoffeeScript. It seems
like this likely wouldn't be a problem in practice, and makes it possible to do
chained soaked operations without things needing to get much more complex.

This change also doesn't handle soaked prototype accesses like `a::?b` and
`a::b?()`, but those weren't working before anyway and seem especially obscure.
It should be reasonable to implement them in the future if necessary, I think.