### PR TITLE
feat: implement bound generator functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "babylon": "^6.12.0",
     "coffee-lex": "^1.4.4",
     "decaffeinate-coffeescript": "^1.10.0-patch5",
-    "decaffeinate-parser": "^2.0.2",
+    "decaffeinate-parser": "^2.1.0",
     "detect-indent": "^4.0.0",
-    "esnext": "^3.0.1",
+    "esnext": "^3.0.6",
     "lines-and-columns": "^1.1.5",
     "magic-string": "^0.16.0",
     "repeating": "^2.0.0"

--- a/src/stages/main/index.js
+++ b/src/stages/main/index.js
@@ -4,6 +4,7 @@ import BinaryOpPatcher from './patchers/BinaryOpPatcher.js';
 import BlockPatcher from './patchers/BlockPatcher.js';
 import BoolPatcher from './patchers/BoolPatcher.js';
 import BoundFunctionPatcher from './patchers/BoundFunctionPatcher.js';
+import BoundGeneratorFunctionPatcher from './patchers/BoundGeneratorFunctionPatcher.js';
 import ChainedComparisonOpPatcher from './patchers/ChainedComparisonOpPatcher.js';
 import ClassAssignOpPatcher from './patchers/ClassAssignOpPatcher.js';
 import ClassPatcher from './patchers/ClassPatcher.js';
@@ -132,6 +133,9 @@ export default class MainStage extends TransformCoffeeScriptStage {
 
       case 'BoundFunction':
         return BoundFunctionPatcher;
+
+      case 'BoundGeneratorFunction':
+        return BoundGeneratorFunctionPatcher;
 
       case 'Bool':
         return BoolPatcher;

--- a/src/stages/main/patchers/BoundGeneratorFunctionPatcher.js
+++ b/src/stages/main/patchers/BoundGeneratorFunctionPatcher.js
@@ -1,16 +1,13 @@
-import FunctionPatcher from './FunctionPatcher.js';
+import ManuallyBoundFunctionPatcher from './ManuallyBoundFunctionPatcher.js';
 
-/**
- * Handles generator functions, i.e. produced by embedding `yield` statements.
- */
-export default class GeneratorFunctionPatcher extends FunctionPatcher {
+export default class BoundGeneratorFunctionPatcher extends ManuallyBoundFunctionPatcher {
   patchFunctionStart({ method=false }) {
     let arrow = this.getArrowToken();
 
     if (!method) {
       this.insert(this.contentStart, 'function*');
     }
-    
+
     if (!this.hasParamStart()) {
       this.insert(this.contentStart, '() ');
     }

--- a/src/stages/main/patchers/ClassAssignOpPatcher.js
+++ b/src/stages/main/patchers/ClassAssignOpPatcher.js
@@ -1,5 +1,6 @@
 import ClassBoundMethodFunctionPatcher from './ClassBoundMethodFunctionPatcher.js';
 import IdentifierPatcher from './IdentifierPatcher.js';
+import ManuallyBoundFunctionPatcher from './ManuallyBoundFunctionPatcher.js';
 import MemberAccessOpPatcher from './MemberAccessOpPatcher.js';
 import ObjectBodyMemberPatcher from './ObjectBodyMemberPatcher.js';
 import ThisPatcher from './ThisPatcher.js';
@@ -102,7 +103,19 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
   isBoundInstanceMethod(): boolean {
     return (
       !this.isStaticMethod() &&
-      this.expression.node.type === 'BoundFunction'
+      (this.expression.node.type === 'BoundFunction' ||
+        this.expression.node.type === 'BoundGeneratorFunction')
     );
+  }
+
+  /**
+   * For classes, unlike in objects, manually bound methods can use regular
+   * method syntax because the bind happens in the constructor.
+   *
+   * @protected
+   */
+  isMethod(): boolean {
+    return this.expression instanceof ManuallyBoundFunctionPatcher ||
+      super.isMethod();
   }
 }

--- a/src/stages/main/patchers/ManuallyBoundFunctionPatcher.js
+++ b/src/stages/main/patchers/ManuallyBoundFunctionPatcher.js
@@ -6,8 +6,19 @@ import FunctionPatcher from './FunctionPatcher.js';
 export default class ManuallyBoundFunctionPatcher extends FunctionPatcher {
   patchAsStatement(options={}) {
     this.insert(this.contentStart, '(');
-    this.patchAsExpression(options);
+    super.patchAsExpression(options);
     this.insert(this.contentEnd, '.bind(this))');
+  }
+
+  patchAsExpression(options={}) {
+    super.patchAsExpression(options);
+    // If we're instructed to patch as a method, then it won't be legal to add
+    // `.bind(this)`, so skip that step. Calling code is expected to bind us
+    // some other way. In practice, this happens when patching class methods;
+    // code will be added to the constructor to bind the method properly.
+    if (!options.method) {
+      this.insert(this.contentEnd, '.bind(this)');
+    }
   }
 
   expectedArrowType(): string {

--- a/src/stages/normalize/patchers/ClassPatcher.js
+++ b/src/stages/normalize/patchers/ClassPatcher.js
@@ -108,7 +108,8 @@ export default class ClassPatcher extends NodePatcher {
     if (this.isClassAssignment(patcher.node)) {
       if (patcher.node.expression.type === 'Function' ||
           patcher.node.expression.type === 'BoundFunction' ||
-          patcher.node.expression.type === 'GeneratorFunction') {
+          patcher.node.expression.type === 'GeneratorFunction' ||
+          patcher.node.expression.type === 'BoundGeneratorFunction') {
         return true;
       }
     }

--- a/src/utils/traverse.js
+++ b/src/utils/traverse.js
@@ -47,6 +47,7 @@ const ORDER = {
   Block: ['statements'],
   Bool: [],
   BoundFunction: ['parameters', 'body'],
+  BoundGeneratorFunction: ['parameters', 'body'],
   Break: [],
   ChainedComparisonOp: ['expression'],
   Class: ['nameAssignee', 'parent', 'body'],


### PR DESCRIPTION
Fixes #516

Generally bound generator functions can be converted to regular `function`
expressions with `.bind(this)` at the end, but there are various edge cases like
when the function is in an object or class body.

Also fix some issues with fat arrow functions referencing `arguments` not always
having `this` bound.