### PR TITLE
fix: properly account for slice ranges ending in 0

### DIFF
--- a/test/slice_test.js
+++ b/test/slice_test.js
@@ -19,12 +19,16 @@ describe('slice', () => {
     check(`a[0..2]`, `a.slice(0, 3);`);
   });
 
+  it('changes inclusive slices ending in -1 to not specify a second argument', () => {
+    check(`a[0..-1]`, `a.slice(0);`);
+  });
+
   it('changes inclusive slices with a literal float end of range to exclusive by inserting `+ 1`', () => {
-    check(`a[0..2.0]`, `a.slice(0, 2.0 + 1);`);
+    check(`a[0..2.0]`, `a.slice(0, 2.0 + 1 || undefined);`);
   });
 
   it('changes inclusive slices with a variable end of range to exclusive by inserting `+ 1`', () => {
-    check(`a[0..b]`, `a.slice(0, b + 1);`);
+    check(`a[0..b]`, `a.slice(0, b + 1 || undefined);`);
   });
 
   it('changes slices with no begin or end of the range to a bare call to `.slice`', () => {


### PR DESCRIPTION
Fixes #524

In an expression like `a[b..-1]`, it's incorrect to use 0 as the second slice
arg, since that refers to the start of the string, not the end. Instead, we want
to just omit the second arg. In the more general case where the right side is a
variable, we need to add `|| undefined` so that if the result is 0, we
effectively pass no arg to the function.