### PR TITLE
fix: improve formatting when a function is the last argument to a function

### DIFF
--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -353,8 +353,7 @@ describe('function calls', () => {
       
         somefunc('something', ['something', function(ContactService) {}
       
-        ])
-      );
+        ]));
     `);
   });
 

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -193,4 +193,28 @@ describe('functions', () => {
       () => ({a: b, c: d});
     `)
   );
+
+  it('properly closes a function as the only argument to a function', () =>
+    check(`
+      it ->
+        a
+        return
+    `, `
+      it(function() {
+        a;
+      });
+    `)
+  );
+
+  it('properly closes a function as the second argument to a function', () =>
+    check(`
+      it a, ->
+        b
+        return
+    `, `
+      it(a, function() {
+        b;
+      });
+    `)
+  );
 });


### PR DESCRIPTION
Closes #451.

There was already a special case that when a function expression is surrounded
by parens, the `}` is placed immediately before the close-paren. This also
worked for single-argument function invocations, but in a multi-argument
function invocation, neither argument is considered to be surrounded by parens,
so it wasn't doing anything smart. To fix, I added a new special case: if a
function expression is the last argument to a function, place the `}` just
before the CALL_END token.