### PR TITLE
fix: properly handle code with Windows newlines or mixed newline style

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ import SemicolonsStage from './stages/semicolons/index.js';
 import EsnextStage from './stages/esnext/index.js';
 import MainStage from './stages/main/index.js';
 import NormalizeStage from './stages/normalize/index.js';
+import convertNewlines from './utils/convertNewlines.js';
+import detectNewlineStr from './utils/detectNewlineStr.js';
 import formatCoffeeLexAst from './utils/formatCoffeeLexTokens.js';
 import formatCoffeeScriptAst from './utils/formatCoffeeScriptAst.js';
 import formatCoffeeScriptLexerTokens from './utils/formatCoffeeScriptLexerTokens.js';
@@ -35,6 +37,8 @@ type Stage = {
  * and formatting.
  */
 export function convert(source: string, options: ?Options={}): ConversionResult {
+  let originalNewlineStr = detectNewlineStr(source);
+  source = convertNewlines(source, '\n');
   let stages = [
     NormalizeStage,
     MainStage,
@@ -51,7 +55,9 @@ export function convert(source: string, options: ?Options={}): ConversionResult 
       return convertCustomStage(source, runToStage);
     }
   }
-  return runStages(source, options.filename || 'input.coffee', stages);
+  let result = runStages(source, options.filename || 'input.coffee', stages);
+  result.code = convertNewlines(result.code, originalNewlineStr);
+  return result;
 }
 
 function runStages(initialContent: string, initialFilename: string, stages: Array<Stage>): ConversionResult {

--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -722,7 +722,7 @@ export default class NodePatcher {
    * Determines whether this patcher's node spanned multiple lines.
    */
   isMultiline(): boolean {
-    return !this.node.virtual && /[\r\n]/.test(this.getOriginalSource());
+    return !this.node.virtual && /\n/.test(this.getOriginalSource());
   }
 
   /**
@@ -899,9 +899,9 @@ export default class NodePatcher {
     // See if there are already non-whitespace characters before the start. If
     // so, skip the start to the next line, since we don't want to put
     // indentation in the middle of a line.
-    for (let i = start - 1; i >= 0 && source[i] !== '\n' && source[i] !== '\r'; i--) {
+    for (let i = start - 1; i >= 0 && source[i] !== '\n'; i--) {
       if (source[i] !== '\t' && source[i] !== ' ') {
-        while (start < end && source[start] !== '\r' && source[start] !== '\n') {
+        while (start < end && source[start] !== '\n') {
           start++;
         }
         break;
@@ -912,7 +912,6 @@ export default class NodePatcher {
     for (let i = start; i < end; i++) {
       switch (source[i]) {
         case '\n':
-        case '\r':
           hasIndentedThisLine = false;
           break;
 

--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.js
@@ -27,7 +27,7 @@ export default class FunctionApplicationPatcher extends NodePatcher {
       let firstArg = args[0];
       let hasOneArg = args.length === 1;
       let firstArgIsOnNextLine = !firstArg ? false :
-        /[\r\n]/.test(this.context.source.slice(this.fn.outerEnd, firstArg.outerStart));
+        /\n/.test(this.context.source.slice(this.fn.outerEnd, firstArg.outerStart));
       let funcEnd = this.getFuncEnd();
       if ((hasOneArg && firstArg.node.virtual) || firstArgIsOnNextLine) {
         this.insert(funcEnd, '(');

--- a/src/utils/convertNewlines.js
+++ b/src/utils/convertNewlines.js
@@ -1,0 +1,16 @@
+/**
+ * Convert the given code to use the specified newline string, either '\n' or
+ * '\r\n'.
+ *
+ * @flow
+ */
+export default function convertNewlines(source: string, newlineStr: string): string {
+  if (newlineStr === '\n') {
+    return source.replace(/\r\n/g, '\n');
+  } else if (newlineStr === '\r\n') {
+    source = source.replace(/\r\n/g, '\n');
+    return source.replace(/\n/g, '\r\n');
+  } else {
+    throw new Error(`Unexpected newling string to convert to: ${JSON.stringify(newlineStr)}`);
+  }
+}

--- a/src/utils/detectNewlineStr.js
+++ b/src/utils/detectNewlineStr.js
@@ -1,0 +1,19 @@
+/**
+ * Determine the most common newline string in the given code, either '\n' or
+ * '\r\n'. Prefer '\n' in the case of a tie.
+ *
+ * @flow
+ */
+export default function detectNewlineStr(source: string): string {
+  let numLFs = 0;
+  let numCRLFs = 0;
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === '\n' && (i === 0 || source[i - 1] !== '\r')) {
+      numLFs++;
+    }
+    if (source.slice(i, i + 2) === '\r\n') {
+      numCRLFs++;
+    }
+  }
+  return numCRLFs > numLFs ? '\r\n' : '\n';
+}

