### PR TITLE
fix: don't crash on empty catch blocks with an exception assignee

### DIFF
--- a/src/stages/main/patchers/TryPatcher.js
+++ b/src/stages/main/patchers/TryPatcher.js
@@ -190,7 +190,7 @@ export default class TryPatcher extends NodePatcher {
    * @private
    */
   getThenTokenIndex(): ?SourceTokenListIndex {
-    if (!this.catchAssignee && !this.catchBody) {
+    if (!this.catchBody) {
       return null;
     }
     return this.indexOfSourceTokenBetweenPatchersMatching(

--- a/test/try_test.js
+++ b/test/try_test.js
@@ -176,4 +176,31 @@ describe('try', () => {
       finally {}
     `);
   });
+
+  it('handles try with an empty catch block with a catch variable', () => {
+    check(`
+      try
+        something()
+      catch err
+    `, `
+      try {
+        something();
+      } catch (err) {}
+    `);
+  });
+
+
+  it('handles try with an empty catch block with a catch variable and an empty finally block', () => {
+    check(`
+      try
+        something()
+      catch err
+      finally
+    `, `
+      try {
+        something();
+      } catch (err) {}
+      finally {}
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #583