### PR TITLE
fix: include the `?` operator as an allowed binary operator

### DIFF
--- a/src/stages/main/patchers/BinaryOpPatcher.js
+++ b/src/stages/main/patchers/BinaryOpPatcher.js
@@ -1,6 +1,6 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
 import type { SourceToken, Node, ParseContext, Editor } from './../../../patchers/types.js';
-import { OPERATOR } from 'coffee-lex';
+import { EXISTENCE, OPERATOR } from 'coffee-lex';
 
 export default class BinaryOpPatcher extends NodePatcher {
   left: NodePatcher;
@@ -71,7 +71,7 @@ export default class BinaryOpPatcher extends NodePatcher {
   }
 
   operatorTokenPredicate(): (token: SourceToken) => boolean {
-    return (token: SourceToken) => token.type === OPERATOR;
+    return (token: SourceToken) => token.type === OPERATOR || token.type === EXISTENCE;
   }
 
   /**

--- a/test/binary_operator_test.js
+++ b/test/binary_operator_test.js
@@ -126,6 +126,14 @@ describe('binary operators', () => {
     `);
   });
 
+  it('handles binary existence operator combined with plus', () => {
+    check(`
+      x = 1 + (y ? 0)
+    `, `
+      let x = 1 + (typeof y !== 'undefined' && y !== null ? y : 0);
+    `);
+  });
+
   it('handles left shift as a nested operator', () => {
     check(`
       value = object.id << 8 | object.type


### PR DESCRIPTION
Fixes #428

The code for handling for handling binary operators almost always deals with the
OPERATOR token from coffee-lex, but sometimes it deals with the EXISTENCE token
when `?` is used in a binary operator context.
