### PR TITLE
fix: properly handle conditionals with a null consequent

### DIFF
--- a/src/stages/normalize/patchers/ConditionalPatcher.js
+++ b/src/stages/normalize/patchers/ConditionalPatcher.js
@@ -14,8 +14,8 @@ import { IF } from 'coffee-lex';
  */
 export default class ConditionalPatcher extends NodePatcher {
   condition: NodePatcher;
-  guard: ?NodePatcher;
-  body: ?NodePatcher;
+  consequent: ?NodePatcher;
+  alternate: ?NodePatcher;
 
   constructor(node: Node, context: ParseContext, editor: Editor, condition: NodePatcher, consequent: NodePatcher, alternate: ?NodePatcher) {
     super(node, context, editor);
@@ -29,7 +29,9 @@ export default class ConditionalPatcher extends NodePatcher {
       this.patchPostIf();
     } else {
       this.condition.patch();
-      this.consequent.patch();
+      if (this.consequent !== null) {
+        this.consequent.patch();
+      }
       if (this.alternate !== null) {
         this.alternate.patch();
       }
@@ -56,7 +58,8 @@ export default class ConditionalPatcher extends NodePatcher {
   }
 
   isPostIf(): boolean {
-    return this.condition.contentStart > this.consequent.contentStart;
+    return this.consequent !== null
+      && this.condition.contentStart > this.consequent.contentStart;
   }
 
   getIfTokenIndex(): SourceTokenListIndex {

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -453,4 +453,35 @@ describe('conditionals', () => {
       })();
     `)
   );
+
+  it('allows a missing consequent in an if-else', () =>
+    check(`
+      if a
+        # Do nothing
+      else
+        b
+    `, `
+      if (a) {
+        // Do nothing
+      } else {
+        b;
+      }
+    `)
+  );
+
+  it('allows a missing consequent in an expression-style if-else', () =>
+    check(`
+      x =
+        if a
+          # Do nothing
+        else
+          b
+    `, `
+      let x =
+        a ?
+          // Do nothing
+        undefined :
+          b;
+    `)
+  );
 });


### PR DESCRIPTION
Closes #305.

This was basically just a matter of going through ConditionalPatcher in both the
normalize stage and the main stage and making sure they account for the case
where `consequent` is null. There are some regions of code that only happen when
`consequent` is non-null, like post-`if` patching and code with a `then` token,
so I left those as-is.

The formatting is a little weird for a missing consequent when the conditional
is used in an expression context, but that's probably a rare case and can be
cleaned up later.