### PR TITLE
fix: properly convert for expressions with implicit object bodies

### DIFF
--- a/test/for_test.js
+++ b/test/for_test.js
@@ -795,4 +795,16 @@ describe('for loops', () => {
         d();
       }
     `));
+
+  it('handles for loop expressions returning implicit objects', () =>
+    check(`
+      x = for a in b
+        c: d
+        e: f
+    `, `
+      let x = b.map((a) => ({
+        c: d,
+        e: f
+      }));
+    `));
 });


### PR DESCRIPTION
Closes #467.

This was a magic string issue where inserts were happening out of order. Now,
when patching expression-style for-in loops, we patch the body in the middle,
and split the `surroundInParens` call into an insert before and after. Placing
the open-paren in a consistent way ended up being tricky, and required some
cases to handle both the inline and multiline cases.