### PR TITLE
fix: silence magic-string warnings and update usage

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -307,28 +307,7 @@ export default class NodePatcher {
   /**
    * Insert content at the specified index.
    */
-  insertLeft(index: number, content: string) {
-    if (typeof index !== 'number') {
-      throw new Error(
-        `cannot insert ${JSON.stringify(content)} at non-numeric index ${index}`
-      );
-    }
-    this.log(
-      'INSERT LEFT',
-      index,
-      JSON.stringify(content),
-      'AFTER',
-      JSON.stringify(this.context.source.slice(index - 8, index))
-    );
-
-    this.adjustBoundsToInclude(index);
-    this.editor.insertLeft(index, content);
-  }
-
-  /**
-   * Insert content at the specified index.
-   */
-  insertRight(index: number, content: string) {
+  insert(index: number, content: string) {
     if (typeof index !== 'number') {
       throw new Error(
         `cannot insert ${JSON.stringify(content)} at non-numeric index ${index}`
@@ -343,14 +322,7 @@ export default class NodePatcher {
     );
 
     this.adjustBoundsToInclude(index);
-    this.editor.insertLeft(index, content);
-  }
-
-  /**
-   * Alias for `#insertRight`.
-   */
-  insert(index: number, content: string) {
-    this.insertRight(index, content);
+    this.editor.appendLeft(index, content);
   }
 
   allowPatchingOuterBounds(): boolean {

--- a/src/patchers/types.js
+++ b/src/patchers/types.js
@@ -16,8 +16,8 @@ export type ParseContext = {
 };
 
 export type Editor = {
-  insertLeft: (index: number, content: string) => Editor;
-  insertRight: (index: number, content: string) => Editor;
+  appendLeft: (index: number, content: string) => Editor;
+  appendRight: (index: number, content: string) => Editor;
   overwrite: (start: number, end: number, content: string) => Editor;
   remove: (start: number, end: number) => Editor;
   slice: (start: number, end: number) => string;

--- a/src/stages/normalize/patchers/ConditionalPatcher.js
+++ b/src/stages/normalize/patchers/ConditionalPatcher.js
@@ -52,7 +52,7 @@ export default class ConditionalPatcher extends NodePatcher {
     if (ifToken) {
       let consequentCode = this.slice(this.consequent.outerStart, this.consequent.outerEnd);
       this.remove(this.consequent.outerStart, ifToken.start);
-      this.insertRight(this.condition.outerEnd, ` then ${consequentCode}`);
+      this.insert(this.condition.outerEnd, ` then ${consequentCode}`);
     }
   }
 

--- a/src/stages/semicolons/index.js
+++ b/src/stages/semicolons/index.js
@@ -33,7 +33,7 @@ export default class SemicolonsStage {
 
     asi(config);
 
-    config.insertions.forEach(({ index, content }) => editor.insertLeft(index, content));
+    config.insertions.forEach(({ index, content }) => editor.appendLeft(index, content));
     config.removals.forEach(({ start, end }) => editor.remove(start, end));
 
     return {

--- a/src/utils/escape.js
+++ b/src/utils/escape.js
@@ -14,7 +14,7 @@ export default function escape(patcher: MagicString, characters: Array<string>|(
     if (source[i] === '\\') {
       i++;
     } else if (predicate(source[i], i, source)) {
-      patcher.insertRight(i, '\\');
+      patcher.appendRight(i, '\\');
     }
   }
 }


### PR DESCRIPTION
magic-string 0.17.0 deprecated insertLeft and insertRight in favor of more
precise prepend/append names. See this issue for a discussion on that:
https://github.com/Rich-Harris/magic-string/issues/109

To silence that warning, this commit moves the code to the new API, which was
pretty easy because there are only a few call sites.

I also cleaned up that part of `NodePatcher`, which didn't make a lot of sense.
Now, instead of `NodePatcher.insert` calling `NodePatcher.insertRight` calling
`MagicString.insertLeft` and `NodePatcher.insertLeft` being unused, we just
have `NodePatcher.insert` calling `MagicString.appendLeft`. At least for now, I
think it's best to always use the same insert method so that inserts go in
order.

I also changed insertRight to appendRight in one case because it probably makes
more sense anyway and the tests pass.