### PR TITLE
fix: change map/filter patching to go in order

### DIFF
--- a/src/stages/main/patchers/ForInPatcher.js
+++ b/src/stages/main/patchers/ForInPatcher.js
@@ -30,10 +30,6 @@ export default class ForInPatcher extends ForPatcher {
     if (this.keyAssignee !== null) {
       this.keyAssignee.patch();
     }
-    this.target.patch();
-    if (this.filter !== null) {
-      this.filter.patch();
-    }
 
     let assigneeCode = this.slice(this.valAssignee.contentStart, this.valAssignee.contentEnd);
     if (this.keyAssignee !== null) {
@@ -43,12 +39,14 @@ export default class ForInPatcher extends ForPatcher {
     // for a in b when c d  ->  b when c d
     // ("then" was removed above).
     this.remove(this.contentStart, this.target.outerStart);
+    this.target.patch();
     if (this.filter !== null) {
       // b when c d  ->  b.filter((a) => c d
       this.overwrite(
         this.target.outerEnd, this.filter.outerStart,
         `.filter((${assigneeCode}) => `
       );
+      this.filter.patch();
       // b.filter((a) => c d  ->  b.filter((a) => c).map((a) => d
       this.insert(this.filter.outerEnd, `).map((${assigneeCode}) =>`);
     } else {

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -862,4 +862,12 @@ describe('for loops', () => {
       }
     `);
   });
+
+  it('handles a `when` clause with a `not of` in map/filter transformations', () => {
+    check(`
+      a = (b for b in c when b not of e)
+    `, `
+      let a = (c.filter((b) => !(b in e)).map((b) => b));
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #491.

This fixes an issue where an overwrite operation would interfere with an earlier
patch. This can be fixed by being more careful about patching order: generally
all patching should happen in order in the code rather than jumping around.