### PR TITLE
fix: improve detection for # to $ replacement in string interpolations

### DIFF
--- a/test/string_interpolation_test.js
+++ b/test/string_interpolation_test.js
@@ -101,4 +101,17 @@ describe('string interpolation', () => {
   it('handles if expressions inside interpolations', () => {
     check('"#{if a then b else c}"', '`${a ? b : c}`;');
   });
+
+
+  it('handles interpolations in indented herestrings', () => {
+    check(`
+      """
+        a
+        #{b}
+        """
+    `, `
+      \`a
+      \${b}\`;
+    `);
+  });
 });

--- a/test/string_interpolation_test.js
+++ b/test/string_interpolation_test.js
@@ -102,7 +102,6 @@ describe('string interpolation', () => {
     check('"#{if a then b else c}"', '`${a ? b : c}`;');
   });
 
-
   it('handles interpolations in indented herestrings', () => {
     check(`
       """


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/252

The previous strategy for finding the `#` character to replace was to look right
after the end of the previous quasi. However, if the string was a herestring
with removed indentation, then the quasi location wouldn't include that removed
indentation, so the `#` wouldn't be properly replaced. One possible fix is to
change the decaffeinate-parser locations, but ignoring removed indentation in
quasi locations doesn't seem unreasonable. Instead, the code now looks for an
INTERPOLATION_START token between the end of the quasi and the start of the
expression and uses that, which seems more reliable anyway.