### PR TITLE
feat: add an option to prefer const rather than let

### DIFF
--- a/docs/conversion-guide.md
+++ b/docs/conversion-guide.md
@@ -7,7 +7,7 @@ JavaScript using decaffeinate.
 
 This guide assumes a few things:
 
-1. You have Node v0.12 or higher installed.
+1. You have Node v4 or higher installed.
 1. You have a project or set of files that currently compile using the
    official CoffeeScript compiler.
 1. Your project is able to run ES2016 code. In particular, depending on what

--- a/src/cli.js
+++ b/src/cli.js
@@ -44,7 +44,15 @@ function parseArguments(args: Array<string>): CLIOptions {
         baseOptions.keepCommonJS = true;
         break;
 
+      case '--prefer-const':
+        baseOptions.preferConst = true;
+        break;
+
       default:
+        if (arg.startsWith('-')) {
+          console.error(`Error: unrecognized option '${arg}'`);
+          process.exit(1);
+        }
         paths.push(arg);
         break;
     }
@@ -162,6 +170,7 @@ function usage() {
   console.log();
   console.log('  -h, --help       Display this help message.');
   console.log('  --keep-commonjs  Do not convert require and module.exports to import and export.');
+  console.log('  --prefer-const   Use the const keyword for variables when possible.');
   console.log();
   console.log('EXAMPLES');
   console.log();

--- a/src/index.js
+++ b/src/index.js
@@ -21,12 +21,14 @@ export type Options = {
   filename: ?string,
   runToStage: ?string,
   keepCommonJS: ?boolean,
+  preferConst: ?boolean,
 };
 
 const DEFAULT_OPTIONS = {
   filename: 'input.coffee',
   runToStage: null,
   keepCommonJS: false,
+  preferConst: false,
 };
 
 type ConversionResult = {

--- a/src/stages/esnext/index.js
+++ b/src/stages/esnext/index.js
@@ -15,6 +15,9 @@ export default class EsnextStage {
       plugins,
       'declarations.block-scope': {
         disableConst({ node, parent }): boolean {
+          if (options.preferConst) {
+            return false;
+          }
           return (
             // Only use `const` for top-level variables…
             parent && parent.type !== 'Program' ||

--- a/test/declaration_test.js
+++ b/test/declaration_test.js
@@ -140,4 +140,8 @@ describe('declarations', () => {
   it('adds pre-declarations and regular declarations together properly', () => {
     check('a = 1\nb = c = 2', 'let c;\nlet a = 1;\nlet b = c = 2;');
   });
+
+  it('uses const rather than let if specified', () => {
+    check('a = 1', 'const a = 1;', { preferConst: true });
+  });
 });


### PR DESCRIPTION
Fixes #408.

While I'm at it, I made the CLI exit with an error message if it sees an invalid
argument. We've dropped support for node 0.12, so it's safe to use `startsWith`,
but the conversion guide hadn't been updated, so I also updated that.