### PR TITLE
fix: update decaffeinate-parser dependency to keep coffee-lex in sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babylon": "^6.12.0",
     "coffee-lex": "^4.2.0",
     "decaffeinate-coffeescript": "^1.10.0-patch5",
-    "decaffeinate-parser": "^2.1.0",
+    "decaffeinate-parser": "^2.1.1",
     "detect-indent": "^4.0.0",
     "esnext": "^3.0.6",
     "lines-and-columns": "^1.1.5",


### PR DESCRIPTION
decaffeinate and decaffeinate-parser need to share the same coffee-lex instance
or else singleton comparisons will fail, so this commit forces both decaffeinate
and decaffeinate-parser to depend on coffee-lex 4.x so they can use the same
instance.