### PR TITLE
fix: add an "engines" line to require node 4 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "magic-string": "^0.17.0",
     "repeating": "^2.0.0"
   },
+  "engines": {
+    "node": ">=4"
+  },
   "files": [
     "bin",
     "dist"


### PR DESCRIPTION
Unfortunately it looks like this only gives a warning when installing on node
0.12 or earlier, but that's probably better than no warning.