### PR TITLE
fix: properly insert brackets around object keys when necessary

### DIFF
--- a/src/stages/main/patchers/ClassAssignOpPatcher.js
+++ b/src/stages/main/patchers/ClassAssignOpPatcher.js
@@ -63,8 +63,8 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
    *
    * @protected
    */
-  isComputed(): boolean {
-    if (!super.isComputed()) {
+  isMethodNameComputed(): boolean {
+    if (!super.isMethodNameComputed()) {
       return false;
     }
     return !this.isStaticMethod();

--- a/src/stages/main/patchers/HerestringPatcher.js
+++ b/src/stages/main/patchers/HerestringPatcher.js
@@ -10,12 +10,12 @@ export default class HerestringPatcher extends NodePatcher {
     let contentEnd = this.contentEnd - HERESTRING_DELIMITER_LENGTH;
 
     // Remove the padding.
-    let { padding, data } = this.node;
+    let { padding } = this.node;
     padding.forEach(([start, end]) => {
       this.remove(start, end);
     });
 
-    if (data.indexOf('\n') >= 0) {
+    if (this.stringContainsNewline()) {
       // Multi-line, so use a template string.
       this.overwrite(this.contentStart, contentStart, '`');
       this.overwrite(contentEnd, this.contentEnd, '`');
@@ -26,5 +26,9 @@ export default class HerestringPatcher extends NodePatcher {
       this.remove(contentEnd + 1, this.contentEnd);
       escape(this.editor, [source[this.contentStart]], contentStart, contentEnd);
     }
+  }
+
+  stringContainsNewline() {
+    return this.node.data.indexOf('\n') >= 0;
   }
 }

--- a/src/stages/main/patchers/ObjectBodyMemberPatcher.js
+++ b/src/stages/main/patchers/ObjectBodyMemberPatcher.js
@@ -1,7 +1,10 @@
 import BoundFunctionPatcher from './BoundFunctionPatcher.js';
 import FunctionPatcher from './FunctionPatcher.js';
 import GeneratorFunctionPatcher from './GeneratorFunctionPatcher.js';
+import HerestringPatcher from './HerestringPatcher.js';
 import IdentifierPatcher from './IdentifierPatcher.js';
+import StringPatcher from './StringPatcher.js';
+import TemplateLiteralPatcher from './TemplateLiteralPatcher.js';
 import NodePatcher from './../../../patchers/NodePatcher.js';
 import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
 
@@ -64,7 +67,39 @@ export default class ObjectBodyMemberPatcher extends NodePatcher {
   }
 
   patchKey() {
-    this.key.patch();
+    let computedKeyPatcher = this.getComputedKeyPatcher();
+    if (computedKeyPatcher !== null) {
+      this.overwrite(this.key.outerStart, computedKeyPatcher.outerStart, '[');
+      computedKeyPatcher.patch();
+      this.overwrite(computedKeyPatcher.outerEnd, this.key.outerEnd, ']');
+    } else {
+      let needsBrackets = !(this.key instanceof StringPatcher) &&
+        !(this.key instanceof IdentifierPatcher) &&
+        !(this.key instanceof HerestringPatcher && !this.key.stringContainsNewline());
+      if (needsBrackets) {
+        this.insert(this.key.outerStart, '[');
+      }
+      this.key.patch();
+      if (needsBrackets) {
+        this.insert(this.key.outerEnd, ']');
+      }
+    }
+  }
+
+  /**
+   * As a special case, transform {"#{a.b}": c} to {[a.b]: c}, since a template
+   * literal is the best way to do computed keys in CoffeeScript. This method
+   * gets the patcher for that computed key node, if any.
+   */
+  getComputedKeyPatcher() {
+    if (this.key instanceof TemplateLiteralPatcher &&
+        this.key.quasis.length === 2 &&
+        this.key.expressions.length === 1 &&
+        this.key.quasis[0].node.data === '' &&
+        this.key.quasis[1].node.data === '') {
+      return this.key.expressions[0];
+    }
+    return null;
   }
 
   patchExpression() {

--- a/src/stages/main/patchers/ObjectBodyMemberPatcher.js
+++ b/src/stages/main/patchers/ObjectBodyMemberPatcher.js
@@ -41,14 +41,14 @@ export default class ObjectBodyMemberPatcher extends NodePatcher {
     if (this.isGeneratorMethod()) {
       this.insert(this.key.outerStart, '*');
     }
-    let computedKey = this.isComputed();
-    if (computedKey) {
+    let isComputed = this.isMethodNameComputed();
+    if (isComputed) {
       // `{ 'hi there': ->` → `{ ['hi there': ->`
       //                         ^
       this.insert(this.key.outerStart, '[');
     }
     this.patchKey();
-    if (computedKey) {
+    if (isComputed) {
       // `{ ['hi there': ->` → `{ ['hi there']: ->`
       //                                     ^
       this.insert(this.key.outerEnd, ']');
@@ -109,7 +109,7 @@ export default class ObjectBodyMemberPatcher extends NodePatcher {
   /**
    * @protected
    */
-  isComputed(): boolean {
+  isMethodNameComputed(): boolean {
     return !(this.key instanceof IdentifierPatcher);
   }
 

--- a/test/object_test.js
+++ b/test/object_test.js
@@ -318,4 +318,30 @@ describe('objects', () => {
       ;
     `);
   });
+
+  it('adds brackets around template literals', () => {
+    check(`
+      {"a#{b}c": d}
+    `, `
+      ({[\`a\${b}c\`]: d});
+    `);
+  });
+
+  it('adds brackets around multiline herestrings', () => {
+    check(`
+      {"""a
+      b""": c}
+    `, `
+      ({[\`a
+      b\`]: c});
+    `);
+  });
+
+  it('special-cases template literals with only a single expression', () => {
+    check(`
+      {"#{a.b}": c}
+    `, `
+      ({[a.b]: c});
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #411

In most cases, object keys in CoffeeScript are just regular strings or
identifiers, so we can just patch them normally. But for template strings and
multiline herestrings, we need to put brackets around the string since those
types of object keys aren't allowed in JS. Also, for the specific case of a
template literal key with only a single expression, it's useful to just convert
that expression directly to the computed key form.