### PR TITLE
fix: always patch the target in for-of loops

### DIFF
--- a/src/stages/main/patchers/ForOfPatcher.js
+++ b/src/stages/main/patchers/ForOfPatcher.js
@@ -17,16 +17,22 @@ export default class ForOfPatcher extends ForPatcher {
 
     this.removeOwnTokenIfExists();
 
-    if (this.requiresExtractingTarget()) {
+    let shouldExtractTarget = this.requiresExtractingTarget();
+    if (shouldExtractTarget) {
       this.insert(
         this.innerStart,
         `${this.getTargetReference()} = ${this.getTargetCode()}\n${this.getLoopIndent()}`
       );
-      this.overwrite(this.target.outerStart, this.target.outerEnd, this.getTargetReference());
     }
 
     let keyBinding = this.getIndexBinding();
     this.insert(keyAssignee.outerStart, '(');
+
+    // Patch the target. Also get a reference in case we need it.
+    let targetReference = this.getTargetReference();
+    if (shouldExtractTarget) {
+      this.overwrite(this.target.outerStart, this.target.outerEnd, targetReference);
+    }
 
     let { valAssignee } = this;
 

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1016,4 +1016,15 @@ describe('for loops', () => {
       }
     `);
   });
+
+  it('properly patches the target in for-of loops', () => {
+    check(`
+      for a of @b
+        c
+    `, `
+      for (let a in this.b) {
+        c;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #538

In PR #518, I changed the `getTargetReference` call in for-of loops to be under
a conditional, which meant that in some cases (when the target was repeatable),
the target wouldn't be patched at all. To fix, we can just always patch the
target, but only sometimes overwrite the actual target code with the reference.