### PR TITLE
fix: patch code in order in conditional consequents

### DIFF
--- a/src/stages/main/patchers/ConditionalPatcher.js
+++ b/src/stages/main/patchers/ConditionalPatcher.js
@@ -194,10 +194,10 @@ export default class ConditionalPatcher extends NodePatcher {
       let elseTokenIndex = this.getElseSourceTokenIndex();
       let elseToken = this.sourceTokenAtIndex(elseTokenIndex);
       let rightBracePosition = elseToken.start;
-      this.insert(rightBracePosition, '} ');
       if (this.consequent !== null) {
         this.consequent.patch({ leftBrace: false, rightBrace: false });
       }
+      this.insert(rightBracePosition, '} ');
     } else {
       if (this.consequent !== null) {
         this.consequent.patch({ leftBrace: false });

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -514,4 +514,12 @@ describe('conditionals', () => {
           // Do nothing
     `)
   );
+
+  it('handles a conditional without a space before the `else` token', () =>
+    check(`
+      if a then (b)else c
+    `, `
+      if (a) { (b);} else { c; }
+    `)
+  );
 });


### PR DESCRIPTION
Closes #492.

The close-brace and the end of the consequent statement were having code
inserted at the same index, so we need to make sure the patching happens in the
order that they should appear in the code.