### PR TITLE
feat: convert CS for-in to JS for-of when possible

### DIFF
--- a/test/continue_test.js
+++ b/test/continue_test.js
@@ -6,8 +6,7 @@ describe('continue', () => {
       for a in b
         continue
     `, `
-      for (let i = 0; i < b.length; i++) {
-        let a = b[i];
+      for (let a of b) {
         continue;
       }
     `);


### PR DESCRIPTION
Closes #323

Technically for-of loops use the JS iterator protocol insead of CoffeeScript's
notion of an array-like object, but that's also true for things like
destructuring. Some of this code was based on the code from `ForOfPatcher`,
since that's similar in that it just changes `of` to `in` in simple cases.