### PR TITLE
feat: allow code within class bodies

### DIFF
--- a/src/stages/normalize/index.js
+++ b/src/stages/normalize/index.js
@@ -1,4 +1,6 @@
 import BlockPatcher from './patchers/BlockPatcher.js';
+import ClassPatcher from './patchers/ClassPatcher.js';
+import AssignOpPatcher from './patchers/AssignOpPatcher.js';
 import ConditionalPatcher from './patchers/ConditionalPatcher.js';
 import ForInPatcher from './patchers/ForInPatcher.js';
 import ForOfPatcher from './patchers/ForOfPatcher.js';
@@ -47,6 +49,13 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
 
       case 'While':
         return WhilePatcher;
+
+      case 'Class':
+        return ClassPatcher;
+
+      case 'AssignOp':
+      case 'ClassProtoAssignOp':
+        return AssignOpPatcher;
 
       case 'Program':
         return ProgramPatcher;

--- a/src/stages/normalize/patchers/AssignOpPatcher.js
+++ b/src/stages/normalize/patchers/AssignOpPatcher.js
@@ -1,0 +1,12 @@
+import PassthroughPatcher from '../../../patchers/PassthroughPatcher.js';
+
+export default class AssignOpPatcher extends PassthroughPatcher {
+  key: NodePatcher;
+  expression: NodePatcher;
+
+  constructor(node: Node, context: ParseContext, editor: Editor, key: NodePatcher, expression: NodePatcher) {
+    super(node, context, editor, key, expression);
+    this.key = key;
+    this.expression = expression;
+  }
+}

