### PR TITLE
fix: change post-if patching to use insert

### DIFF
--- a/src/stages/normalize/patchers/ConditionalPatcher.js
+++ b/src/stages/normalize/patchers/ConditionalPatcher.js
@@ -44,17 +44,16 @@ export default class ConditionalPatcher extends NodePatcher {
    */
   patchPostIf() {
     this.condition.patch();
+    this.consequent.patch();
 
     let ifTokenIndex = this.getIfTokenIndex();
     let ifToken = this.sourceTokenAtIndex(ifTokenIndex);
 
     if (ifToken) {
-      this.remove(this.consequent.outerEnd, ifToken.start);
-      this.move(ifToken.start, this.condition.outerEnd, this.consequent.outerStart);
-      this.insertRight(this.condition.outerEnd, ` then `);
+      let consequentCode = this.slice(this.consequent.outerStart, this.consequent.outerEnd);
+      this.remove(this.consequent.outerStart, ifToken.start);
+      this.insertRight(this.condition.outerEnd, ` then ${consequentCode}`);
     }
-
-    this.consequent.patch();
   }
 
   isPostIf(): boolean {

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -394,4 +394,60 @@ describe('function calls', () => {
       }
     `);
   });
+
+  it('handles implicit calls ending in a postfix conditional (#479)', () => {
+    check(`
+      baz () =>
+        foo if bar
+    `, `
+      baz(() => {
+        if (bar) { return foo; }
+      }
+      );
+    `);
+  });
+
+  it('handles nested implicit calls ending in a postfix conditional (#459)', () => {
+    check(`
+      define [], ->
+        something: ->
+          $.on 'click', assignThis if someCondition
+    `, `
+      define([], () =>
+        ({
+          something() {
+            if (someCondition) { return $.on('click', assignThis); }
+          }
+        })
+      );
+    `);
+  });
+
+  it('handles single-line implicit calls ending in a postfix conditional (#419)', () => {
+    check(`
+      @someMethod => 'returnValue' if condition
+    `, `
+      this.someMethod(() => { if (condition) { return 'returnValue'; } });
+    `);
+  });
+
+  it('handles simple implicit calls ending in a postfix conditional (#378)', () => {
+    check(`
+      a => b if c
+    `, `
+      a(() => { if (c) { return b; } });
+    `);
+  });
+
+
+  it('handles implicit method calls with a postfix conditional (#334)', () => {
+    check(`
+      a.then () ->
+        b if c
+    `, `
+      a.then(function() {
+        if (c) { return b; }
+      });
+    `);
+  });
 });


### PR DESCRIPTION
Closes #479.
Closes #459.
Closes #419.
Closes #378.
Closes #334.

The post-if patcher was changed to use `move` in magic-string, but that ended up
messing with the order that things were written in. Now that magic-string
properly handles `remove`, it should be safe to go back to using `insert`, with
the general strategy being to insert fragments in order in the source code
whenever possible.