### PR TITLE
fix: properly detect break statements within switch cases

### DIFF
--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -433,4 +433,26 @@ describe('switch', () => {
       })();
     `);
   });
+
+  it('handles a switch case with a while loop with a break', () => {
+    check(`
+      switch a
+        when 'b'
+          while false
+            break
+        when 'c'
+          console.log 'Got here'
+    `, `
+      switch (a) {
+        case 'b':
+          while (false) {
+            break;
+          }
+          break;
+        case 'c':
+          console.log('Got here');
+          break;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #607.

Previously, we would detect if the switch case body ends with a `break` token,
but that's actually not good enough; we should directly check that the last
statement is a break statement.