### PR TITLE
feat: use `.includes` instead of a helper method for `in`

### DIFF
--- a/docs/conversion-guide.md
+++ b/docs/conversion-guide.md
@@ -10,6 +10,9 @@ This guide assumes a few things:
 1. You have Node v0.12 or higher installed.
 1. You have a project or set of files that currently compile using the
    official CoffeeScript compiler.
+1. Your project is able to run ES2016 code. In particular, depending on what
+   browsers/runtimes you need to support, you may need to set up Babel,
+   including standard library polyfills like `Array.prototype.includes`.
 1. You understand CoffeeScript, ES6, and the files being converted
    reasonably well.
 1. You are using Linux, Mac OS X, or a compatible OS and are comfortable

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -365,11 +365,8 @@ describe('function calls', () => {
         )
     `, `
       a =>
-        !__in__(a, b.map(a, e => e))
+        !b.map(a, e => e).includes(a)
       ;
-      function __in__(needle, haystack) {
-        return haystack.indexOf(needle) >= 0;
-      }
     `);
   });
 

--- a/test/in_test.js
+++ b/test/in_test.js
@@ -5,10 +5,7 @@ describe('in operator', () => {
     check(`
       a in b
     `, `
-      __in__(a, b);
-      function __in__(needle, haystack) {
-        return haystack.indexOf(needle) >= 0;
-      }
+      b.includes(a);
     `);
   });
 
@@ -16,10 +13,7 @@ describe('in operator', () => {
     check(`
       a.b in c
     `, `
-      __in__(a.b, c);
-      function __in__(needle, haystack) {
-        return haystack.indexOf(needle) >= 0;
-      }
+      c.includes(a.b);
     `);
   });
 
@@ -27,10 +21,7 @@ describe('in operator', () => {
     check(`
       a(b, c.d in e)
     `, `
-      a(b, __in__(c.d, e));
-      function __in__(needle, haystack) {
-        return haystack.indexOf(needle) >= 0;
-      }
+      a(b, e.includes(c.d));
     `);
   });
 
@@ -38,10 +29,7 @@ describe('in operator', () => {
     check(`
       a in b + c
     `, `
-      __in__(a, b + c);
-      function __in__(needle, haystack) {
-        return haystack.indexOf(needle) >= 0;
-      }
+      (b + c).includes(a);
     `);
   });
 
@@ -50,11 +38,8 @@ describe('in operator', () => {
       if a + b in c + d
         e
     `, `
-      if (__in__(a + b, c + d)) {
+      if ((c + d).includes(a + b)) {
         e;
-      }
-      function __in__(needle, haystack) {
-        return haystack.indexOf(needle) >= 0;
       }
     `);
   });
@@ -63,10 +48,7 @@ describe('in operator', () => {
     check(`
       a not in b
     `, `
-      !__in__(a, b);
-      function __in__(needle, haystack) {
-        return haystack.indexOf(needle) >= 0;
-      }
+      !b.includes(a);
     `);
   });
 
@@ -74,10 +56,7 @@ describe('in operator', () => {
     check(`
       a or a not in b
     `, `
-      a || !__in__(a, b);
-      function __in__(needle, haystack) {
-        return haystack.indexOf(needle) >= 0;
-      }
+      a || !b.includes(a);
     `);
   });
 
@@ -85,10 +64,7 @@ describe('in operator', () => {
     check(`
       a and a not in b
     `, `
-      a && !__in__(a, b);
-      function __in__(needle, haystack) {
-        return haystack.indexOf(needle) >= 0;
-      }
+      a && !b.includes(a);
     `);
   });
 
@@ -97,11 +73,8 @@ describe('in operator', () => {
       unless a in b
         c
     `, `
-      if (!__in__(a, b)) {
+      if (!b.includes(a)) {
         c;
-      }
-      function __in__(needle, haystack) {
-        return haystack.indexOf(needle) >= 0;
       }
     `);
   });
@@ -111,11 +84,8 @@ describe('in operator', () => {
       if not (a in b)
         c
     `, `
-      if (!(__in__(a, b))) {
+      if (!(b.includes(a))) {
         c;
-      }
-      function __in__(needle, haystack) {
-        return haystack.indexOf(needle) >= 0;
       }
     `);
   });
@@ -125,11 +95,8 @@ describe('in operator', () => {
       unless a not in b
         c
     `, `
-      if (__in__(a, b)) {
+      if (b.includes(a)) {
         c;
-      }
-      function __in__(needle, haystack) {
-        return haystack.indexOf(needle) >= 0;
       }
     `);
   });
@@ -195,11 +162,8 @@ describe('in operator', () => {
       if a in []
         b
     `, `
-      if (__in__(a, [])) {
+      if ([].includes(a)) {
         b;
-      }
-      function __in__(needle, haystack) {
-        return haystack.indexOf(needle) >= 0;
       }
     `);
   });


### PR DESCRIPTION
Closes #363

Note that this means that anyone using decaffeinate needs to be in an
environment supporting ES2016. I updated the docs to include this.