### PR TITLE
feat: add an option to disable the conversion from require to import

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,16 @@ are made.
 
 ## Usage
 
-See the output of `decaffeinate --help` after installing.
+```
+$ decaffeinate input.coffee
+input.coffee → input.js
+```
+
+Options:
+* `--keep-commonjs`: Do not convert `require` and `module.exports` to `import`
+  and `export`.
+
+For more usages examples, see the output of `decaffeinate --help`.
 
 [issues]: https://github.com/decaffeinate/decaffeinate/issues
 [conversion-guide]: https://github.com/decaffeinate/decaffeinate/blob/master/docs/conversion-guide.md

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "decaffeinate-coffeescript": "^1.10.0-patch5",
     "decaffeinate-parser": "^4.0.0",
     "detect-indent": "^4.0.0",
-    "esnext": "^3.0.6",
+    "esnext": "^3.0.7",
     "lines-and-columns": "^1.1.5",
     "magic-string": "^0.17.0",
     "repeating": "^2.0.0"

--- a/src/stages/TransformCoffeeScriptStage.js
+++ b/src/stages/TransformCoffeeScriptStage.js
@@ -6,9 +6,11 @@ import type { Node, ParseContext, Editor } from '../patchers/types.js';
 import { basename } from 'path';
 import { childPropertyNames } from '../utils/traverse.js';
 import { logger } from '../utils/debug.js';
+import type { Options } from '../index.js';
 
 export default class TransformCoffeeScriptStage {
-  static run(content: string, filename: string): { code: string, map: Object } {
+  static run(content: string, options: Options): { code: string, map: Object } {
+    let { filename } = options;
     let log = logger(this.name);
     log(content);
 

--- a/src/stages/add-variable-declarations/index.js
+++ b/src/stages/add-variable-declarations/index.js
@@ -2,9 +2,11 @@ import addVariableDeclarations from 'add-variable-declarations';
 import MagicString from 'magic-string';
 import { basename } from 'path';
 import { logger } from '../../utils/debug.js';
+import type { Options } from '../../index.js';
 
 export default class AddVariableDeclarationsStage {
-  static run(content: string, filename: string): { code: string, map: Object } {
+  static run(content: string, options: Options): { code: string, map: Object } {
+    let { filename } = options;
     let log = logger(this.name);
     log(content);
 

--- a/src/stages/esnext/index.js
+++ b/src/stages/esnext/index.js
@@ -1,12 +1,18 @@
-import { convert } from 'esnext';
+import { allPlugins, convert } from 'esnext';
 import { logger } from '../../utils/debug.js';
+import type { Options } from '../../index.js';
 
 export default class EsnextStage {
-  static run(content: string): { code: string } {
+  static run(content: string, options: Options): { code: string } {
     let log = logger(this.name);
     log(content);
+    let plugins = allPlugins;
+    if (options.keepCommonJS) {
+      plugins = plugins.filter(plugin => plugin.name !== 'modules.commonjs');
+    }
 
     let { code } = convert(content, {
+      plugins,
       'declarations.block-scope': {
         disableConst({ node, parent }): boolean {
           return (

--- a/src/stages/semicolons/index.js
+++ b/src/stages/semicolons/index.js
@@ -4,6 +4,7 @@ import buildConfig from 'ast-processor-babylon-config';
 import { basename } from 'path';
 import { logger } from '../../utils/debug.js';
 import { parse } from 'babylon';
+import type { Options } from '../../index.js';
 
 const BABYLON_PLUGINS = [
   'flow',
@@ -23,7 +24,8 @@ const BABYLON_PLUGINS = [
 ];
 
 export default class SemicolonsStage {
-  static run(content: string, filename: string): { code: string, map: Object } {
+  static run(content: string, options: Options): { code: string, map: Object } {
+    let { filename } = options;
     let log = logger(this.name);
     log(content);
 

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -1,0 +1,25 @@
+import check from './support/check.js';
+
+describe('imports', () => {
+  it('converts commonjs code to JS modules by default', () => {
+    check(`
+      x = require('x');
+      module.exports.y = 3;
+    `, `
+      import x from 'x';
+      export let y = 3;
+    `);
+  });
+
+  it('keeps commonjs when the preference is specified', () => {
+    check(`
+      x = require('x');
+      module.exports.y = 3;
+    `, `
+      let x = require('x');
+      module.exports.y = 3;
+    `, {
+      keepCommonJS: true
+    });
+  });
+});

--- a/test/support/check.js
+++ b/test/support/check.js
@@ -3,12 +3,12 @@ import stripSharedIndent from '../../src/utils/stripSharedIndent.js';
 import { convert } from '../../'; // eslint-disable-line decaffeinate/require-import-extension
 import { strictEqual } from 'assert';
 
-export default function check(source, expected) {
+export default function check(source, expected, options={}) {
   if (source[0] === '\n') { source = stripSharedIndent(source); }
   if (expected[0] === '\n') { expected = stripSharedIndent(expected); }
 
   try {
-    let converted = convert(source);
+    let converted = convert(source, options);
     strictEqual(converted.code, expected);
   } catch (err) {
     if (PatchError.detect(err)) {


### PR DESCRIPTION
Fixes #407.

This adds a new command line arg, `--keep-commonjs`, which disables that esnext
transform. To accomplish this, I made it so the decaffeinate options are sent to
every stage instead of just the filename. This should also make it a bit easier
to implement other options in the future.