--- a/src/stages/normalize/patchers/ClassPatcher.js
+++ b/src/stages/normalize/patchers/ClassPatcher.js
@@ -1,0 +1,218 @@
+import NodePatcher from './../../../patchers/NodePatcher.js';
+import AssignOpPatcher from './AssignOpPatcher.js';
+
+import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+
+export default class ClassPatcher extends NodePatcher {
+  nameAssignee: ?NodePatcher;
+  superclass: ?NodePatcher;
+  body: ?BlockPatcher;
+
+  constructor(node: Node, context: ParseContext, editor: Editor, nameAssignee: ?NodePatcher, parent: ?NodePatcher, body: ?BlockPatcher) {
+    super(node, context, editor);
+    this.nameAssignee = nameAssignee;
+    this.superclass = parent;
+    this.body = body;
+  }
+
+  /**
+   * Handle code within class bodies by restructuring the class to use a static
+   * method instead.
+   *
+   * Current limitations:
+   * - Doesn't handle anonymous classes.
+   * - Doesn't handle classes used in an expression context.
+   * - Doesn't deconflict the "initClass" name of the static method.
+   * - Doesn't deconflict the variable assignments that are moved outside the
+   *   class body.
+   * - Technically this changes the execution order of the class body, although
+   *   it does so in a way that is unlikely to cause problems in reasonable
+   *   code.
+   */
+  patchAsStatement() {
+    if (this.nameAssignee) {
+      this.nameAssignee.patch();
+    }
+    if (this.superclass) {
+      this.superclass.patch();
+    }
+    if (this.body) {
+      this.body.patch();
+    }
+
+    if (!this.body) {
+      return;
+    }
+
+    if (this.body.statements.length === 0) {
+      return;
+    }
+
+    let insertPoint = this.getInitClassInsertPoint();
+    let nonMethodPatchers = this.getNonMethodPatchers(insertPoint);
+
+    if (nonMethodPatchers.length > 0) {
+      let assignmentNames = this.generateInitClassMethod(nonMethodPatchers, insertPoint);
+      let indent = this.getIndent();
+      this.insert(this.outerEnd, `\n${indent}${this.nameAssignee.node.data}.initClass()`);
+      for (let assignmentName of assignmentNames) {
+        this.insert(this.outerStart, `${assignmentName} = undefined\n${indent}`);
+      }
+    }
+  }
+
+  /**
+   * For now, code in class bodies is only supported for statement classes.
+   */
+  patchAsExpression() {
+    this.body.patch();
+  }
+
+  getInitClassInsertPoint() {
+    if (this.superclass) {
+      return this.superclass.outerEnd;
+    }
+    if (this.nameAssignee) {
+      return this.nameAssignee.outerEnd;
+    }
+    if (this.body) {
+      return this.body.outerStart;
+    }
+    return this.outerStart;
+  }
+
+  /**
+   * Find the statements in the class body that can't be converted to JS
+   * methods. These will later be moved to the top of the class in a static
+   * method.
+   */
+  getNonMethodPatchers(initialDeleteStart) {
+    let nonMethodPatchers = [];
+    let deleteStart = initialDeleteStart;
+    for (let patcher of this.body.statements) {
+      if (!this.isClassMethod(patcher)) {
+        nonMethodPatchers.push({
+          patcher,
+          deleteStart,
+        });
+      }
+      deleteStart = patcher.outerEnd;
+    }
+    return nonMethodPatchers;
+  }
+
+  isClassMethod(patcher) {
+    if (patcher.node.type === 'Constructor') {
+      return true;
+    }
+    if (this.isClassAssignment(patcher.node)) {
+      if (patcher.node.expression.type === 'Function' ||
+          patcher.node.expression.type === 'BoundFunction' ||
+          patcher.node.expression.type === 'GeneratorFunction') {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  isClassAssignment(node) {
+    if (node.type === 'ClassProtoAssignOp') {
+      return true;
+    }
+    if (node.type === 'AssignOp') {
+      let {assignee} = node;
+      if (assignee.type === 'MemberAccessOp') {
+        if (assignee.expression.type === 'This') {
+          return true;
+        }
+        if (this.nameAssignee) {
+          let className = this.nameAssignee.node.data;
+          if (assignee.expression.type === 'Identifier' &&
+              assignee.expression.data === className) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Create the initClass static method by moving nodes from the class body into
+   * the static method and indenting them one level.
+   *
+   * Also return an array of variables that were assigned so that later code can
+   * declare them outside the class body to make them accessible within the
+   * class.
+   */
+  generateInitClassMethod(nonMethodPatchers, insertPoint) {
+    let bodyIndent = this.body.getIndent();
+    let indentString = this.getProgramIndentString();
+    this.insert(insertPoint, `\n${bodyIndent}@initClass: ->`);
+    let assignmentNames = [];
+    for (let {patcher, deleteStart} of nonMethodPatchers) {
+      let assignmentName = this.getAssignmentName(patcher);
+      if (assignmentName) {
+        assignmentNames.push(assignmentName);
+      }
+      let statementCode = this.getNonMethodStatementCode(patcher, deleteStart);
+      statementCode = statementCode.replace(/\n/g, `\n${indentString}`);
+      this.insert(insertPoint, statementCode);
+      this.remove(deleteStart, patcher.outerEnd);
+    }
+    this.insert(insertPoint, `\n${bodyIndent}${indentString}return`);
+    return assignmentNames;
+  }
+
+  /**
+   * Determine the variable assigned in the given statement, if any, since any
+   * assigned variables need to be declared externally so they are available
+   * within the class body. Note that this is incomplete at the moment and only
+   * covers the common case of a single variable being defined.
+   */
+  getAssignmentName(statementPatcher) {
+    if (statementPatcher.node.type === 'AssignOp' &&
+      statementPatcher.node.assignee.type === 'Identifier') {
+      return statementPatcher.node.assignee.data;
+    }
+    if (statementPatcher instanceof ClassPatcher) {
+      return statementPatcher.nameAssignee.node.data;
+    }
+    return null;
+  }
+
+  getNonMethodStatementCode(statementPatcher, deleteStart) {
+    if (statementPatcher instanceof AssignOpPatcher &&
+        this.isClassAssignment(statementPatcher.node)) {
+      let {key, expression} = statementPatcher;
+      let prefixCode = this.slice(deleteStart, key.outerStart);
+      let keyCode = this.slice(key.outerStart, key.outerEnd);
+      let suffixCode = this.slice(key.outerEnd, expression.outerEnd);
+
+      let equalIndex = suffixCode.indexOf('=');
+      let colonIndex = suffixCode.indexOf(':');
+      if (equalIndex === -1 || colonIndex < equalIndex) {
+        suffixCode = suffixCode.replace(/:/, ' =');
+      }
+
+      if (statementPatcher.node.type === 'ClassProtoAssignOp') {
+        // a: b -> @prototype.a = b
+        return `${prefixCode}@prototype.${keyCode}${suffixCode}`;
+      } else {
+        // @a: b -> @a = b
+        return `${prefixCode}${keyCode}${suffixCode}`;
+      }
+    } else if (statementPatcher instanceof ClassPatcher &&
+        statementPatcher.nameAssignee) {
+      // Nested classes need a special case: they need to be converted to an
+      // assignment statement so that the name can be declared outside the outer
+      // class body and the initialized within initClass.
+      let className = statementPatcher.nameAssignee.node.data;
+      let prefix = this.slice(deleteStart, statementPatcher.outerStart);
+      let suffix = this.slice(statementPatcher.outerStart, statementPatcher.outerEnd);
+      return `${prefix}${className} = ${suffix}`;
+    } else {
+      return this.slice(deleteStart, statementPatcher.outerEnd);
+    }
+  }
+}

--- a/src/stages/normalize/patchers/ProgramPatcher.js
+++ b/src/stages/normalize/patchers/ProgramPatcher.js
@@ -1,7 +1,18 @@
 import PassthroughPatcher from '../../../patchers/PassthroughPatcher.js';
+import determineIndent from '../../../utils/determineIndent.js';
 
 export default class ProgramPatcher extends PassthroughPatcher {
   shouldTrimContentRange() {
     return true;
+  }
+
+  /**
+   * Gets the indent string used for each indent in this program.
+   */
+  getProgramIndentString(): string {
+    if (!this._indentString) {
+      this._indentString = determineIndent(this.context.source);
+    }
+    return this._indentString;
   }
 }


### PR DESCRIPTION
Closes #397. See that issue for a much more thorough description of the strategy
here. This change doesn't handle all cases described in that issue (in
particular, it doesn't support arbitrary code within classes that are used in an
expression context), but it handles enough cases to support all classes in the
codebase I'm working with.

Since this transform significantly rearranges classes, I decided to do it as a
CS->CS transform in the normalize stage. That should hopefully avoid weird
magic-string issues in the main stage.

This approach is maybe a bit controversial in that it changes the implementation
for class fields to use prototype properties. In my case, putting class
properties on the prototype is necessary to avoid widespread correctness issues
in my codebase. (See http://benmccormick.org/2015/07/06/backbone-and-es6-classes-revisited/
for more details.) My current thought is I'll leave the class fields code in
place and we can make the behavior configurable with a command line flag if
there's demand for it. Or I can add the flag as part of this PR.