### PR TITLE
fix: properly insert break statements in switches with conditionals

### DIFF
--- a/src/stages/main/patchers/SwitchCasePatcher.js
+++ b/src/stages/main/patchers/SwitchCasePatcher.js
@@ -55,7 +55,8 @@ export default class SwitchCasePatcher extends NodePatcher {
     let hasBreak = this.getBreakToken() !== null;
     let implicitReturnWillBreak = (
       this.implicitlyReturns() &&
-      this.implicitReturnWillBreak()
+      this.implicitReturnWillBreak() &&
+      (!this.consequent || this.consequent.allCodePathsPresent())
     );
     let shouldAddBreak = !hasBreak && !implicitReturnWillBreak;
     if (shouldAddBreak) {

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -340,4 +340,32 @@ describe('switch', () => {
       } })());
     `);
   });
+
+  it('inserts break statements properly in cases containing returns', () => {
+    check(`
+      ->
+        switch a
+          when b
+            if c
+              return d
+          when e
+            if f
+              return g
+    `, `
+      (function() {
+        switch (a) {
+          case b:
+            if (c) {
+              return d;
+            }
+            break;
+          case e:
+            if (f) {
+              return g;
+            }
+            break;
+        }
+      });
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #449

The switch case code was assuming that because the consequent was in an implicit
return context, the code would return and no break was necessary. However,
that's not always true; in a conditional, there may be missing code paths,
meaning that no implicit return happens, so we need to also make sure that all
code paths exist.