### PR TITLE
fix: place implicit call close parens more carefully to avoid later parse errors

### DIFF
--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.js
@@ -56,7 +56,7 @@ export default class FunctionApplicationPatcher extends NodePatcher {
    */
   insertImplicitCloseParen() {
     let lastTokenType = this.lastToken().type;
-    if (lastTokenType === RBRACE || lastTokenType === RBRACKET) {
+    if (!this.isMultiline() || lastTokenType === RBRACE || lastTokenType === RBRACKET) {
       this.insert(this.contentEnd, ')');
       return;
     }

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -466,4 +466,24 @@ describe('function calls', () => {
       );
     `);
   });
+
+  it('handles an implicit call before a close-paren with different indentation', () => {
+    check(`
+      (a ->
+        null
+        )
+    `, `
+      (a(() => null));
+    `);
+  });
+
+  it('handles an implicit call before a call end with different indentation', () => {
+    check(`
+      a(b, c ->
+        null
+        )
+    `, `
+      a(b, c(() => null));
+    `);
+  });
 });

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -486,4 +486,22 @@ describe('function calls', () => {
       a(b, c(() => null));
     `);
   });
+
+  it('handles an implicit call at the end of an argument list of a multiline function call', () => {
+    check(`
+      x(
+        if a
+          b c
+        if d
+          e f
+      )
+    `, `
+      x(
+        a ?
+          b(c) : undefined,
+        d ?
+          e(f) : undefined
+      );
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #417
Fixes #387

In some cases, the code path to insert the implicit close-paren in a function
call would create a new line with a properly-indented close-paren, but that
would confuse the CoffeeScript parser if the following token was a close-paren
at a greater indentation. Now, in that case, we put the close-paren next to the
following close-paren so the indentation can't get messed up.