### PR TITLE
fix: properly set patching bounds for new and soaked function call operations

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -367,7 +367,7 @@ export default class NodePatcher {
     // comma/paren to the next comma/paren), so loosen the restriction to the
     // entire function.
     if (boundingPatcher.parent &&
-        boundingPatcher.parent.node.type === 'FunctionApplication') {
+        this.isNodeFunctionApplication(boundingPatcher.parent.node)) {
       boundingPatcher = boundingPatcher.parent;
     }
     if (this.allowPatchingOuterBounds()) {
@@ -803,7 +803,7 @@ export default class NodePatcher {
     if (this.isSurroundedByParentheses()) {
       return this;
     } else if (this.parent) {
-      if (this.parent.node.type === 'FunctionApplication' &&
+      if (this.isNodeFunctionApplication(this.parent.node) &&
           this.parent.node.arguments.some(arg => arg === this.node)) {
         return this;
       }
@@ -811,6 +811,12 @@ export default class NodePatcher {
     } else {
       return this;
     }
+  }
+
+  isNodeFunctionApplication(node) {
+    return node.type === 'FunctionApplication' ||
+        node.type === 'SoakedFunctionApplication' ||
+        node.type === 'NewOp';
   }
 
   /**

--- a/test/new_op_test.js
+++ b/test/new_op_test.js
@@ -51,4 +51,21 @@ describe('`new` operator', () => {
       });
     `);
   });
+
+  it('defines proper bounds for new operators', () => {
+    check(`
+      new Construct a, 
+        a: [
+          'abc'
+          'def'
+        ]
+    `, `
+      new Construct(a, { 
+        a: [
+          'abc',
+          'def'
+        ]
+      });
+    `);
+  });
 });

--- a/test/soaked_test.js
+++ b/test/soaked_test.js
@@ -443,4 +443,20 @@ describe('soaked expressions', () => {
       }
     `);
   });
+
+  it('properly sets patching bounds for soaked function applications', () => {
+    check(`
+      f?(a, 
+        b: c
+        d: e)
+    `, `
+      __guardFunc__(f, f => f(a, { 
+        b: c,
+        d: e
+      }));
+      function __guardFunc__(func, transform) {
+        return typeof func === 'function' ? transform(func) : undefined;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #501

This is similar to #445, but that change tested exactly for the
`FunctionApplication` node (we can't reference patchers because `NodePatcher`
is independent of stage). But really, this happens in any case where we have an
argument list, so we need to broaden it to include new operations and soaked
function applications.