--- a/src/utils/getStartOfLine.js
+++ b/src/utils/getStartOfLine.js
@@ -5,16 +5,8 @@
  */
 export default function getStartOfLine(source: string, offset: number): number {
   let lfIndex = source.lastIndexOf('\n', offset - 1);
-
   if (lfIndex < 0) {
-    let crIndex = source.lastIndexOf('\r', offset - 1);
-
-    if (crIndex < 0) {
-      return 0;
-    }
-
-    return crIndex + 1;
+    return 0;
   }
-
   return lfIndex + 1;
 }

--- a/test/newline_test.js
+++ b/test/newline_test.js
@@ -1,0 +1,24 @@
+import check from './support/check.js';
+
+describe('newlines', () => {
+  it('handles code with Windows newlines', () => {
+    check(
+      '->\r\n  if a\r\n    b\r\n  return\r\n',
+      '(function() {\r\n  if (a) {\r\n    b;\r\n  }\r\n});\r\n'
+    );
+  });
+
+  it('handles code with mixed newlines, preferring UNIX when there is a tie', () => {
+    check(
+      '->\r\n  if a\n    b\n  return\r\n',
+      '(function() {\n  if (a) {\n    b;\n  }\n});\n'
+    );
+  });
+
+  it('handles code with UNIX newlines', () => {
+    check(
+      '->\n  if a\n    b\n  return\n',
+      '(function() {\n  if (a) {\n    b;\n  }\n});\n'
+    );
+  });
+});

--- a/test/utils/convertNewlines_test.js
+++ b/test/utils/convertNewlines_test.js
@@ -1,0 +1,12 @@
+import convertNewlines from '../../src/utils/convertNewlines.js';
+import { strictEqual } from 'assert';
+
+describe('convertNewlines', () => {
+  it('converts mixed newlines to LF', () => {
+    strictEqual(convertNewlines('a\r\nb\nc\nd\r\ne', '\n'), 'a\nb\nc\nd\ne');
+  });
+
+  it('converts mixed newlines to CRLF', () => {
+    strictEqual(convertNewlines('a\r\nb\nc\nd\r\ne', '\r\n'), 'a\r\nb\r\nc\r\nd\r\ne');
+  });
+});

--- a/test/utils/detectNewlineStr_test.js
+++ b/test/utils/detectNewlineStr_test.js
@@ -1,0 +1,20 @@
+import detectNewlineStr from '../../src/utils/detectNewlineStr.js';
+import { strictEqual } from 'assert';
+
+describe('detectNewlineStr', () => {
+  it('detects LF on a string without newlines', () => {
+    strictEqual(detectNewlineStr('abc'), '\n');
+  });
+
+  it('detects LF when it is more common', () => {
+    strictEqual(detectNewlineStr('a\nb\nc\r\nd'), '\n');
+  });
+
+  it('detects LF when there is a tie', () => {
+    strictEqual(detectNewlineStr('a\nb\r\nc'), '\n');
+  });
+
+  it('detects CRLF when it is more common', () => {
+    strictEqual(detectNewlineStr('a\r\nb\nc\r\nd'), '\r\n');
+  });
+});

--- a/test/utils/getIndent_test.js
+++ b/test/utils/getIndent_test.js
@@ -39,18 +39,6 @@ describe('getIndent', function() {
       }
     });
 
-    it('returns the indent for lines split by carriage returns', () => {
-      let i;
-
-      for (i = 0; i < '  abc'.length; i++) {
-        strictEqual(getIndent('  abc\rdef', i), '  ');
-      }
-
-      for (i = '  abc\r'.length; i < '  abc\rdef'.length; i++) {
-        strictEqual(getIndent('  abc\rdef', i), '');
-      }
-    });
-
     it('considers newlines as part of the previous line', () => {
       strictEqual(getIndent('a\n  b: c', 1), '');
     });


### PR DESCRIPTION
Fixes #550

We convert the newline style to \n at the start, then convert it to its original
style at the end. That way, decaffeinate can detect and generate \n newlines
without having to worry about the different styles.

There are some libraries out there for detecting and converting newline styles,
but they're a bit more complicated than I need and don't behave exactly the way
I want, and both operations are pretty easy to implement.

This change also means that we can simplify some of the code that was handling
CR characters. Generally, any code now can assume that '\n' is the only type of
newline.

Note that I don't make any attempt at supporting CR newlines. Hopefully Mac OS 9
is far enough in the past that we don't need to have to think about it.