### PR TITLE
fix: don't include parens when patching loop filters

### DIFF
--- a/src/stages/main/patchers/ForPatcher.js
+++ b/src/stages/main/patchers/ForPatcher.js
@@ -38,7 +38,7 @@ export default class ForPatcher extends LoopPatcher {
       return null;
     }
     if (!this._filterCode) {
-      filter.patch();
+      filter.patch({ needsParens: false });
       this._filterCode = this.slice(filter.contentStart, filter.contentEnd);
     }
     return this._filterCode;

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -846,4 +846,20 @@ describe('for loops', () => {
         return result;
       })();
     `));
+
+  it('handles a `when` clause with existence operator', () => {
+    check(`
+      filteredData = {}
+      for k, v of data when v?
+        filteredData[k] = v
+    `, `
+      let filteredData = {};
+      for (let k in data) {
+        let v = data[k];
+        if (v != null) {
+          filteredData[k] = v;
+        }
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #483.

Since the condition in a loop is already going to be surrounded by parens,
there's no need to add an extra set of parens. Also, it was causing a bug where
one of the parens was kept but the other one wasn't.

This doesn't really solve the general case; ideally there would be a way to get
the expression including the parens.