### PR TITLE
fix: rework constructor patching code to better handle bound methods

### DIFF
--- a/src/stages/main/patchers/ConstructorPatcher.js
+++ b/src/stages/main/patchers/ConstructorPatcher.js
@@ -13,36 +13,64 @@ export default class ConstructorPatcher extends ObjectBodyMemberPatcher {
   }
 
   patch(options={}) {
-    super.patch(options);
     let boundMethods = this.parent.boundInstanceMethods();
-    if (boundMethods.length > 0) {
-      let statements = this.expression.body.statements;
-      let indexOfSuperStatement = -1;
-      for (let i = 0; i < statements.length; i++) {
-        let callsSuper = false;
-        traverse(statements[i].node, child => {
-          if (callsSuper) {
-            // Already found it, skip this one.
-            return false;
-          } else if (child.type === 'Super') {
-            // Found it.
-            callsSuper = true;
-          } else if (child.type === 'Class') {
-            // Don't go into other classes.
-            return false;
-          }
-        });
-        if (callsSuper) {
-          indexOfSuperStatement = i;
-          break;
-        }
+    let bindings = boundMethods.map(method => {
+      let key = this.context.source.slice(method.key.contentStart, method.key.contentEnd);
+      return `this.${key} = this.${key}.bind(this)`;
+    });
+
+    if (bindings.length > 0 && this.expression.body) {
+      let indexOfSuperStatement = this.getIndexOfSuperStatement(this.expression.body.statements);
+      // Work around some magic-string issues by carefully deciding patching
+      // order. If we're adding statements to the start, patch the function
+      // first so the statements are patched after the initial function code. If
+      // we're adding statements to the end, patch the function last so we don't
+      // end up adding statements after the close-brace.
+      if (indexOfSuperStatement < 0) {
+        super.patch(options);
+        this.expression.body.insertStatementsAtIndex(bindings, 0);
+      } else {
+        this.expression.body.insertStatementsAtIndex(bindings, indexOfSuperStatement + 1);
+        super.patch(options);
       }
-      let bindings = boundMethods.map(method => {
-        let key = this.context.source.slice(method.key.contentStart, method.key.contentEnd);
-        return `this.${key} = this.${key}.bind(this)`;
-      });
-      this.expression.body.insertStatementsAtIndex(bindings, indexOfSuperStatement + 1);
+    } else if (bindings.length > 0) {
+      super.patch();
+      // As a special case, if there's no function body but we still want to
+      // generate bindings, overwrite the function body with the desired
+      // contents, since it's sort of hard to insert contents in the middle of
+      // the generated {}.
+      let indent = this.getIndent();
+      let bodyIndent = this.getIndent(1);
+      let arrowToken = this.expression.getArrowToken();
+
+      let bindingLines = bindings.map(binding => `${bodyIndent}${binding}\n`);
+      let bodyCode = `{\n${bindingLines.join('')}${indent}}`;
+      this.overwrite(arrowToken.start, this.expression.outerEnd, bodyCode);
+    } else {
+      super.patch(options);
     }
+  }
+
+  getIndexOfSuperStatement(statements) {
+    for (let i = 0; i < statements.length; i++) {
+      let callsSuper = false;
+      traverse(statements[i].node, child => {
+        if (callsSuper) {
+          // Already found it, skip this one.
+          return false;
+        } else if (child.type === 'Super') {
+          // Found it.
+          callsSuper = true;
+        } else if (child.type === 'Class') {
+          // Don't go into other classes.
+          return false;
+        }
+      });
+      if (callsSuper) {
+        return i;
+      }
+    }
+    return -1;
   }
 
   /**

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -656,4 +656,101 @@ describe('classes', () => {
       A.initClass();
     `);
   });
+
+  it('handles a bound method and an implicit super in the constructor', () => {
+    check(`
+      class X
+        constructor: ->
+          super
+      
+        add: =>
+    `, `
+      class X {
+        constructor() {
+          super(...arguments);
+          this.add = this.add.bind(this);
+        }
+      
+        add() {}
+      }
+    `);
+  });
+
+  it('handles a bound method and an empty constructor', () => {
+    check(`
+      class X
+        constructor: ->
+      
+        add: =>
+    `, `
+      class X {
+        constructor() {
+          this.add = this.add.bind(this);
+        }
+      
+        add() {}
+      }
+    `);
+  });
+
+  it('handles a bound method and an empty constructor with a parameter', () => {
+    check(`
+      class X
+        constructor: (a, b) ->
+      
+        add: =>
+    `, `
+      class X {
+        constructor(a, b) {
+          this.add = this.add.bind(this);
+        }
+      
+        add() {}
+      }
+    `);
+  });
+
+  it('places method bindings after the super call', () => {
+    check(`
+      class X
+        constructor: ->
+          if a
+            b
+          super
+          if c
+            d
+      
+        add: =>
+    `, `
+      class X {
+        constructor() {
+          if (a) {
+            b;
+          }
+          super(...arguments);
+          this.add = this.add.bind(this);
+          if (c) {
+            d;
+          }
+        }
+      
+        add() {}
+      }
+    `);
+  });
+
+  it('places method bindings at the start of the constructor if there is no super', () => {
+    check(`
+      class X
+        constructor: ->a
+      
+        add: =>
+    `, `
+      class X {
+        constructor() {this.add = this.add.bind(this);   a; }
+      
+        add() {}
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #596
Fixes #597

When patching constructors when there are bound methods, we need to insert code
after the super statement, if there is one. This is inherently a bit fragile,
since magic-string works best when all code is patched in order. Previously, we
were patching the method body, then inserting the bindings, but that could cause
the new statements to be inserted after the `}`. To fix this, I made the code
smarter about patching order: it patches the function either before or after the
inserted statements to avoid interfering with the start or end. This solution
feels a bit hacky, but at least for now seems nicer than trying to actually
force everything to patch in order.

Also, the code was assuming that the body was non-null, so I added a special
case with a null body where we overwrite the method body with the proper
contents.