### PR TITLE
fix: update decaffeinate-coffeescript to patch 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "automatic-semicolon-insertion": "^1.0.2",
     "babylon": "^6.12.0",
     "coffee-lex": "^1.4.4",
-    "decaffeinate-coffeescript": "^1.10.0-patch2",
+    "decaffeinate-coffeescript": "^1.10.0-patch5",
     "decaffeinate-parser": "^2.0.2",
     "detect-indent": "^4.0.0",
     "esnext": "^3.0.0",

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -447,4 +447,23 @@ describe('function calls', () => {
       });
     `);
   });
+
+  it('handles an implicit call with nested function expressions', () => {
+    check(`
+      a b, ->
+        c: () ->
+          if d
+            e
+    `, `
+      a(b, () =>
+        ({
+          c() {
+            if (d) {
+              return e;
+            }
+          }
+        })
+      );
+    `);
+  });
 });


### PR DESCRIPTION
This isn't strictly necessary due to semver rules, but it's nice in that it
forces the latest version and triggers a build. This change also adds a test for
the most recent fix.