### PR TITLE
fix: use `== null` when possible for `?=` statements

### DIFF
--- a/test/compound_assignment_test.js
+++ b/test/compound_assignment_test.js
@@ -404,7 +404,17 @@ describe('compound assignment', () => {
         a ?= 2
       `, `
         let a = 1;
-        if (typeof a === 'undefined' || a === null) { a = 2; }
+        if (a == null) { a = 2; }
+      `);
+    });
+
+    it('handles simple existence assignment to an undeclared variable', () => {
+      check(`
+        a ?= 2
+        console.log a
+      `, `
+        if (typeof a === 'undefined' || a === null) { var a = 2; }
+        console.log(a);
       `);
     });
 


### PR DESCRIPTION
Progress toward #125

The expression patcher already had logic to detect if we need to do a `typeof`
check by seeing if there was already a declared variable, but the statement
patcher wasn't doing that check. Pull the checkout into a separate method and
use it everywhere.