### PR TITLE
fix: remove unnecessary commas in the normalize stage

### DIFF
--- a/src/stages/normalize/index.js
+++ b/src/stages/normalize/index.js
@@ -1,3 +1,4 @@
+import ArrayInitialiserPatcher from './patchers/ArrayInitialiserPatcher.js';
 import BlockPatcher from './patchers/BlockPatcher.js';
 import ClassPatcher from './patchers/ClassPatcher.js';
 import AssignOpPatcher from './patchers/AssignOpPatcher.js';
@@ -6,6 +7,7 @@ import ForInPatcher from './patchers/ForInPatcher.js';
 import ForOfPatcher from './patchers/ForOfPatcher.js';
 import FunctionApplicationPatcher from './patchers/FunctionApplicationPatcher.js';
 import NodePatcher from '../../patchers/NodePatcher.js';
+import ObjectInitialiserPatcher from './patchers/ObjectInitialiserPatcher.js';
 import ObjectInitialiserMemberPatcher from './patchers/ObjectInitialiserMemberPatcher.js';
 import PassthroughPatcher from '../../patchers/PassthroughPatcher.js';
 import ProgramPatcher from './patchers/ProgramPatcher.js';
@@ -23,6 +25,9 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
 
   patcherConstructorForNode(node: Node): ?Class<NodePatcher> {
     switch (node.type) {
+      case 'ArrayInitialiser':
+        return ArrayInitialiserPatcher;
+
       case 'MemberAccessOp':
         return MemberAccessOpPatcher;
 
@@ -62,6 +67,9 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
 
       case 'DefaultParam':
         return DefaultParamPatcher;
+
+      case 'ObjectInitialiser':
+        return ObjectInitialiserPatcher;
 
       case 'ObjectInitialiserMember':
         return ObjectInitialiserMemberPatcher;

--- a/src/stages/normalize/patchers/ArrayInitialiserPatcher.js
+++ b/src/stages/normalize/patchers/ArrayInitialiserPatcher.js
@@ -1,0 +1,26 @@
+import NodePatcher from './../../../patchers/NodePatcher.js';
+import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+import { COMMA } from 'coffee-lex';
+
+export default class ArrayInitialiserPatcher extends NodePatcher {
+  members: Array<NodePatcher>;
+
+  constructor(node: Node, context: ParseContext, editor: Editor, members: Array<NodePatcher>) {
+    super(node, context, editor);
+    this.members = members;
+  }
+
+  patchAsExpression() {
+    for (let member of this.members) {
+      // If the last token of the arg is a comma, then the actual delimiter must
+      // be a newline and the comma is unnecessary and can cause a syntax error
+      // when combined with other normalize stage transformations. So just
+      // remove the redundant comma.
+      let lastToken = member.lastToken();
+      if (lastToken.type === COMMA) {
+        this.remove(lastToken.start, lastToken.end);
+      }
+      member.patch();
+    }
+  }
+}

--- a/src/stages/normalize/patchers/ObjectInitialiserPatcher.js
+++ b/src/stages/normalize/patchers/ObjectInitialiserPatcher.js
@@ -1,0 +1,29 @@
+import NodePatcher from './../../../patchers/NodePatcher.js';
+import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+import { COMMA } from 'coffee-lex';
+
+/**
+ * Handles object literals.
+ */
+export default class ObjectInitialiserPatcher extends NodePatcher {
+  members: Array<NodePatcher>;
+
+  constructor(node: Node, context: ParseContext, editor: Editor, members: Array<NodePatcher>) {
+    super(node, context, editor);
+    this.members = members;
+  }
+
+  patchAsExpression() {
+    for (let member of this.members) {
+      // If the last token of the arg is a comma, then the actual delimiter must
+      // be a newline and the comma is unnecessary and can cause a syntax error
+      // when combined with other normalize stage transformations. So just
+      // remove the redundant comma.
+      let lastToken = member.lastToken();
+      if (lastToken.type === COMMA) {
+        this.remove(lastToken.start, lastToken.end);
+      }
+      member.patch();
+    }
+  }
+}

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -504,4 +504,58 @@ describe('function calls', () => {
       );
     `);
   });
+
+  it('handles an implicit call followed by an unnecessary comma in an array literal', () => {
+    check(`
+      [
+        if a
+          b c,
+        if d
+          e f
+      ]
+    `, `
+      [
+        a ?
+          b(c) : undefined,
+        d ?
+          e(f) : undefined
+      ];
+    `);
+  });
+
+  it('handles an implicit call followed by an unnecessary comma in a function call', () => {
+    check(`
+      x(
+        if a
+          b c,
+        if d
+          e f
+      )
+    `, `
+      x(
+        a ?
+          b(c) : undefined,
+        d ?
+          e(f) : undefined
+      );
+    `);
+  });
+
+  it('handles an implicit call followed by an unnecessary comma in an object literal', () => {
+    check(`
+      {
+        x: if a
+          b c,
+        y: if d
+          e f
+      }
+    `, `
+      ({
+        x: a ?
+          b(c) : undefined,
+        y: d ?
+          e(f) : undefined
+      });
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #447.

CoffeeScript is not particularly consistent about when to allow trailing commas
in multiline argument lists, array literals, and object literals. If the last
part of the argument or element is an implicit function call, then they are
allowed, but if the function call has parens, then the trailing comma is not
allowed. This means that the normalize stage can make code incorrect in some
cases, so we need to remove these unnecessary parens.