### PR TITLE
fix: remove logical operators case for `in` patching

### DIFF
--- a/test/in_test.js
+++ b/test/in_test.js
@@ -106,7 +106,7 @@ describe('in operator', () => {
       if a in [yes, no]
         b
     `, `
-      if (a === true || a === false) {
+      if ([true, false].includes(a)) {
         b;
       }
     `);
@@ -117,7 +117,7 @@ describe('in operator', () => {
       if a not in [yes, no]
         b
     `, `
-      if (a !== true && a !== false) {
+      if (![true, false].includes(a)) {
         b;
       }
     `);
@@ -128,7 +128,7 @@ describe('in operator', () => {
       if a in [yes]
         b
     `, `
-      if (a === true) {
+      if ([true].includes(a)) {
         b;
       }
     `);
@@ -139,8 +139,7 @@ describe('in operator', () => {
       if a() in [yes, no]
         b
     `, `
-      let ref;
-      if ((ref = a()) === true || ref === false) {
+      if ([true, false].includes(a())) {
         b;
       }
     `);
@@ -151,7 +150,7 @@ describe('in operator', () => {
       if a in [b and c, +d]
         e
     `, `
-      if (a === (b && c) || a === +d) {
+      if ([b && c, +d].includes(a)) {
         e;
       }
     `);


### PR DESCRIPTION
Fixes #482

Now that the code uses `.includes`, it seems cleaner to use that always even
when the array operand is an array literal. Also, there were some precedence
issues with the logical operators case, so getting rid of it fixes those issues.
