### PR TITLE
fix: improve error reporting in esnext failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "decaffeinate-coffeescript": "^1.10.0-patch5",
     "decaffeinate-parser": "^2.0.2",
     "detect-indent": "^4.0.0",
-    "esnext": "^3.0.0",
+    "esnext": "^3.0.1",
     "lines-and-columns": "^1.1.5",
     "magic-string": "^0.16.0",
     "repeating": "^2.0.0"


### PR DESCRIPTION
esnext now exposes a `source` field on exceptions with the relevant source code
when the failure happened, so use that so we have better context on the error,
particularly in the repl.