### PR TITLE
fix: respect bounds when writing the end of a switch expression

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -943,8 +943,9 @@ export default class NodePatcher {
    * Appends the given content at the end of the current line.
    */
   appendToEndOfLine(content: string) {
-    let eol = this.getEndOfLine();
-    this.insert(eol, content);
+    let boundingPatcher = this.getBoundingPatcher();
+    let endOfLine = this.getEndOfLine();
+    this.insert(Math.min(endOfLine, boundingPatcher.innerEnd), content);
   }
 
   /**

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -289,4 +289,17 @@ describe('switch', () => {
       }
     `);
   });
+
+  it('works with switch expressions returning an object literal', () => {
+    check(`
+      a b, switch c
+        when d
+          {}
+    `, `
+      a(b, (() => { switch (c) {
+        case d:
+          return {};
+      } })());
+    `);
+  });
 });


### PR DESCRIPTION
Closes #448.

The switch patcher was using `appendToEndOfLine`, which was just writing to the
end of the current line, even if it was past the end of the expression (in this
case, it was writing past the close-paren for the function call). To fix, I just
made `appendToEndOfLine` include the same logic as `appendLineAfter`: write to
the right place if possible, but not past the bounding patcher.