### PR TITLE
fix: patch the assignee when generating JS for-of loops

### DIFF
--- a/src/stages/main/patchers/ForInPatcher.js
+++ b/src/stages/main/patchers/ForInPatcher.js
@@ -178,6 +178,7 @@ export default class ForInPatcher extends ForPatcher {
       this.remove(this.target.outerEnd, this.filter.outerEnd);
     }
 
+    this.valAssignee.patch();
     this.insert(this.valAssignee.outerStart, '(');
     this.overwrite(relationToken.start, relationToken.end, 'of');
     this.target.patch();

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -977,4 +977,15 @@ describe('for loops', () => {
       }
     `);
   });
+
+  it('handles this-assignment in a loop variable', () => {
+    check(`
+      for @a in b
+        c
+    `, `
+      for (this.a of b) {
+        c;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #520

It turns out that this-assignment works in a for-of loop in JS, so we can just
convert `for @a in b` to `for (this.a of b)`. The for-of conversion always
happens when there's a value assignee and no key assignee, so we can just always
patch the value assignee.