### PR TITLE
fix: handle try/catch with empty catch or finally blocks

### DIFF
--- a/test/try_test.js
+++ b/test/try_test.js
@@ -138,4 +138,42 @@ describe('try', () => {
       } catch (error1) {}
     `);
   });
+
+  it('handles try with an empty catch block', () => {
+    check(`
+      try
+        something()
+      catch
+    `, `
+      try {
+        something();
+      } catch (error) {}
+    `);
+  });
+
+  it('handles try with an empty finally block', () => {
+    check(`
+      try
+        something()
+      finally
+    `, `
+      try {
+        something();
+      } finally {}
+    `);
+  });
+
+  it('handles try with an empty catch and finally block', () => {
+    check(`
+      try
+        something()
+      catch
+      finally
+    `, `
+      try {
+        something();
+      } catch (error) {}
+      finally {}
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #265

There can still be a catch or finally case without a catch or finally body, so
we need to be a little smarter about searching for the token and handling the
different cases.
