### PR TITLE
refactor: consolidate patcher constructor args into a PatcherContext type

### DIFF
--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -238,11 +238,11 @@ This time, however, we have children that will be passed to our constructor (see
 
 ```js
 import NodePatcher from './NodePatcher.js';
-import type { Node, ParseContext, Editor } from './types.js';
+import type { PatcherContext } from './types.js';
 
 export default class PlusOpPatcher extends NodePatcher {
-  constructor(node: Node, context: ParseContext, editor: Editor, left: NodePatcher, right: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, left: NodePatcher, right: NodePatcher) {
+    super(patcherContext);
     this.left = left;
     this.right = right;
   }
@@ -255,11 +255,11 @@ with `BoolPatcher` above.
 
 ```js
 import NodePatcher from './NodePatcher.js';
-import type { Node, ParseContext, Editor } from './types.js';
+import type { PatcherContext } from './types.js';
 
 export default class PlusOpPatcher extends NodePatcher {
-  constructor(node: Node, context: ParseContext, editor: Editor, left: NodePatcher, right: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, left: NodePatcher, right: NodePatcher) {
+    super(patcherContext);
     this.left = left;
     this.right = right;
   }
@@ -280,11 +280,11 @@ delegate to them.
 
 ```js
 import NodePatcher from './NodePatcher.js';
-import type { Node, ParseContext, Editor } from './types.js';
+import type { PatcherContext } from './types.js';
 
 export default class PlusOpPatcher extends NodePatcher {
-  constructor(node: Node, context: ParseContext, editor: Editor, left: NodePatcher, right: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, left: NodePatcher, right: NodePatcher) {
+    super(patcherContext);
     this.left = left;
     this.right = right;
   }
@@ -308,11 +308,11 @@ our children that they must be expressions, which we do in `initialize`.
 
 ```js
 import NodePatcher from './NodePatcher.js';
-import type { Node, ParseContext, Editor } from './types.js';
+import type { PatcherContext } from './types.js';
 
 export default class PlusOpPatcher extends NodePatcher {
-  constructor(node: Node, context: ParseContext, editor: Editor, left: NodePatcher, right: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, left: NodePatcher, right: NodePatcher) {
+    super(patcherContext);
     this.left = left;
     this.right = right;
   }
@@ -345,11 +345,11 @@ delegate to `patchAsExpression`, which is the default behavior.
 
 ```js
 import NodePatcher from './NodePatcher.js';
-import type { Node, ParseContext, Editor } from './types.js';
+import type { PatcherContext } from './types.js';
 
 export default class PlusOpPatcher extends NodePatcher {
-  constructor(node: Node, context: ParseContext, editor: Editor, left: NodePatcher, right: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, left: NodePatcher, right: NodePatcher) {
+    super(patcherContext);
     this.left = left;
     this.right = right;
   }

--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -1,7 +1,7 @@
 import PatcherError from '../utils/PatchError.js';
 import adjustIndent from '../utils/adjustIndent.js';
 import repeat from 'repeating';
-import type { SourceType, SourceToken, SourceTokenListIndex, Editor, Node, ParseContext, SourceTokenList } from './types.js';
+import type { SourceType, SourceToken, SourceTokenListIndex, PatcherContext, SourceTokenList } from './types.js';
 import { CALL_START, CALL_END, LPAREN, RPAREN } from 'coffee-lex';
 import { isSemanticToken } from '../utils/types.js';
 import { logger } from '../utils/debug.js';
@@ -28,7 +28,7 @@ export default class NodePatcher {
 
   adjustedIndentLevel: number = 0;
 
-  constructor(node: Node, context: ParseContext, editor: Editor) {
+  constructor({node, context, editor}: PatcherContext) {
     this.log = logger(this.constructor.name);
 
     this.node = node;

--- a/src/patchers/PassthroughPatcher.js
+++ b/src/patchers/PassthroughPatcher.js
@@ -1,11 +1,11 @@
 import NodePatcher from './NodePatcher.js';
-import type { Editor, Node, ParseContext } from './types.js';
+import type { PatcherContext } from './types.js';
 
 export default class PassthroughPatcher extends NodePatcher {
   children: Array<?NodePatcher|Array<?NodePatcher>>;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, ...children: Array<?NodePatcher|Array<?NodePatcher>>) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, ...children: Array<?NodePatcher|Array<?NodePatcher>>) {
+    super(patcherContext);
     this.children = children;
   }
 

--- a/src/patchers/types.js
+++ b/src/patchers/types.js
@@ -25,6 +25,12 @@ export type Editor = {
   move: (start: number, end: number, index: number) => Editor;
 };
 
+export type PatcherContext = {
+  node: Node;
+  context: ParseContext;
+  editor: Editor;
+};
+
 export type SourceType = {
   name: string,
 };

--- a/src/stages/TransformCoffeeScriptStage.js
+++ b/src/stages/TransformCoffeeScriptStage.js
@@ -81,7 +81,8 @@ export default class TransformCoffeeScriptStage {
       }
     });
 
-    let patcher = new constructor(node, this.context, this.editor, ...children);
+    let patcherContext = {node, context: this.context, editor: this.editor};
+    let patcher = new constructor(patcherContext, ...children);
     this.patchers.push(patcher);
     this.associateParent(patcher, children);
 

--- a/src/stages/main/patchers/ArrayInitialiserPatcher.js
+++ b/src/stages/main/patchers/ArrayInitialiserPatcher.js
@@ -1,12 +1,12 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 import { COMMA } from 'coffee-lex';
 
 export default class ArrayInitialiserPatcher extends NodePatcher {
   members: Array<NodePatcher>;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, members: Array<NodePatcher>) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, members: Array<NodePatcher>) {
+    super(patcherContext);
     this.members = members;
   }
 

--- a/src/stages/main/patchers/AssignOpPatcher.js
+++ b/src/stages/main/patchers/AssignOpPatcher.js
@@ -1,14 +1,14 @@
 import ArrayInitialiserPatcher from './ArrayInitialiserPatcher.js';
 import ExpansionPatcher from './ExpansionPatcher.js';
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 export default class AssignOpPatcher extends NodePatcher {
   assignee: NodePatcher;
   expression: NodePatcher;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, assignee: NodePatcher, expression: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, assignee: NodePatcher, expression: NodePatcher) {
+    super(patcherContext);
     this.assignee = assignee;
     this.expression = expression;
   }

--- a/src/stages/main/patchers/BinaryOpPatcher.js
+++ b/src/stages/main/patchers/BinaryOpPatcher.js
@@ -1,13 +1,13 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { SourceToken, Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { SourceToken, PatcherContext } from './../../../patchers/types.js';
 import { EXISTENCE, OPERATOR } from 'coffee-lex';
 
 export default class BinaryOpPatcher extends NodePatcher {
   left: NodePatcher;
   right: NodePatcher;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, left: NodePatcher, right: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, left: NodePatcher, right: NodePatcher) {
+    super(patcherContext);
     this.left = left;
     this.right = right;
   }

--- a/src/stages/main/patchers/BlockPatcher.js
+++ b/src/stages/main/patchers/BlockPatcher.js
@@ -1,15 +1,15 @@
 import FunctionPatcher from './FunctionPatcher.js';
 import NodePatcher from './../../../patchers/NodePatcher.js';
 import ReturnPatcher from './ReturnPatcher.js';
-import type { SourceToken, Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { SourceToken, PatcherContext } from './../../../patchers/types.js';
 import { NEWLINE, SEMICOLON } from 'coffee-lex';
 
 export default class BlockPatcher extends NodePatcher {
   statements: Array<NodePatcher>;
   shouldPatchInline: ?boolean;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, statements: Array<NodePatcher>) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, statements: Array<NodePatcher>) {
+    super(patcherContext);
     this.statements = statements;
     this.shouldPatchInline = null;
   }

--- a/src/stages/main/patchers/ChainedComparisonOpPatcher.js
+++ b/src/stages/main/patchers/ChainedComparisonOpPatcher.js
@@ -1,6 +1,6 @@
 import BinaryOpPatcher from './BinaryOpPatcher.js';
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 /**
  * Handles constructs of the form `a < b < c < … < z`.
@@ -11,8 +11,8 @@ export default class ChainedComparisonOpPatcher extends NodePatcher {
   /**
    * `node` should have type `ChainedComparisonOp`.
    */
-  constructor(node: Node, context: ParseContext, editor: Editor, expression: BinaryOpPatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, expression: BinaryOpPatcher) {
+    super(patcherContext);
     this.expression = expression;
     this.negated = false;
   }

--- a/src/stages/main/patchers/ClassPatcher.js
+++ b/src/stages/main/patchers/ClassPatcher.js
@@ -2,7 +2,7 @@ import ClassBlockPatcher from './ClassBlockPatcher.js';
 import IdentifierPatcher from './IdentifierPatcher.js';
 import MemberAccessOpPatcher from './MemberAccessOpPatcher.js';
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { SourceToken, Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { SourceToken, PatcherContext } from './../../../patchers/types.js';
 import { CLASS } from 'coffee-lex';
 
 export default class ClassPatcher extends NodePatcher {
@@ -10,8 +10,8 @@ export default class ClassPatcher extends NodePatcher {
   superclass: ?NodePatcher;
   body: ?ClassBlockPatcher;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, nameAssignee: ?NodePatcher, parent: ?NodePatcher, body: ?ClassBlockPatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, nameAssignee: ?NodePatcher, parent: ?NodePatcher, body: ?ClassBlockPatcher) {
+    super(patcherContext);
     this.nameAssignee = nameAssignee;
     this.superclass = parent;
     this.body = body;

--- a/src/stages/main/patchers/ConditionalPatcher.js
+++ b/src/stages/main/patchers/ConditionalPatcher.js
@@ -1,6 +1,6 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
 import type BlockPatcher from './BlockPatcher.js';
-import type { Node, SourceTokenListIndex, ParseContext, Editor } from './../../../patchers/types.js';
+import type { PatcherContext, SourceTokenListIndex } from './../../../patchers/types.js';
 import { ELSE, IF, THEN } from 'coffee-lex';
 
 export default class ConditionalPatcher extends NodePatcher {
@@ -8,8 +8,8 @@ export default class ConditionalPatcher extends NodePatcher {
   consequent: BlockPatcher;
   alternate: ?BlockPatcher;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, condition: NodePatcher, consequent: BlockPatcher, alternate: ?BlockPatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, condition: NodePatcher, consequent: BlockPatcher, alternate: ?BlockPatcher) {
+    super(patcherContext);
     this.condition = condition;
     this.consequent = consequent;
     this.alternate = alternate;

--- a/src/stages/main/patchers/ConstructorPatcher.js
+++ b/src/stages/main/patchers/ConstructorPatcher.js
@@ -2,11 +2,11 @@ import ObjectBodyMemberPatcher from './ObjectBodyMemberPatcher.js';
 import traverse from '../../../utils/traverse.js';
 import type FunctionPatcher from './FunctionPatcher.js';
 import type NodePatcher from '../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 export default class ConstructorPatcher extends ObjectBodyMemberPatcher {
-  constructor(node: Node, context: ParseContext, editor: Editor, assignee: NodePatcher, expression: FunctionPatcher) {
-    super(node, context, editor, assignee, expression);
+  constructor(patcherContext: PatcherContext, assignee: NodePatcher, expression: FunctionPatcher) {
+    super(patcherContext, assignee, expression);
 
     // Constructor methods do not have implicit returns.
     expression.disableImplicitReturns();

--- a/src/stages/main/patchers/DefaultParamPatcher.js
+++ b/src/stages/main/patchers/DefaultParamPatcher.js
@@ -1,12 +1,12 @@
 import NodePatcher from '../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext } from '../../../patchers/types.js';
+import type { PatcherContext } from '../../../patchers/types.js';
 
 export default class DefaultParamPatcher extends NodePatcher {
   param: NodePatcher;
   value: NodePatcher;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, param: NodePatcher, value: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, param: NodePatcher, value: NodePatcher) {
+    super(patcherContext);
     this.param = param;
     this.value = value;
   }

--- a/src/stages/main/patchers/DoOpPatcher.js
+++ b/src/stages/main/patchers/DoOpPatcher.js
@@ -1,14 +1,14 @@
 import DefaultParamPatcher from './DefaultParamPatcher.js';
 import FunctionPatcher from './FunctionPatcher.js';
 import NodePatcher from '../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext, SourceTokenListIndex } from '../../../patchers/types.js';
+import type { PatcherContext, SourceTokenListIndex } from '../../../patchers/types.js';
 import { DO } from 'coffee-lex';
 
 export default class DoOpPatcher extends NodePatcher {
   expression: NodePatcher;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, expression: NodePatcher) {
+    super(patcherContext);
     this.expression = expression;
   }
 

--- a/src/stages/main/patchers/DynamicMemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/DynamicMemberAccessOpPatcher.js
@@ -1,12 +1,12 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 export default class DynamicMemberAccessOpPatcher extends NodePatcher {
   expression: NodePatcher;
   indexingExpr: NodePatcher;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher, indexingExpr: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, expression: NodePatcher, indexingExpr: NodePatcher) {
+    super(patcherContext);
     this.expression = expression;
     this.indexingExpr = indexingExpr;
   }

--- a/src/stages/main/patchers/ForInPatcher.js
+++ b/src/stages/main/patchers/ForInPatcher.js
@@ -3,7 +3,7 @@ import RangePatcher from './RangePatcher.js';
 import isObjectInitialiserBlock from '../../../utils/isObjectInitialiserBlock.js';
 import type BlockPatcher from './BlockPatcher.js';
 import type NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 const UP = 'UP';
 const DOWN = 'DOWN';
@@ -11,8 +11,8 @@ const UNKNOWN = 'UNKNOWN';
 type IndexDirection = 'UP' | 'DOWN' | 'UNKNOWN';
 
 export default class ForInPatcher extends ForPatcher {
-  constructor(node: Node, context: ParseContext, editor: Editor, keyAssignee: ?NodePatcher, valAssignee: ?NodePatcher, target: NodePatcher, step: ?NodePatcher, filter: ?NodePatcher, body: BlockPatcher) {
-    super(node, context, editor, keyAssignee, valAssignee, target, filter, body);
+  constructor(patcherContext: PatcherContext, keyAssignee: ?NodePatcher, valAssignee: ?NodePatcher, target: NodePatcher, step: ?NodePatcher, filter: ?NodePatcher, body: BlockPatcher) {
+    super(patcherContext, keyAssignee, valAssignee, target, filter, body);
     this.step = step;
   }
 

--- a/src/stages/main/patchers/ForPatcher.js
+++ b/src/stages/main/patchers/ForPatcher.js
@@ -2,7 +2,7 @@ import NodePatcher from './../../../patchers/NodePatcher.js';
 import IdentifierPatcher from './IdentifierPatcher.js';
 import LoopPatcher from './LoopPatcher.js';
 import type BlockPatcher from './BlockPatcher.js';
-import type { Node, ParseContext, Editor, SourceToken } from './../../../patchers/types.js';
+import type { PatcherContext, SourceToken } from './../../../patchers/types.js';
 import { RELATION, THEN } from 'coffee-lex';
 
 export default class ForPatcher extends LoopPatcher {
@@ -11,8 +11,8 @@ export default class ForPatcher extends LoopPatcher {
   target: NodePatcher;
   filter: ?NodePatcher;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, keyAssignee: ?NodePatcher, valAssignee: ?NodePatcher, target: NodePatcher, filter: ?NodePatcher, body: BlockPatcher) {
-    super(node, context, editor, body);
+  constructor(patcherContext: PatcherContext, keyAssignee: ?NodePatcher, valAssignee: ?NodePatcher, target: NodePatcher, filter: ?NodePatcher, body: BlockPatcher) {
+    super(patcherContext, body);
     this.keyAssignee = keyAssignee;
     this.valAssignee = valAssignee;
     this.target = target;

--- a/src/stages/main/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/main/patchers/FunctionApplicationPatcher.js
@@ -1,5 +1,5 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 import { COMMA } from 'coffee-lex';
 import { isSemanticToken } from '../../../utils/types.js';
 
@@ -7,8 +7,8 @@ export default class FunctionApplicationPatcher extends NodePatcher {
   fn: NodePatcher;
   args: Array<NodePatcher>;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, fn: NodePatcher, args: Array<NodePatcher>) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, fn: NodePatcher, args: Array<NodePatcher>) {
+    super(patcherContext);
     this.fn = fn;
     this.args = args;
   }

--- a/src/stages/main/patchers/FunctionPatcher.js
+++ b/src/stages/main/patchers/FunctionPatcher.js
@@ -1,15 +1,15 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
 import FunctionApplicationPatcher from './FunctionApplicationPatcher.js';
 import type BlockPatcher from './BlockPatcher.js';
-import type { Node, ParseContext, Editor, SourceToken } from './../../../patchers/types.js';
+import type { PatcherContext, SourceToken } from './../../../patchers/types.js';
 import { CALL_END, COMMA, FUNCTION, LPAREN, RPAREN } from 'coffee-lex';
 
 export default class FunctionPatcher extends NodePatcher {
   parameters: Array<NodePatcher>;
   body: ?BlockPatcher;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, parameters: Array<NodePatcher>, body: ?NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, parameters: Array<NodePatcher>, body: ?NodePatcher) {
+    super(patcherContext);
     this.parameters = parameters;
     this.body = body;
   }

--- a/src/stages/main/patchers/InOpPatcher.js
+++ b/src/stages/main/patchers/InOpPatcher.js
@@ -6,7 +6,7 @@ import IdentifierPatcher from './IdentifierPatcher.js';
 import MemberAccessOpPatcher from './MemberAccessOpPatcher.js';
 import StringPatcher from './StringPatcher.js';
 import type NodePatcher from './../../../patchers/NodePatcher.js';
-import type { SourceToken, Editor, Node, ParseContext } from './../../../patchers/types.js';
+import type { SourceToken, PatcherContext } from './../../../patchers/types.js';
 import { RELATION } from 'coffee-lex';
 
 /**
@@ -18,9 +18,9 @@ export default class InOpPatcher extends BinaryOpPatcher {
   /**
    * `node` is of type `InOp`.
    */
-  constructor(node: Node, context: ParseContext, editor: Editor, left: NodePatcher, right: NodePatcher) {
-    super(node, context, editor, left, right);
-    this.negated = node.isNot;
+  constructor(patcherContext: PatcherContext, left: NodePatcher, right: NodePatcher) {
+    super(patcherContext, left, right);
+    this.negated = patcherContext.node.isNot;
   }
 
   negate() {

--- a/src/stages/main/patchers/InterpolatedPatcher.js
+++ b/src/stages/main/patchers/InterpolatedPatcher.js
@@ -8,8 +8,8 @@ export default class InterpolatedPatcher extends NodePatcher {
   quasis: Array<NodePatcher>;
   expressions: Array<NodePatcher>;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, quasis: Array<NodePatcher>, expressions: Array<NodePatcher>) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, quasis: Array<NodePatcher>, expressions: Array<NodePatcher>) {
+    super(patcherContext);
     this.quasis = quasis;
     this.expressions = expressions;
   }

--- a/src/stages/main/patchers/LogicalOpPatcher.js
+++ b/src/stages/main/patchers/LogicalOpPatcher.js
@@ -1,6 +1,6 @@
 import BinaryOpPatcher from './BinaryOpPatcher.js';
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 /**
  * Handles logical AND and logical OR.
@@ -19,8 +19,8 @@ export default class LogicalOpPatcher extends BinaryOpPatcher {
   /**
    * `node` is expected to be either `LogicalAndOp` or `LogicalOrOp`.
    */
-  constructor(node: Node, context: ParseContext, editor: Editor, left: NodePatcher, right: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, left: NodePatcher, right: NodePatcher) {
+    super(patcherContext);
     this.left = left;
     this.right = right;
   }

--- a/src/stages/main/patchers/LoopPatcher.js
+++ b/src/stages/main/patchers/LoopPatcher.js
@@ -6,8 +6,8 @@ export default class LoopPatcher extends NodePatcher {
   body: BlockPatcher;
   yielding: boolean;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, body: BlockPatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, body: BlockPatcher) {
+    super(patcherContext);
     this.body = body;
   }
 

--- a/src/stages/main/patchers/MemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/MemberAccessOpPatcher.js
@@ -1,13 +1,13 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Node, ParseContext, Editor, SourceToken } from './../../../patchers/types.js';
+import type { PatcherContext, SourceToken } from './../../../patchers/types.js';
 import { AT, DOT, IDENTIFIER, PROTO } from 'coffee-lex';
 
 export default class MemberAccessOpPatcher extends NodePatcher {
   expression: NodePatcher;
   _skipImplicitDotCreation: boolean;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, expression: NodePatcher) {
+    super(patcherContext);
     this.expression = expression;
     this._skipImplicitDotCreation = false;
   }

--- a/src/stages/main/patchers/ModuloOpPatcher.js
+++ b/src/stages/main/patchers/ModuloOpPatcher.js
@@ -1,6 +1,6 @@
 import BinaryOpPatcher from './BinaryOpPatcher.js';
 import type NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 const MOD_HELPER =
   `function __mod__(a, b) {
@@ -16,8 +16,8 @@ export default class ModuloOpPatcher extends BinaryOpPatcher {
   /**
    * `node` is of type `ModuloOp`.
    */
-  constructor(node: Node, context: ParseContext, editor: Editor, left: NodePatcher, right: NodePatcher) {
-    super(node, context, editor, left, right);
+  constructor(patcherContext: PatcherContext, left: NodePatcher, right: NodePatcher) {
+    super(patcherContext, left, right);
   }
 
   patchAsExpression() {

--- a/src/stages/main/patchers/NegatableBinaryOpPatcher.js
+++ b/src/stages/main/patchers/NegatableBinaryOpPatcher.js
@@ -1,6 +1,6 @@
 import BinaryOpPatcher from './BinaryOpPatcher.js';
 import type NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 /**
  * Handles `instanceof` operator, e.g. `a instanceof b`.
@@ -8,9 +8,9 @@ import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
 export default class NegatableBinaryOpPatcher extends BinaryOpPatcher {
   negated: boolean;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, left: NodePatcher, right: NodePatcher) {
-    super(node, context, editor, left, right);
-    this.negated = node.isNot;
+  constructor(patcherContext: PatcherContext, left: NodePatcher, right: NodePatcher) {
+    super(patcherContext, left, right);
+    this.negated = patcherContext.node.isNot;
   }
 
   negate() {

--- a/src/stages/main/patchers/ObjectBodyMemberPatcher.js
+++ b/src/stages/main/patchers/ObjectBodyMemberPatcher.js
@@ -6,7 +6,7 @@ import IdentifierPatcher from './IdentifierPatcher.js';
 import ManuallyBoundFunctionPatcher from './ManuallyBoundFunctionPatcher.js';
 import StringPatcher from './StringPatcher.js';
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 /**
  * Handles object properties.
@@ -15,8 +15,8 @@ export default class ObjectBodyMemberPatcher extends NodePatcher {
   key: NodePatcher;
   expression: NodePatcher;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, key: NodePatcher, expression: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, key: NodePatcher, expression: NodePatcher) {
+    super(patcherContext);
     this.key = key;
     this.expression = expression;
   }

--- a/src/stages/main/patchers/ObjectInitialiserPatcher.js
+++ b/src/stages/main/patchers/ObjectInitialiserPatcher.js
@@ -1,6 +1,6 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
 import ObjectInitialiserMemberPatcher from './ObjectInitialiserMemberPatcher.js';
-import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 import { COMMA, LBRACE } from 'coffee-lex';
 import { isSemanticToken } from '../../../utils/types.js';
 
@@ -10,8 +10,8 @@ import { isSemanticToken } from '../../../utils/types.js';
 export default class ObjectInitialiserPatcher extends NodePatcher {
   members: Array<NodePatcher>;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, members: Array<NodePatcher>) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, members: Array<NodePatcher>) {
+    super(patcherContext);
     this.members = members;
   }
 

--- a/src/stages/main/patchers/ProgramPatcher.js
+++ b/src/stages/main/patchers/ProgramPatcher.js
@@ -4,7 +4,7 @@ import determineIndent from '../../../utils/determineIndent.js';
 import getIndent from '../../../utils/getIndent.js';
 import { COMMENT, CONTINUATION, HERECOMMENT} from 'coffee-lex';
 import type BlockPatcher from './BlockPatcher.js';
-import type { Editor, Node, ParseContext, SourceToken } from './../../../patchers/types.js';
+import type { PatcherContext, SourceToken } from './../../../patchers/types.js';
 
 const BLOCK_COMMENT_DELIMITER = '###';
 
@@ -13,8 +13,8 @@ export default class ProgramPatcher extends NodePatcher {
   helpers: { [key: string]: string };
   _indentString: ?string;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, body: ?BlockPatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, body: ?BlockPatcher) {
+    super(patcherContext);
     this.body = body;
 
     this.helpers = blank();

--- a/src/stages/main/patchers/ReturnPatcher.js
+++ b/src/stages/main/patchers/ReturnPatcher.js
@@ -1,11 +1,11 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 export default class ReturnPatcher extends NodePatcher {
   expression: NodePatcher;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, expression: ?NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, expression: ?NodePatcher) {
+    super(patcherContext);
     this.expression = expression;
   }
 

--- a/src/stages/main/patchers/SlicePatcher.js
+++ b/src/stages/main/patchers/SlicePatcher.js
@@ -1,5 +1,5 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { SourceToken, Editor, Node, ParseContext } from './../../../patchers/types.js';
+import type { SourceToken, PatcherContext } from './../../../patchers/types.js';
 import { LBRACKET, RANGE, RBRACKET } from 'coffee-lex';
 
 /**
@@ -13,8 +13,8 @@ export default class SlicePatcher extends NodePatcher {
   /**
    * `node` is of type `Slice`.
    */
-  constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher, left: ?NodePatcher, right: ?NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, expression: NodePatcher, left: ?NodePatcher, right: ?NodePatcher) {
+    super(patcherContext);
     this.expression = expression;
     this.left = left;
     this.right = right;

--- a/src/stages/main/patchers/SoakedDynamicMemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/SoakedDynamicMemberAccessOpPatcher.js
@@ -9,8 +9,8 @@ const GUARD_HELPER =
 export default class SoakedDynamicMemberAccessOpPatcher extends DynamicMemberAccessOpPatcher {
   _shouldSkipSoakPatch: boolean;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher, indexingExpr: NodePatcher) {
-    super(node, context, editor, expression, indexingExpr);
+  constructor(patcherContext: PatcherContext, expression: NodePatcher, indexingExpr: NodePatcher) {
+    super(patcherContext, expression, indexingExpr);
     this._shouldSkipSoakPatch = false;
   }
 

--- a/src/stages/main/patchers/SoakedMemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/SoakedMemberAccessOpPatcher.js
@@ -9,8 +9,8 @@ const GUARD_HELPER =
 export default class SoakedMemberAccessOpPatcher extends MemberAccessOpPatcher {
   _shouldSkipSoakPatch: boolean;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher) {
-    super(node, context, editor, expression);
+  constructor(patcherContext: PatcherContext, expression: NodePatcher) {
+    super(patcherContext, expression);
     this._shouldSkipSoakPatch = false;
   }
 

--- a/src/stages/main/patchers/SpreadPatcher.js
+++ b/src/stages/main/patchers/SpreadPatcher.js
@@ -1,5 +1,5 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 /**
  * Handles spread operations, e.g. `a(b...)` or `[a...]`.
@@ -7,8 +7,8 @@ import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
 export default class SpreadPatcher extends NodePatcher {
   expression: ?NodePatcher;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, expression: ?NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, expression: ?NodePatcher) {
+    super(patcherContext);
     this.expression = expression;
   }
 

--- a/src/stages/main/patchers/SwitchCasePatcher.js
+++ b/src/stages/main/patchers/SwitchCasePatcher.js
@@ -1,5 +1,5 @@
 import NodePatcher from '../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext, SourceToken } from '../../../patchers/types.js';
+import type { PatcherContext, SourceToken } from '../../../patchers/types.js';
 import { BREAK, COMMA, THEN, WHEN } from 'coffee-lex';
 
 export default class SwitchCasePatcher extends NodePatcher {
@@ -8,8 +8,8 @@ export default class SwitchCasePatcher extends NodePatcher {
 
   negated: boolean;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, conditions: Array<NodePatcher>, consequent: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, conditions: Array<NodePatcher>, consequent: NodePatcher) {
+    super(patcherContext);
     this.conditions = conditions;
     this.consequent = consequent;
     this.negated = false;

--- a/src/stages/main/patchers/SwitchPatcher.js
+++ b/src/stages/main/patchers/SwitchPatcher.js
@@ -1,5 +1,5 @@
 import NodePatcher from '../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext, SourceToken } from '../../../patchers/types.js';
+import type { PatcherContext, SourceToken } from '../../../patchers/types.js';
 import { ELSE, SWITCH } from 'coffee-lex';
 
 export default class SwitchPatcher extends NodePatcher {
@@ -7,8 +7,8 @@ export default class SwitchPatcher extends NodePatcher {
   cases: Array<NodePatcher>;
   alternate: ?NodePatcher;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher, cases: Array<NodePatcher>, alternate: ?NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, expression: NodePatcher, cases: Array<NodePatcher>, alternate: ?NodePatcher) {
+    super(patcherContext);
     this.expression = expression;
     this.cases = cases;
     this.alternate = alternate;

--- a/src/stages/main/patchers/ThrowPatcher.js
+++ b/src/stages/main/patchers/ThrowPatcher.js
@@ -1,12 +1,12 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 import { THROW } from 'coffee-lex';
 
 export default class ThrowPatcher extends NodePatcher {
   expression: NodePatcher;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, expression: NodePatcher) {
+    super(patcherContext);
     this.expression = expression;
   }
 

--- a/src/stages/main/patchers/TryPatcher.js
+++ b/src/stages/main/patchers/TryPatcher.js
@@ -1,6 +1,6 @@
 import NodePatcher from '../../../patchers/NodePatcher.js';
 import type BlockPatcher from './BlockPatcher.js';
-import type { Node, ParseContext, Editor, SourceToken, SourceTokenListIndex } from '../../../patchers/types.js';
+import type { PatcherContext, SourceToken, SourceTokenListIndex } from '../../../patchers/types.js';
 import { CATCH, FINALLY, THEN, TRY } from 'coffee-lex';
 
 /**
@@ -12,8 +12,8 @@ export default class TryPatcher extends NodePatcher {
   catchBody: ?BlockPatcher;
   finallyBody: ?BlockPatcher;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, body: BlockPatcher, catchAssignee: ?NodePatcher, catchBody: ?BlockPatcher, finallyBody: ?BlockPatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, body: BlockPatcher, catchAssignee: ?NodePatcher, catchBody: ?BlockPatcher, finallyBody: ?BlockPatcher) {
+    super(patcherContext);
     this.body = body;
     this.catchAssignee = catchAssignee;
     this.catchBody = catchBody;

--- a/src/stages/main/patchers/UnaryOpPatcher.js
+++ b/src/stages/main/patchers/UnaryOpPatcher.js
@@ -1,11 +1,11 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 export default class UnaryOpPatcher extends NodePatcher {
   expression: NodePatcher;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, expression: NodePatcher) {
+    super(patcherContext);
     this.expression = expression;
   }
 

--- a/src/stages/main/patchers/WhilePatcher.js
+++ b/src/stages/main/patchers/WhilePatcher.js
@@ -1,7 +1,7 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
 import LoopPatcher from './LoopPatcher.js';
 import type BlockPatcher from './BlockPatcher.js';
-import type { Editor, Node, ParseContext, SourceTokenListIndex } from './../../../patchers/types.js';
+import type { PatcherContext, SourceTokenListIndex } from './../../../patchers/types.js';
 import { LOOP, THEN, WHILE } from 'coffee-lex';
 
 /**
@@ -14,8 +14,8 @@ export default class WhilePatcher extends LoopPatcher {
   condition: NodePatcher;
   guard: ?NodePatcher;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, condition: NodePatcher, guard: ?NodePatcher, body: BlockPatcher) {
-    super(node, context, editor, body);
+  constructor(patcherContext: PatcherContext, condition: NodePatcher, guard: ?NodePatcher, body: BlockPatcher) {
+    super(patcherContext, body);
     this.condition = condition;
     this.guard = guard;
   }

--- a/src/stages/main/patchers/YieldFromPatcher.js
+++ b/src/stages/main/patchers/YieldFromPatcher.js
@@ -1,11 +1,11 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 export default class YieldFromPatcher extends NodePatcher {
   expression: NodePatcher;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, expression: NodePatcher) {
+    super(patcherContext);
     this.expression = expression;
   }
   

--- a/src/stages/main/patchers/YieldPatcher.js
+++ b/src/stages/main/patchers/YieldPatcher.js
@@ -1,11 +1,11 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 export default class YieldPatcher extends NodePatcher {
   expression: NodePatcher;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, expression: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, expression: NodePatcher) {
+    super(patcherContext);
     this.expression = expression;
   }
   

--- a/src/stages/normalize/patchers/ArrayInitialiserPatcher.js
+++ b/src/stages/normalize/patchers/ArrayInitialiserPatcher.js
@@ -1,12 +1,12 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 import { COMMA } from 'coffee-lex';
 
 export default class ArrayInitialiserPatcher extends NodePatcher {
   members: Array<NodePatcher>;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, members: Array<NodePatcher>) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, members: Array<NodePatcher>) {
+    super(patcherContext);
     this.members = members;
   }
 

--- a/src/stages/normalize/patchers/AssignOpPatcher.js
+++ b/src/stages/normalize/patchers/AssignOpPatcher.js
@@ -4,8 +4,8 @@ export default class AssignOpPatcher extends PassthroughPatcher {
   key: NodePatcher;
   expression: NodePatcher;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, key: NodePatcher, expression: NodePatcher) {
-    super(node, context, editor, key, expression);
+  constructor(patcherContext: PatcherContext, key: NodePatcher, expression: NodePatcher) {
+    super(patcherContext, key, expression);
     this.key = key;
     this.expression = expression;
   }

--- a/src/stages/normalize/patchers/BlockPatcher.js
+++ b/src/stages/normalize/patchers/BlockPatcher.js
@@ -1,13 +1,13 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
 import getStartOfLine from './../../../utils/getStartOfLine.js';
 
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 export default class BlockPatcher extends NodePatcher {
   statements: Array<NodePatcher>;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, statements: Array<NodePatcher>) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, statements: Array<NodePatcher>) {
+    super(patcherContext);
     this.statements = statements;
   }
 

--- a/src/stages/normalize/patchers/ClassPatcher.js
+++ b/src/stages/normalize/patchers/ClassPatcher.js
@@ -1,15 +1,15 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
 import AssignOpPatcher from './AssignOpPatcher.js';
 
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 export default class ClassPatcher extends NodePatcher {
   nameAssignee: ?NodePatcher;
   superclass: ?NodePatcher;
   body: ?BlockPatcher;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, nameAssignee: ?NodePatcher, parent: ?NodePatcher, body: ?BlockPatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, nameAssignee: ?NodePatcher, parent: ?NodePatcher, body: ?BlockPatcher) {
+    super(patcherContext);
     this.nameAssignee = nameAssignee;
     this.superclass = parent;
     this.body = body;

--- a/src/stages/normalize/patchers/ConditionalPatcher.js
+++ b/src/stages/normalize/patchers/ConditionalPatcher.js
@@ -1,5 +1,5 @@
 import NodePatcher from '../../../patchers/NodePatcher.js';
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 import type { SourceTokenListIndex } from 'coffee-lex';
 import { IF } from 'coffee-lex';
 
@@ -17,8 +17,8 @@ export default class ConditionalPatcher extends NodePatcher {
   consequent: ?NodePatcher;
   alternate: ?NodePatcher;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, condition: NodePatcher, consequent: NodePatcher, alternate: ?NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, condition: NodePatcher, consequent: NodePatcher, alternate: ?NodePatcher) {
+    super(patcherContext);
     this.condition = condition;
     this.consequent = consequent;
     this.alternate = alternate;

--- a/src/stages/normalize/patchers/DefaultParamPatcher.js
+++ b/src/stages/normalize/patchers/DefaultParamPatcher.js
@@ -4,8 +4,8 @@ export default class DefaultParamPatcher extends PassthroughPatcher {
   param: NodePatcher;
   value: NodePatcher;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, param: NodePatcher, value: NodePatcher) {
-    super(node, context, editor, param, value);
+  constructor(patcherContext: PatcherContext, param: NodePatcher, value: NodePatcher) {
+    super(patcherContext, param, value);
     this.param = param;
     this.value = value;
   }

--- a/src/stages/normalize/patchers/ForInPatcher.js
+++ b/src/stages/normalize/patchers/ForInPatcher.js
@@ -1,12 +1,12 @@
 import ForPatcher from './ForPatcher.js';
 import type NodePatcher from '../../../patchers/NodePatcher.js';
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 export default class ForInPatcher extends ForPatcher {
   step: ?NodePatcher;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, keyAssignee: ?NodePatcher, valAssignee: ?NodePatcher, target: NodePatcher, step: ?NodePatcher, filter: ?NodePatcher, body: NodePatcher) {
-    super(node, context, editor, keyAssignee, valAssignee, target, filter, body);
+  constructor(patcherContext: PatcherContext, keyAssignee: ?NodePatcher, valAssignee: ?NodePatcher, target: NodePatcher, step: ?NodePatcher, filter: ?NodePatcher, body: NodePatcher) {
+    super(patcherContext, keyAssignee, valAssignee, target, filter, body);
     this.step = step;
   }
 

--- a/src/stages/normalize/patchers/ForPatcher.js
+++ b/src/stages/normalize/patchers/ForPatcher.js
@@ -1,5 +1,5 @@
 import NodePatcher from '../../../patchers/NodePatcher.js';
-import type { Node, ParseContext, Editor, SourceToken } from './../../../patchers/types.js';
+import type { PatcherContext, SourceToken } from './../../../patchers/types.js';
 import { FOR } from 'coffee-lex';
 
 export default class ForPatcher extends NodePatcher {
@@ -9,8 +9,8 @@ export default class ForPatcher extends NodePatcher {
   filter: ?NodePatcher;
   body: NodePatcher;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, keyAssignee: ?NodePatcher, valAssignee: ?NodePatcher, target: NodePatcher, filter: ?NodePatcher, body: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, keyAssignee: ?NodePatcher, valAssignee: ?NodePatcher, target: NodePatcher, filter: ?NodePatcher, body: NodePatcher) {
+    super(patcherContext);
     this.keyAssignee = keyAssignee;
     this.valAssignee = valAssignee;
     this.target = target;

--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.js
@@ -1,13 +1,13 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 import { CALL_START, CALL_END, COMMA, EXISTENCE, NEWLINE, RBRACE, RBRACKET, RPAREN } from 'coffee-lex';
 
 export default class FunctionApplicationPatcher extends NodePatcher {
   fn: NodePatcher;
   args: Array<NodePatcher>;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, fn: NodePatcher, args: Array<NodePatcher>) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, fn: NodePatcher, args: Array<NodePatcher>) {
+    super(patcherContext);
     this.fn = fn;
     this.args = args;
   }

--- a/src/stages/normalize/patchers/FunctionPatcher.js
+++ b/src/stages/normalize/patchers/FunctionPatcher.js
@@ -1,12 +1,12 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 export default class FunctionPatcher extends NodePatcher {
   parameters: Array<NodePatcher>;
   body: ?NodePatcher;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, parameters: Array<NodePatcher>, body: ?NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, parameters: Array<NodePatcher>, body: ?NodePatcher) {
+    super(patcherContext);
     this.parameters = parameters;
     this.body = body;
   }

--- a/src/stages/normalize/patchers/ObjectInitialiserMemberPatcher.js
+++ b/src/stages/normalize/patchers/ObjectInitialiserMemberPatcher.js
@@ -4,8 +4,8 @@ export default class ObjectInitialiserMemberPatcher extends PassthroughPatcher {
   key: NodePatcher;
   expression: NodePatcher;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, key: NodePatcher, expression: NodePatcher) {
-    super(node, context, editor, key, expression);
+  constructor(patcherContext: PatcherContext, key: NodePatcher, expression: NodePatcher) {
+    super(patcherContext, key, expression);
     this.key = key;
     this.expression = expression;
   }

--- a/src/stages/normalize/patchers/ObjectInitialiserPatcher.js
+++ b/src/stages/normalize/patchers/ObjectInitialiserPatcher.js
@@ -1,5 +1,5 @@
 import NodePatcher from './../../../patchers/NodePatcher.js';
-import type { Editor, Node, ParseContext } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 import { COMMA } from 'coffee-lex';
 
 /**
@@ -8,8 +8,8 @@ import { COMMA } from 'coffee-lex';
 export default class ObjectInitialiserPatcher extends NodePatcher {
   members: Array<NodePatcher>;
 
-  constructor(node: Node, context: ParseContext, editor: Editor, members: Array<NodePatcher>) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, members: Array<NodePatcher>) {
+    super(patcherContext);
     this.members = members;
   }
 

--- a/src/stages/normalize/patchers/WhilePatcher.js
+++ b/src/stages/normalize/patchers/WhilePatcher.js
@@ -1,5 +1,5 @@
 import NodePatcher from '../../../patchers/NodePatcher.js';
-import type { Node, ParseContext, Editor } from './../../../patchers/types.js';
+import type { PatcherContext } from './../../../patchers/types.js';
 
 /**
  * Normalizes `while` loops by rewriting post-`while` into standard `while`, e.g.
@@ -15,8 +15,8 @@ export default class WhilePatcher extends NodePatcher {
   guard: ?NodePatcher;
   body: NodePatcher;
   
-  constructor(node: Node, context: ParseContext, editor: Editor, condition: NodePatcher, guard: ?NodePatcher, body: NodePatcher) {
-    super(node, context, editor);
+  constructor(patcherContext: PatcherContext, condition: NodePatcher, guard: ?NodePatcher, body: NodePatcher) {
+    super(patcherContext);
     this.condition = condition;
     this.guard = guard;
     this.body = body;


### PR DESCRIPTION
I want the decaffeinate options to be accessible from any patcher, but currently
we have exactly three constructor args that we forward all over the place. To
make it easier to add new constructor args, I made a new type for those three
and changed everything to use that.

This was done with some simple find-and-replace operations, but given how good
the test coverage is and how explosive any mistakes would be, it seems like it
should be fine to make a widespread change like this without needing to be too
careful.