### PR TITLE
fix: properly handle soak expressions combined with `in` operators

### DIFF
--- a/test/soaked_test.js
+++ b/test/soaked_test.js
@@ -459,4 +459,26 @@ describe('soaked expressions', () => {
       }
     `);
   });
+
+  it('properly transforms an `in` operator with a soak expression on the left', () => {
+    check(`
+      a?.b in c
+    `, `
+      c.includes(__guard__(a, x => x.b));
+      function __guard__(value, transform) {
+        return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+      }
+    `);
+  });
+
+  it('properly transforms an `in` operator with a soak expression on the right', () => {
+    check(`
+      a in b?.c
+    `, `
+      __guard__(b, x => x.c).includes(a);
+      function __guard__(value, transform) {
+        return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #606

The `includes` case of `in` patching needs to switch the order of the two
operands, and it was doing this by keeping the right one in place and moving the
left one to the right. However, this could miss some code patched to the left of
the left expression because we use `insertLeft` in magic-string. We can fix this
by simply patching the other way: moving the right side to the left. We can use
`patchAndGetCode` to get the proper patched code, and because the `remove`
operation overlaps `this.right.outerStart`, we don't need to worry about extra
code being left over.

For the same reason, I think in general it's more robust to move the right side
to the left when switching the order of two expressions.