### PR TITLE
fix: properly handle break and continue in loop expressions

### DIFF
--- a/src/stages/main/patchers/IdentifierPatcher.js
+++ b/src/stages/main/patchers/IdentifierPatcher.js
@@ -8,4 +8,12 @@ export default class IdentifierPatcher extends PassthroughPatcher {
   isRepeatable(): boolean {
     return true;
   }
+
+  /**
+   * Currently, break and continue are parsed as identifiers, but they need to
+   * behave differently in some cases.
+   */
+  canPatchAsExpression(): boolean {
+    return this.node.data !== 'break' && this.node.data !== 'continue';
+  }
 }

--- a/src/stages/main/patchers/LoopPatcher.js
+++ b/src/stages/main/patchers/LoopPatcher.js
@@ -155,6 +155,10 @@ export default class LoopPatcher extends NodePatcher {
    * at the end of the loop body.
    */
   patchImplicitReturnStart(patcher: NodePatcher) {
+    // Control flow statements like break and continue should be skipped.
+    if (!patcher.canPatchAsExpression()) {
+      return;
+    }
     patcher.setRequiresExpression();
     if (this.allBodyCodePathsPresent()) {
       // `a + b` → `result.push(a + b`
@@ -171,6 +175,9 @@ export default class LoopPatcher extends NodePatcher {
    * @see patchImplicitReturnStart
    */
   patchImplicitReturnEnd(patcher: NodePatcher) {
+    if (!patcher.canPatchAsExpression()) {
+      return;
+    }
     if (this.allBodyCodePathsPresent()) {
       this.insert(patcher.outerEnd, `)`);
     }

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -807,4 +807,43 @@ describe('for loops', () => {
         e: f
       }));
     `));
+
+  it('handles for loop expressions ending in a break', () =>
+    check(`
+      x = for a in b
+        break
+    `, `
+      let x = (() => {
+        let result = [];
+        for (let i = 0; i < b.length; i++) {
+          let a = b[i];
+          break;
+        }
+        return result;
+      })();
+    `));
+
+  it('handles for loop expressions with multiple branches including a control flow statement', () =>
+    check(`
+      x = for a in b
+        if a
+          a
+        else if b
+          continue
+    `, `
+      let x = (() => {
+        let result = [];
+        for (let i = 0; i < b.length; i++) {
+          let a = b[i];
+          let item;
+          if (a) {
+            item = a;
+          } else if (b) {
+            continue;
+          }
+          result.push(item);
+        }
+        return result;
+      })();
+    `));
 });


### PR DESCRIPTION
Fixes #473

`break` and `continue` were parsed as regular identifiers, so the loop
expression patching code would sometimes make a lambda trying to return them or
generated code like `result.push(break)`. Probably the cleanest fix would be to
parse `break` and `continue` differently in the AST, but the easy fix is to just
say that the identifier can't be patched as an expression in those cases, and
handle that properly.