### PR TITLE
feat: implement strictly correct default params and enable them by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Options:
 * `--keep-commonjs`: Do not convert `require` and `module.exports` to `import`
   and `export`.
 * `--prefer-const`: Use `const` when possible in output code.
+* `--loose-default-params`: Convert CS default params to JS default params.
 
 For more usages examples, see the output of `decaffeinate --help`.
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -48,6 +48,10 @@ function parseArguments(args: Array<string>): CLIOptions {
         baseOptions.preferConst = true;
         break;
 
+      case '--loose-default-params':
+        baseOptions.looseDefaultParams = true;
+        break;
+
       default:
         if (arg.startsWith('-')) {
           console.error(`Error: unrecognized option '${arg}'`);
@@ -168,9 +172,10 @@ function usage() {
   console.log();
   console.log('OPTIONS');
   console.log();
-  console.log('  -h, --help       Display this help message.');
-  console.log('  --keep-commonjs  Do not convert require and module.exports to import and export.');
-  console.log('  --prefer-const   Use the const keyword for variables when possible.');
+  console.log('  -h, --help              Display this help message.');
+  console.log('  --keep-commonjs         Do not convert require and module.exports to import and export.');
+  console.log('  --prefer-const          Use the const keyword for variables when possible.');
+  console.log('  --loose-default-params  Convert CS default params to JS default params.');
   console.log();
   console.log('EXAMPLES');
   console.log();

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ export type Options = {
   runToStage: ?string,
   keepCommonJS: ?boolean,
   preferConst: ?boolean,
+  looseDefaultParams: ?boolean,
 };
 
 const DEFAULT_OPTIONS = {
@@ -29,6 +30,7 @@ const DEFAULT_OPTIONS = {
   runToStage: null,
   keepCommonJS: false,
   preferConst: false,
+  looseDefaultParams: false,
 };
 
 type ConversionResult = {

--- a/src/stages/normalize/index.js
+++ b/src/stages/normalize/index.js
@@ -3,9 +3,11 @@ import BlockPatcher from './patchers/BlockPatcher.js';
 import ClassPatcher from './patchers/ClassPatcher.js';
 import AssignOpPatcher from './patchers/AssignOpPatcher.js';
 import ConditionalPatcher from './patchers/ConditionalPatcher.js';
+import DoOpPatcher from './patchers/DoOpPatcher.js';
 import ForInPatcher from './patchers/ForInPatcher.js';
 import ForOfPatcher from './patchers/ForOfPatcher.js';
 import FunctionApplicationPatcher from './patchers/FunctionApplicationPatcher.js';
+import IdentifierPatcher from './patchers/IdentifierPatcher.js';
 import NodePatcher from '../../patchers/NodePatcher.js';
 import ObjectInitialiserPatcher from './patchers/ObjectInitialiserPatcher.js';
 import ObjectInitialiserMemberPatcher from './patchers/ObjectInitialiserMemberPatcher.js';
@@ -41,6 +43,9 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
       case 'Conditional':
         return ConditionalPatcher;
 
+      case 'DoOp':
+        return DoOpPatcher;
+
       case 'ForIn':
         return ForInPatcher;
 
@@ -51,6 +56,9 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
       case 'NewOp':
       case 'SoakedFunctionApplication':
         return FunctionApplicationPatcher;
+
+      case 'Identifier':
+        return IdentifierPatcher;
 
       case 'While':
         return WhilePatcher;

--- a/src/stages/normalize/patchers/DefaultParamPatcher.js
+++ b/src/stages/normalize/patchers/DefaultParamPatcher.js
@@ -1,3 +1,7 @@
+import DoOpPatcher from './DoOpPatcher.js';
+import FunctionPatcher from './FunctionPatcher.js';
+import IdentifierPatcher from './IdentifierPatcher.js';
+import MemberAccessOpPatcher from './MemberAccessOpPatcher.js';
 import PassthroughPatcher from '../../../patchers/PassthroughPatcher.js';
 
 export default class DefaultParamPatcher extends PassthroughPatcher {
@@ -8,5 +12,63 @@ export default class DefaultParamPatcher extends PassthroughPatcher {
     super(patcherContext, param, value);
     this.param = param;
     this.value = value;
+  }
+
+  patch() {
+    // Note that when there is both a `this` assignment and a default param
+    // assignment (e.g. `(@a=b()) -> c`), assignment callbacks are run
+    // bottom-up, so by the time this code runs, any necessary parameter
+    // renaming will have already happened. This means that `paramCode` will
+    // naturally have the renamed parameter, so we don't need to do anything
+    // special.
+    super.patch();
+    if (this.shouldExtractToConditionalAssign()) {
+      let callback = this.findAddDefaultParamAssignmentCallback();
+      if (callback) {
+        let paramCode = this.slice(this.param.contentStart, this.param.contentEnd);
+        let valueCode = this.slice(this.value.contentStart, this.value.contentEnd);
+        let assigneeIsValidExpression = this.param instanceof IdentifierPatcher ||
+          this.param instanceof MemberAccessOpPatcher;
+
+        let newParamCode = callback(paramCode, valueCode, assigneeIsValidExpression);
+        this.overwrite(this.param.contentStart, this.param.contentEnd, newParamCode);
+        this.remove(this.param.outerEnd, this.value.outerEnd);
+      }
+    }
+  }
+
+  findAddDefaultParamAssignmentCallback() {
+    let patcher = this;
+
+    while (patcher) {
+      if (patcher.addDefaultParamAssignmentAtScopeHeader) {
+        return patcher.addDefaultParamAssignmentAtScopeHeader;
+      }
+      // Don't consider this node if we're on the right side of another default
+      // param (e.g. `(foo = (bar=3) ->) ->`).
+      if (patcher.parent instanceof DefaultParamPatcher &&
+        patcher.parent.value === patcher) {
+        break;
+      }
+      patcher = patcher.parent;
+    }
+    return null;
+  }
+
+  /**
+   * For correctness reasons, we usually need to extract the assignment into a
+   * statement that checks null and undefined rather than just undefined. But
+   * skip that step if the user opted out of it in favor of cleaner code, and
+   * also in a case like `do (a=1) -> a`, which is handled later as a special
+   * case and doesn't use JS default params.
+   */
+  shouldExtractToConditionalAssign() {
+    if (this.options.looseDefaultParams) {
+      return false;
+    }
+    if (this.parent instanceof FunctionPatcher && this.parent.parent instanceof DoOpPatcher) {
+      return false;
+    }
+    return true;
   }
 }

--- a/src/stages/normalize/patchers/DoOpPatcher.js
+++ b/src/stages/normalize/patchers/DoOpPatcher.js
@@ -1,0 +1,3 @@
+import PassthroughPatcher from '../../../patchers/PassthroughPatcher.js';
+
+export default class DoOpPatcher extends PassthroughPatcher {}

--- a/src/stages/normalize/patchers/IdentifierPatcher.js
+++ b/src/stages/normalize/patchers/IdentifierPatcher.js
@@ -1,0 +1,3 @@
+import PassthroughPatcher from '../../../patchers/PassthroughPatcher.js';
+
+export default class DefaultParamPatcher extends PassthroughPatcher {}

--- a/src/stages/normalize/patchers/MemberAccessOpPatcher.js
+++ b/src/stages/normalize/patchers/MemberAccessOpPatcher.js
@@ -9,19 +9,19 @@ export default class MemberAccessOpPatcher extends PassthroughPatcher {
 
   patch() {
     super.patch();
-    let callback = this.findAddStatementCallback();
+    let callback = this.findAddThisAssignmentCallback();
     if (callback) {
       let content = this.slice(this.contentStart, this.contentEnd);
       this.overwrite(this.contentStart, this.contentEnd, callback(this.node.memberName, content));
     }
   }
 
-  findAddStatementCallback() {
+  findAddThisAssignmentCallback() {
     let patcher = this;
 
     while (patcher) {
-      if (patcher.addStatementAtScopeHeader) {
-        return patcher.addStatementAtScopeHeader;
+      if (patcher.addThisAssignmentAtScopeHeader) {
+        return patcher.addThisAssignmentAtScopeHeader;
       }
       // Don't consider this node if we're on the right side of a default param
       // (e.g. `(foo = @bar) ->`) or if we're on the left side of an object

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -193,7 +193,8 @@ describe('classes', () => {
       check(`
         (@a = 1) ->
       `, `
-        (function(a = 1) {
+        (function(a) {
+          if (a == null) { a = 1; }
           this.a = a;
         });
       `);
@@ -223,10 +224,21 @@ describe('classes', () => {
       check(`
         (@a, b = @c) ->
       `, `
-        (function(a, b = this.c) {
+        (function(a, b) {
+          if (b == null) { b = this.c; }
           this.a = a;
         });
       `);
+    });
+
+    it('uses correct value for default param with loose params when using another member', () => {
+      check(`
+        (@a, b = @c) ->
+      `, `
+        (function(a, b = this.c) {
+          this.a = a;
+        });
+      `, { looseDefaultParams: true });
     });
 
     it.skip('uses correct value for default param when reusing an already implicitly assigned param', () => {

--- a/test/default_param_test.js
+++ b/test/default_param_test.js
@@ -1,19 +1,106 @@
 import check from './support/check.js';
 
 describe('default params', () => {
-  it('ensures default value is left in place', () => {
-    check(`(a=2) ->`, `(function(a=2) {});`);
+  it('keeps default value with loose mode enabled', () => {
+    check(`(a=2) ->`, `(function(a=2) {});`, { looseDefaultParams: true });
+  });
+
+  it('ensures transforms happen on the default value in loose mode', () => {
+    check(`(a=b c) ->`, `(function(a=b(c)) {});`, { looseDefaultParams: true });
+  });
+
+  it('ensures @foo is transformed correctly in loose mode', () => {
+    check(`(a=@b) ->`, `(function(a=this.b) {});`, { looseDefaultParams: true });
+  });
+
+  it('patches value as an expression in loose mode', () => {
+    check(`(a=b: c) ->`, `(function(a={b: c}) {});`, { looseDefaultParams: true });
+  });
+
+  it('changes default params to conditional assignments by default', () => {
+    check(`
+      (a=b()) ->
+        return
+    `, `
+      (function(a) {
+        if (a == null) { a = b(); }
+      });
+    `);
   });
 
   it('ensures transforms happen on the default value', () => {
-    check(`(a=b c) ->`, `(function(a=b(c)) {});`);
+    check(`
+      (a=b c) ->
+    `, `
+      (function(a) {
+        if (a == null) { a = b(c); }
+      });
+    `);
   });
 
-  it('ensures @foo is transformed correctly', () => {
-    check(`(a=@b) ->`, `(function(a=this.b) {});`);
+  it('handles a `this` assignment and a default param assignment in the same param', () => {
+    check(`
+      a = 3
+      (@a=b()) ->
+        console.log a
+        return
+    `, `
+      let a = 3;
+      (function(a1) {
+        if (a1 == null) { a1 = b(); }
+        this.a = a1;
+        console.log(a);
+      });
+    `);
   });
 
-  it('patches value as an expression', () => {
-    check(`(a=b: c) ->`, `(function(a={b: c}) {});`);
+  it('handles a destructure with a default param', () => {
+    check(`
+      ({a}={}) ->
+        return
+    `, `
+      (function(param) {
+        if (param == null) { param = {}; }
+        let {a} = param;
+      });
+    `);
+  });
+
+  it('handles a multiline destructure with a default param with the expression indented', () => {
+    check(`
+      ->
+        a = ({
+          b,
+        } = {}) ->
+          return c
+    `, `
+      (function() {
+        let a;
+        return a = function(param) {
+          if (param == null) { param = {}; }
+          let {
+            b,
+          } = param;
+          return c;
+        };
+      });
+    `);
+  });
+
+  it('handles a multiline destructure with a default param', () => {
+    check(`
+      a = ({
+        b,
+      } = {}) ->
+        return c
+    `, `
+      let a = function(param) {
+        if (param == null) { param = {}; }
+        let {
+          b,
+        } = param;
+        return c;
+      };
+    `);
   });
 });

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -303,8 +303,12 @@ describe('function calls', () => {
             return cb null, {person, authKey, user, org}
     `, `
       ({
-        _authenticate(authKey, cb) {
-          return this._getSession(authKey, (err, {person, user, authKey, org} = {}) => cb(null, {person, authKey, user, org}));
+          _authenticate(authKey, cb) {
+            return this._getSession(authKey, function(err, param) {
+                let org, person, user;
+                if (param == null) { param = {}; }
+                ({person, user, authKey, org} = param);
+                return cb(null, {person, authKey, user, org});});
         }
       });
     `);

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -229,8 +229,8 @@ describe('functions', () => {
     check(`(args...) =>`, `(...args) => {};`);
   });
 
-  it('keeps function with a single assignment as a parameter in braces', () => {
-    check(`(args=false) =>`, `(args=false) => {};`);
+  it('keeps function with a single assignment as a parameter in braces in loose param mode', () => {
+    check(`(args=false) =>`, `(args=false) => {};`, { looseDefaultParams: true });
   });
 
   it('places the function end in the right place when ending in an implicit function call', () =>


### PR DESCRIPTION
Fixes #125

Now, instead of converting CS default params to JS default params, the default
behavior is to emit assignments behind a null/undefined check. This is more true
to CS semantics: in CS, defaults are used when the argument is null or
undefined, while in JS, they are only used when the argument is undefined.

There was already similar code for handling `this` assignment in parameters, so
I based default parameter code off of that. There were various special cases to
consider:
* In a function like `(@a=b) -> c`, we need to generate code for both the
  default assignment and the `this` assignment, and the variable names need to
  match up.
* In a function like `({a}={}) -> b`, we need to do the null check before the
  destructure since the null check needs to be on a regular variable, so we need
  to introduce a new variable.
* If the destructure is multiline, moving it inside the function might end up
  with code with bad indentation, so adjust the indentation to avoid this.

After handling these cases, decaffeinate can handle all files in my codebase
without crashing, and it doesn't introduce any obvious new correctness issues.

This commit also adds a `--loose-default-params` option to disable this
behavior and instead output the old code that was cleaner but less correct.