### PR TITLE
fix: properly position the first part of switch IIFE patching

### DIFF
--- a/src/stages/main/patchers/SwitchPatcher.js
+++ b/src/stages/main/patchers/SwitchPatcher.js
@@ -64,7 +64,7 @@ export default class SwitchPatcher extends NodePatcher {
 
     // `` → `(() => { `
     //       ^^^^^^^^^
-    this.insert(this.outerStart, '(() => { ');
+    this.insert(this.contentStart, '(() => { ');
     this.patchAsStatement();
 
     // `` → ` })()`

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -251,13 +251,14 @@ describe('switch', () => {
     `);
   });
 
-  it.skip('works with `switch` used as an expression surrounded by parens', () => {
+  it('works with `switch` used as an expression surrounded by parens', () => {
     check(`
       a(switch b
         when c then d)
     `, `
       a((() => { switch (b) {
-        case c: return d; } })());
+        case c: return d;
+      } })());
     `);
   });
 
@@ -319,6 +320,24 @@ describe('switch', () => {
           break;
       }
           // Do nothing
+    `);
+  });
+
+  it('handles a switch as an argument to a function call', () => {
+    check(`
+      a switch b
+        when c
+          d
+        when e
+          f
+    `, `
+      a((() => { switch (b) {
+        case c:
+          return d;
+        case e:
+          return f;
+      
+      } })());
     `);
   });
 });


### PR DESCRIPTION
Fixes #494.
Fixes #319.

The code was inserting the first part at `outerStart`, which is before the
enclosing left-paren, which is wrong. Instead, it should use `contentStart`.