### PR TITLE
fix: place `arguments...` in the right place for implicit super calls

### DIFF
--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.js
@@ -19,7 +19,7 @@ export default class FunctionApplicationPatcher extends NodePatcher {
     this.fn.patch();
 
     if (this.isImplicitSuper()) {
-      this.insert(this.fn.outerEnd, '(arguments...)');
+      this.insert(this.fn.contentEnd, '(arguments...)');
       return;
     }
 

--- a/test/super_test.js
+++ b/test/super_test.js
@@ -23,7 +23,7 @@ describe('super', () => {
   });
 
   // https://github.com/decaffeinate/decaffeinate/issues/375
-  it.skip('can be used as an argument to another call', () => {
+  it('can be used as an argument to another call', () => {
     check(`
       class A
         b: ->


### PR DESCRIPTION
Fixes #375

The code was placed at outerEnd, past the enclosing function call parens, when
it should have been placed at contentEnd.