### PR TITLE
fix: handle parameter lists with missing commas

### DIFF
--- a/src/stages/main/patchers/FunctionPatcher.js
+++ b/src/stages/main/patchers/FunctionPatcher.js
@@ -2,7 +2,7 @@ import NodePatcher from './../../../patchers/NodePatcher.js';
 import FunctionApplicationPatcher from './FunctionApplicationPatcher.js';
 import type BlockPatcher from './BlockPatcher.js';
 import type { Node, ParseContext, Editor, SourceToken } from './../../../patchers/types.js';
-import { CALL_END, FUNCTION, LPAREN, RPAREN } from 'coffee-lex';
+import { CALL_END, COMMA, FUNCTION, LPAREN, RPAREN } from 'coffee-lex';
 
 export default class FunctionPatcher extends NodePatcher {
   parameters: Array<NodePatcher>;
@@ -29,7 +29,14 @@ export default class FunctionPatcher extends NodePatcher {
 
   patchAsExpression({ method=false }={}) {
     this.patchFunctionStart({ method });
-    this.parameters.forEach(parameter => parameter.patch());
+    this.parameters.forEach((parameter, i) => {
+      let isLast = i === this.parameters.length - 1;
+      let needsComma = !isLast && !parameter.hasSourceTokenAfter(COMMA);
+      parameter.patch();
+      if (needsComma) {
+        this.insert(parameter.outerEnd, ',');
+      }
+    });
     this.patchFunctionBody({ method });
   }
 

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -217,4 +217,15 @@ describe('functions', () => {
       });
     `)
   );
+
+  it('handles functions that omit commas in the parameter list', () =>
+    check(`
+      (foo
+      bar) ->
+        return baz
+    `, `
+      (foo,
+      bar) => baz;
+    `)
+  );
 });


### PR DESCRIPTION
Fixes #456

We already have similar code for arrays and objects, so it was just a matter of
using the same approach for parameter lists.