### PR TITLE
fix: in switch cases, defer negation until just before patching

### DIFF
--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -234,6 +234,25 @@ describe('switch', () => {
     `);
   });
 
+  it('converts a switch without an expression with function call cases', () => {
+    check(`
+      switch
+        when a()
+          'B'
+        when c()
+          'D'
+    `, `
+      switch (false) {
+        case !a():
+          'B';
+          break;
+        case !c():
+          'D';
+          break;
+      }
+    `);
+  });
+
   it('works with `switch` used as an expression', () => {
     check(`
       a = switch b


### PR DESCRIPTION
Fixes #562

The switch case patcher does a magic-string remove operation from the start of
the `when` token to the start of the condition. When the condition was negated,
it would sometimes have a `!` inserted at the start that would then be removed
by this remove operation, producing incorrect code. To fix, we can just track
the negation and delay it until just before the conditions are patched.

Generally, this moves code toward the best practice of making sure magic-string
operations happen in order, and a similar strategy may be useful if other
patchers cause issues.