### PR TITLE
fix: rework the implicit return protocol and fix several bugs with its usage

### DIFF
--- a/src/stages/main/patchers/ConditionalPatcher.js
+++ b/src/stages/main/patchers/ConditionalPatcher.js
@@ -148,6 +148,10 @@ export default class ConditionalPatcher extends NodePatcher {
     this.insert(this.innerEnd, `\n${baseIndent}})()`);
   }
 
+  canHandleImplicitReturn(): boolean {
+    return this.willPatchAsIIFE();
+  }
+
   patchAsStatement() {
     this.patchConditionForStatement();
     this.patchConsequentForStatement();

--- a/src/stages/main/patchers/ForInPatcher.js
+++ b/src/stages/main/patchers/ForInPatcher.js
@@ -95,6 +95,10 @@ export default class ForInPatcher extends ForPatcher {
     return true;
   }
 
+  willPatchAsIIFE(): boolean {
+    return this.willPatchAsExpression() && !this.canPatchAsMapExpression();
+  }
+
   patchAsStatement() {
     if (!this.body.inline()) {
       this.body.setIndent(this.getLoopBodyIndent());

--- a/src/stages/main/patchers/ForOfPatcher.js
+++ b/src/stages/main/patchers/ForOfPatcher.js
@@ -100,4 +100,9 @@ export default class ForOfPatcher extends ForPatcher {
   indexBindingCandidates(): Array<string> {
     return ['key'];
   }
+
+  willPatchAsIIFE(): boolean {
+    return this.willPatchAsExpression();
+  }
 }
+

--- a/src/stages/main/patchers/FunctionPatcher.js
+++ b/src/stages/main/patchers/FunctionPatcher.js
@@ -113,12 +113,8 @@ export default class FunctionPatcher extends NodePatcher {
   hasParamStart(): boolean {
     return this.sourceTokenAtIndex(this.contentStartTokenIndex).type === LPAREN;
   }
-  
-  implicitReturnPatcher(): NodePatcher {
-    return this;
-  }
-  
-  implicitReturnWillBreak(): boolean {
+
+  canHandleImplicitReturn(): boolean {
     return true;
   }
 

--- a/src/stages/main/patchers/LoopPatcher.js
+++ b/src/stages/main/patchers/LoopPatcher.js
@@ -116,6 +116,14 @@ export default class LoopPatcher extends NodePatcher {
     return this.willPatchAsExpression() && this.body.node.inline;
   }
 
+  canHandleImplicitReturn(): boolean {
+    return this.willPatchAsIIFE();
+  }
+
+  willPatchAsIIFE(): boolean {
+    throw this.error(`'willPatchAsIIFE' must be overridden in subclasses`);
+  }
+
   /**
    * Most implicit returns cause program flow to break by using a `return`
    * statement, but we don't do that since we're just collecting values in
@@ -123,24 +131,7 @@ export default class LoopPatcher extends NodePatcher {
    * behavior accordingly.
    */
   implicitReturnWillBreak(): boolean {
-    if (this.willPatchAsExpression()) {
-      return false;
-    } else {
-      return super.implicitReturnWillBreak();
-    }
-  }
-
-  /**
-   * We decide how statements in implicit return positions are patched, if
-   * we're being used as an expression. This is because we don't want to return
-   * them, but add them to an array.
-   */
-  implicitReturnPatcher(): NodePatcher {
-    if (this.willPatchAsExpression()) {
-      return this;
-    } else {
-      return super.implicitReturnPatcher();
-    }
+    return false;
   }
 
   /**

--- a/src/stages/main/patchers/ProgramPatcher.js
+++ b/src/stages/main/patchers/ProgramPatcher.js
@@ -188,14 +188,7 @@ export default class ProgramPatcher extends NodePatcher {
   /**
    * Serve as the implicit return patcher for anyone not included in a function.
    */
-  implicitReturnPatcher(): NodePatcher {
-    return this;
-  }
-
-  /**
-   * Serve as the default for anyone not included in a function.
-   */
-  implicitReturnWillBreak(): boolean {
+  canHandleImplicitReturn(): boolean {
     return true;
   }
 }

--- a/src/stages/main/patchers/SwitchCasePatcher.js
+++ b/src/stages/main/patchers/SwitchCasePatcher.js
@@ -61,7 +61,7 @@ export default class SwitchCasePatcher extends NodePatcher {
     let hasBreak = this.getBreakToken() !== null;
     let implicitReturnWillBreak = (
       this.implicitlyReturns() &&
-      this.implicitReturnWillBreak() &&
+      this.implicitReturnPatcher().implicitReturnWillBreak() &&
       (!this.consequent || this.consequent.allCodePathsPresent())
     );
     let shouldAddBreak = !hasBreak && !implicitReturnWillBreak;

--- a/src/stages/main/patchers/SwitchPatcher.js
+++ b/src/stages/main/patchers/SwitchPatcher.js
@@ -72,6 +72,10 @@ export default class SwitchPatcher extends NodePatcher {
     this.appendToEndOfLine(' })()');
   }
 
+  canHandleImplicitReturn(): boolean {
+    return this.willPatchAsExpression();
+  }
+
   /**
    * @private
    */

--- a/src/stages/main/patchers/WhilePatcher.js
+++ b/src/stages/main/patchers/WhilePatcher.js
@@ -161,4 +161,8 @@ export default class WhilePatcher extends LoopPatcher {
       return this.getOuterLoopBodyIndent();
     }
   }
+
+  willPatchAsIIFE(): boolean {
+    return this.willPatchAsExpression();
+  }
 }

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -546,4 +546,36 @@ describe('conditionals', () => {
       if (a) { (b);} else { c; }
     `)
   );
+
+  it('handles an IIFE conditional within an IIFE for loop', () =>
+    check(`
+      x = for a in b by 1
+        y = 
+          if a
+            if b
+              c
+          else
+            d
+        y
+    `, `
+      let x = (() => {
+        let result = [];
+        for (let i = 0; i < b.length; i++) {
+          let a = b[i];
+          let y = 
+            (() => {
+            if (a) {
+              if (b) {
+                return c;
+              }
+            } else {
+              return d;
+            }
+          })();
+          result.push(y);
+        }
+        return result;
+      })();
+    `)
+  );
 });

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -387,4 +387,50 @@ describe('switch', () => {
       });
     `);
   });
+
+  it('handles switch expressions within simple for expressions', () => {
+    check(`
+      x = for a in b
+        switch a
+          when 'c'
+            d
+          else
+            e
+    `, `
+      let x = b.map((a) =>
+        (() => { switch (a) {
+          case 'c':
+            return d;
+          default:
+            return e;
+        } })());
+    `);
+  });
+
+  it('handles switch expressions within complex for expressions', () => {
+    check(`
+      x = for a in b by 1
+        y = switch a
+          when 'c'
+            d
+          else
+            e
+        y
+    `, `
+      let x = (() => {
+        let result = [];
+        for (let i = 0; i < b.length; i++) {
+          let a = b[i];
+          let y = (() => { switch (a) {
+            case 'c':
+              return d;
+            default:
+              return e;
+          } })();
+          result.push(y);
+        }
+        return result;
+      })();
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #589

Switch expressions and conditional expressions can both be patched as IIFEs, in
which case they get to decide how to handle sub-expressions in an implicit
return position. However, neither of these classes implemented the methods to
declare that they are an implicit return patcher, so the code was using the next
ancestor instead when searching for the implicit return patcher. That meant that
a switch or conditional IIFE within a loop IIFE would include `.push` lines in
the inner IIFE when it shouldn't.

Another issue was that loop patchers were declaring themselves as an implicit
return patcher even when they were patched as a normal expression and not an
IIFE. I'm not aware of any correctness issues this caused, but it seems good to
fix.

To fix, I changed conditional, switch, and loop patchers to all properly declare
when they should decide the behavior of subexpressions in an implicit return
position. I also reworked the protocol to hopefully be a little simpler; any
class just declares when it's an implicit return patcher, and there are a few
other hooks that LoopPatcher uses to provide custom behavior.