### PR TITLE
fix: allow empty switch cases

### DIFF
--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -302,4 +302,23 @@ describe('switch', () => {
       } })());
     `);
   });
+
+  it('works with empty switch cases', () => {
+    check(`
+    switch a
+      when b then
+        # Do nothing
+      when c then
+        # Do nothing
+    `, `
+      switch (a) {
+        case b: then;
+          break;
+          // Do nothing
+        case c: then;
+          break;
+      }
+          // Do nothing
+    `);
+  });
 });


### PR DESCRIPTION
Closes #340

This was just a matter of going through `SwitchCasePatcher` and handling the
case where `consequent` is null.