### PR TITLE
fix: respect the isUnless flag when patching a conditional as an expression

### DIFF
--- a/src/stages/main/patchers/ConditionalPatcher.js
+++ b/src/stages/main/patchers/ConditionalPatcher.js
@@ -73,6 +73,10 @@ export default class ConditionalPatcher extends NodePatcher {
       addParens ? '(' : ''
     );
 
+    if (this.node.isUnless) {
+      this.condition.negate();
+    }
+
     this.condition.patch();
 
     let thenTokenIndex = this.getThenTokenIndex();

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -335,6 +335,30 @@ describe('conditionals', () => {
     `);
   });
 
+  it('works with `unless` in an expression context', () => {
+    check(`
+      x = (a unless b)
+    `, `
+      let x = (!b ? a : undefined);
+    `);
+  });
+
+  it('works with `unless` in an object value (#566)', () => {
+    check(`
+      isValid = true
+
+      testing = {
+          test: "Hello world" unless isValid
+      }
+    `, `
+      let isValid = true;
+
+      let testing = {
+          test: !isValid ? "Hello world" : undefined
+      };
+    `);
+  });
+
   it('surrounds the conditional expression in parens as part of a binary expression', () => {
     check(`
       a + if b then c else d


### PR DESCRIPTION
Fixes #566

We negated the condition when `unless` was used in a statement context, but not
when it was used in an expression context.