### PR TITLE
fix: improve the process of patching code for use elsewhere

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -233,6 +233,28 @@ export default class NodePatcher {
   }
 
   /**
+   * Patch the given expression and get the underlying generated code. This is
+   * more robust then calling patch and slice directly, since it also includes
+   * code inserted at contentStart (which normally isn't picked up by slice
+   * because it's inserted to the left of the index boundary). To accomplish
+   * this, we look at the range from contentStart - 1 to contentStart before and
+   * after patching and include anything new that was added.
+   */
+  patchAndGetCode(options={}) {
+    let sliceStart = this.contentStart > 0 ? this.contentStart - 1 : 0;
+    let beforeCode = this.slice(sliceStart, this.contentStart);
+    this.patch(options);
+    let code = this.slice(sliceStart, this.contentEnd);
+    let startIndex = 0;
+    while (startIndex < beforeCode.length &&
+        startIndex < code.length &&
+        beforeCode[startIndex] === code[startIndex]) {
+      startIndex++;
+    }
+    return code.substr(startIndex);
+  }
+
+  /**
    * Catch errors and throw them again annotated with the current node.
    */
   withPrettyErrors(body: () => void) {

--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -234,7 +234,7 @@ export default class NodePatcher {
 
   /**
    * Patch the given expression and get the underlying generated code. This is
-   * more robust then calling patch and slice directly, since it also includes
+   * more robust than calling patch and slice directly, since it also includes
    * code inserted at contentStart (which normally isn't picked up by slice
    * because it's inserted to the left of the index boundary). To accomplish
    * this, we look at the range from contentStart - 1 to contentStart before and

--- a/src/stages/main/patchers/ForPatcher.js
+++ b/src/stages/main/patchers/ForPatcher.js
@@ -38,8 +38,7 @@ export default class ForPatcher extends LoopPatcher {
       return null;
     }
     if (!this._filterCode) {
-      filter.patch({ needsParens: false });
-      this._filterCode = this.slice(filter.contentStart, filter.contentEnd);
+      this._filterCode = filter.patchAndGetCode({ needsParens: false });
     }
     return this._filterCode;
   }

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -946,4 +946,20 @@ describe('for loops', () => {
       let a = (c.filter((b) => !(b in e)).map((b) => b));
     `);
   });
+
+  it('handles a `when` clause with a `not of` operator', () => {
+    check(`
+      a = (b for b of c when d not of e)
+    `, `
+      let a = ((() => {
+        let result = [];
+        for (let b in c) {
+          if (!(d in e)) {
+            result.push(b);
+          }
+        }
+        return result;
+      })());
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #498

Previously, you might call `patch` on a sub-patcher, then use `slice` to get the
generated code, but this didn't always work out well, since we always do
`insertLeft` (for magic-string sanity), so slice would sometimes miss an
open-paren inserted at the start.

This commit changes the loop filter case to use this new method, but probably
other code paths should be moved over to it as well in the future.