### PR TITLE
fix: use expression patching for existence assign ops with soaks

### DIFF
--- a/test/compound_assignment_test.js
+++ b/test/compound_assignment_test.js
@@ -452,6 +452,17 @@ describe('compound assignment', () => {
       `);
     });
 
+    it('handles existence assignment with a soak lhs', () => {
+      check(`
+        a.b?.c ?= d
+      `, `
+        __guard__(a.b, x => x.c != null ? a.b.c : (a.b.c = d));
+        function __guard__(value, transform) {
+          return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+        }
+      `);
+    });
+
     it('patches children', () => {
       check(`
         (a or b).c or= d or e


### PR DESCRIPTION
Fixes #512

Existence assignment ops assume that if we're patching as a statement, we can
remain a statement (and thus change to an `if` statement), but the `__guard__`
approach to soak operations assumes that an assignment can have parens wrapped
around it. To avoid this conflict, we can have the existence assignment code
look ahead to see if there's a soak operation, and just do an expression-style
patch in that case. Since this should be a relatively rare case, the main goal
here is to just make sure the result is correct.