### PR TITLE
fix: improve handling of loop targets to get the right code

### DIFF
--- a/src/stages/main/patchers/ForOfPatcher.js
+++ b/src/stages/main/patchers/ForOfPatcher.js
@@ -22,14 +22,13 @@ export default class ForOfPatcher extends ForPatcher {
         this.innerStart,
         `${this.getTargetReference()} = ${this.getTargetCode()}\n${this.getLoopIndent()}`
       );
+      this.overwrite(this.target.outerStart, this.target.outerEnd, this.getTargetReference());
     }
 
     let keyBinding = this.getIndexBinding();
     this.insert(keyAssignee.outerStart, '(');
 
     let { valAssignee } = this;
-
-    this.overwrite(this.target.outerStart, this.target.outerEnd, this.getTargetReference());
 
     let valueAssignment = null;
     if (valAssignee) {

--- a/src/stages/main/patchers/ForPatcher.js
+++ b/src/stages/main/patchers/ForPatcher.js
@@ -133,11 +133,11 @@ export default class ForPatcher extends LoopPatcher {
 
   getTargetReference(): string {
     if (!this._targetReference) {
-      this.target.patch();
       if (this.requiresExtractingTarget()) {
+        this.target.patch();
         this._targetReference = this.claimFreeBinding(this.targetBindingCandidate());
       } else {
-        this._targetReference = this.slice(this.target.contentStart, this.target.contentEnd);
+        this._targetReference = this.target.patchAndGetCode();
       }
     }
     return this._targetReference;

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -962,4 +962,19 @@ describe('for loops', () => {
       })());
     `);
   });
+
+  it('handles a soak operation as a loop target', () => {
+    check(`
+      for a, b of c?.d
+        console.log a
+    `, `
+      for (let a in __guard__(c, x => x.d)) {
+        let b = __guard__(c, x => x.d)[a];
+        console.log(a);
+      }
+      function __guard__(value, transform) {
+        return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #511.

The new `patchAndGetCode` method is more robust than the previous approach,
especially in cases like soaks that add code to the start. Also, the code was
overwriting the target even if it didn't need to be extracted, which caused
problems in some cases, so only overwrite it if it's going to be replaced by
something different.