### PR TITLE
fix: properly place the implicit close-paren for multiline calls

### DIFF
--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.js
@@ -64,8 +64,11 @@ export default class FunctionApplicationPatcher extends NodePatcher {
    * close-paren properly-indented on its own line.
    */
   insertImplicitCloseParen() {
+    let argListCode = this.slice(
+      this.args[0].contentStart, this.args[this.args.length - 1].contentEnd);
+    let isArgListMultiline = argListCode.indexOf('\n') !== -1;
     let lastTokenType = this.lastToken().type;
-    if (!this.isMultiline() || lastTokenType === RBRACE || lastTokenType === RBRACKET) {
+    if (!isArgListMultiline || lastTokenType === RBRACE || lastTokenType === RBRACKET) {
       this.insert(this.contentEnd, ')');
       return;
     }

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -558,4 +558,20 @@ describe('function calls', () => {
       });
     `);
   });
+
+  it('properly places implicit parens for multiline method calls', () => {
+    check(`
+      a
+        .b(c, ->
+          d
+            .e f
+        )
+    `, `
+      a
+        .b(c, () =>
+          d
+            .e(f)
+        );
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #540

CoffeeScript expects that if an argument list is just one line, then the
close-paren is also on that line. I mostly already handled that case by checking
if the function call node was multiline, but really I needed to be more careful
and check the argument list specifically, since sometimes the function
expression itself can span multiple lines while the argument list is only one
one line.