### PR TITLE
fix: allow throw statements containing a newline

### DIFF
--- a/src/stages/main/patchers/ThrowPatcher.js
+++ b/src/stages/main/patchers/ThrowPatcher.js
@@ -1,5 +1,6 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
 import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import { THROW } from 'coffee-lex';
 
 export default class ThrowPatcher extends NodePatcher {
   expression: NodePatcher;
@@ -53,6 +54,14 @@ export default class ThrowPatcher extends NodePatcher {
   }
 
   patchAsStatement() {
+    let throwToken = this.sourceTokenAtIndex(this.contentStartTokenIndex);
+    if (throwToken.type !== THROW) {
+      this.error('Expected to find throw token at the start of throw statement.');
+    }
+    let spacing = this.slice(throwToken.end, this.expression.outerStart);
+    if (spacing.indexOf('\n') !== -1) {
+      this.overwrite(throwToken.end, this.expression.outerStart, ' ');
+    }
     this.expression.patch();
   }
 

--- a/test/throw_test.js
+++ b/test/throw_test.js
@@ -50,4 +50,22 @@ describe('throw', () => {
       () => { if (a) { throw b; } };
     `);
   });
+
+  it('allows multiline throw statements', () => {
+    check(`
+      throw
+        a
+    `, `
+      throw a;
+    `);
+  });
+
+  it('allows multiline throw expressions', () => {
+    check(`
+      (throw
+        a)
+    `, `
+      (() => { throw a; })();
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #503

Apparently CoffeeScript lets you put a newline between throw and the error,
while JavaScript doesn't. To fix, just remove that spacing if necessary. Note
that this can sometimes end up removing comments, so ideally we would find a
place to move them, but this seems like an unlikely place to put a comment in a
case that already seems relatively rare, so this is probably fine for now.