### PR TITLE
test: un-skip some now-passing tests

### DIFF
--- a/test/binary_operator_test.js
+++ b/test/binary_operator_test.js
@@ -142,6 +142,42 @@ describe('binary operators', () => {
     `);
   });
 
+  it.skip('deals gracefully with extra parens in simple binary existential operators', () => {
+    check(`a ? (b)`, `if ((typeof a !== "undefined" && a !== null)) { a; } else { b; }`);
+  });
+
+  it.skip('deals gracefully with extra parens in complex binary existential operators', () => {
+    check(
+      `@a ? (@b)`,
+      `
+         var ref;
+         if (((ref = this.a) != null)) { ref; } else { this.b; }
+        `
+    );
+  });
+
+  it('prevents using temporary variables that clash with existing bindings', () => {
+    check(`
+        left = 1
+        x = a() ? @b
+      `, `
+        let left1;
+        let left = 1;
+        let x = (left1 = a()) != null ? left1 : this.b;
+      `);
+  });
+
+  it('prevents using temporary variables that clash with existing temporary variables', () => {
+    check(`
+        x = a() ? @b
+        y = c() ? @d
+      `, `
+        let left, left1;
+        let x = (left = a()) != null ? left : this.b;
+        let y = (left1 = c()) != null ? left1 : this.d;
+      `);
+  });
+
   it('handles binary existence operator combined with plus', () => {
     check(`
       x = 1 + (y ? 0)

--- a/test/decaffeinate_test.js
+++ b/test/decaffeinate_test.js
@@ -191,55 +191,5 @@ describe('automatic conversions', () => {
         d(e);
       `);
     });
-
-    it.skip('handles simple binary existential operators', () => {
-      check(`a ? b`, `if ((typeof a !== "undefined" && a !== null)) { a; } else { b; }`);
-    });
-
-    it.skip('deals gracefully with extra parens in simple binary existential operators', () => {
-      check(`a ? (b)`, `if ((typeof a !== "undefined" && a !== null)) { a; } else { b; }`);
-    });
-
-    it.skip('handles complex binary existential operators', () => {
-      check(
-        `@a ? @b`,
-      `
-        var ref;
-        if (((ref = this.a) != null)) { ref; } else { this.b; }
-      `);
-    });
-
-    it.skip('deals gracefully with extra parens in complex binary existential operators', () => {
-      check(
-        `@a ? (@b)`,
-        `
-         var ref;
-         if (((ref = this.a) != null)) { ref; } else { this.b; }
-        `
-      );
-    });
-
-    it.skip('prevents using temporary variables that clash with existing bindings', () => {
-      check(`
-        ref = 1
-        @a ? @b
-      `, `
-        var ref1;
-        var ref = 1;
-        if (((ref1 = this.a) != null)) { ref1; } else { this.b; }
-      `);
-    });
-
-    it.skip('prevents using temporary variables that clash with existing temporary variables', () => {
-      check(`
-        @a ? @b
-        @c ? @d
-      `, `
-        var ref;
-        var ref1;
-        if (((ref = this.a) != null)) { ref; } else { this.b; }
-        if (((ref1 = this.c) != null)) { ref1; } else { this.d; }
-      `);
-    });
   });
 });

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -402,7 +402,7 @@ describe('for loops', () => {
     `);
   });
 
-  it.skip('special-cases for-in inclusive range loops to avoid creating arrays', () => {
+  it('special-cases for-in inclusive range loops to avoid creating arrays', () => {
     check(`
       for i in [0..10]
         i
@@ -413,7 +413,7 @@ describe('for loops', () => {
     `);
   });
 
-  it.skip('special-cases for-in exclusive range loops to avoid creating arrays', () => {
+  it('special-cases for-in exclusive range loops to avoid creating arrays', () => {
     check(`
       for i in [0...10]
         i
@@ -424,7 +424,7 @@ describe('for loops', () => {
     `);
   });
 
-  it.skip('special-cases descending for-in inclusive range loops to avoid creating arrays', () => {
+  it('special-cases descending for-in inclusive range loops to avoid creating arrays', () => {
     check(`
       for i in [10..0]
         i
@@ -435,7 +435,7 @@ describe('for loops', () => {
     `);
   });
 
-  it.skip('special-cases descending for-in exclusive range loops to avoid creating arrays', () => {
+  it('special-cases descending for-in exclusive range loops to avoid creating arrays', () => {
     check(`
       for i in [10...0]
         i
@@ -446,7 +446,7 @@ describe('for loops', () => {
     `);
   });
 
-  it.skip('special-cases descending for-in range loops with step count to avoid creating arrays', () => {
+  it('special-cases descending for-in range loops with step count to avoid creating arrays', () => {
     check(`
       for i in [100..0] by -2
         i

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -134,19 +134,13 @@ describe('function calls', () => {
     check(`(a)()`, `(a)();`);
   });
 
-  it.skip('works with a multi-line callee', () => {
-    // FIXME: This doesn't work because FunctionApplicationPatcher thinks it is
-    // an implicit call (i.e. no parens), since the token after the function is
-    // a newline and not a CALL_START (i.e. ')'). We should switch to coffee-lex
-    // tokens and skip past any NEWLINE, COMMENT, or HERECOMMENT tokens.
+  it('works with a multi-line callee', () => {
     check(`
-      (->
+      x = (->
         1
       )()
     `, `
-      (function() {
-        return 1;
-      )();
+      let x = (() => 1)();
     `);
   });
 

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -61,7 +61,7 @@ describe('functions', () => {
     `);
   });
 
-  it.skip('puts the closing punctuation after trailing comments for multi-line bodies', () => {
+  it('puts the closing punctuation after trailing comments for multi-line bodies', () => {
     check(`
       validExpirationDate = (month, year) ->
         today = new Date()

--- a/test/indentation_test.js
+++ b/test/indentation_test.js
@@ -17,7 +17,7 @@ describe('indentation', () => {
     check(`if a\n\tif b\n\t\tc`, `if (a) {\n\tif (b) {\n\t\tc;\n\t}\n}`);
   });
 
-  it.skip('matches indentation when adding standalone lines', () => {
+  it('matches indentation when adding standalone lines', () => {
     check(`if a\n\tswitch b\n\t\twhen c\n\t\t\td`, `if (a) {\n\tswitch (b) {\n\t\tcase c:\n\t\t\td;\n\t\t\tbreak;\n\t}\n}`);
   });
 

--- a/test/parameter_assignment_test.js
+++ b/test/parameter_assignment_test.js
@@ -27,7 +27,7 @@ describe('parameter assignment', () => {
     `);
   });
 
-  it.skip('adds assignments to `this` properties before any function body', () => {
+  it('adds assignments to `this` properties before any function body', () => {
     check(`
       (@a, @b) ->
         @a + @b
@@ -40,24 +40,24 @@ describe('parameter assignment', () => {
     `);
   });
 
-  it.skip('does not clobber any variables declared in the function scope', () => {
+  it('does not clobber any variables declared in the function scope', () => {
     check(`
       a = 1
       (@a, @b) ->
         b = 2
         a + b
     `, `
-      var a = 1;
+      let a = 1;
       (function(a1, b1) {
         this.a = a1;
         this.b = b1;
-        var b = 2;
+        let b = 2;
         return a + b;
       });
     `);
   });
 
-  it.skip('inserts the assignments at the right indentation', () => {
+  it('inserts the assignments at the right indentation', () => {
     check(`
       if true
         (@a) ->
@@ -72,7 +72,7 @@ describe('parameter assignment', () => {
     `);
   });
 
-  it.skip('inserts all assignments with the right indentation', () => {
+  it('inserts all assignments with the right indentation', () => {
     check(`
       z()
 
@@ -81,10 +81,11 @@ describe('parameter assignment', () => {
     `, `
       z();
 
-      ({a(b) {
-          this.b = b;
-          return this.b;
-      }
+      ({
+          a(b) {
+              this.b = b;
+              return this.b;
+          }
       });
     `);
   });
@@ -109,13 +110,14 @@ describe('parameter assignment', () => {
     `);
   });
 
-  it.skip('ensures parameters with default values are not redeclared', () => {
+  it('ensures parameters with default values are not redeclared', () => {
     check(`
       (a=0) ->
         a ?= 1
     `, `
-      (function(a=0) {
-        if ((typeof a !== "undefined" && a !== null)) { return a; } else { return a = 1; }
+      (function(a) {
+        if (a == null) { a = 0; }
+        return a != null ? a : (a = 1);
       });
     `);
   });

--- a/test/semicolon_test.js
+++ b/test/semicolon_test.js
@@ -1,25 +1,25 @@
 import check from './support/check';
 
 describe('semicolons', () => {
-  it.skip('are inserted after all the parentheses surrounding statements', () => {
+  it('are inserted after all the parentheses surrounding statements', () => {
     check(`
       ((->
         result)())
+      a
     `, `
-      ((function() {
-        return result;
-      })());
+      ((() => result)());
+      a;
     `);
   });
 
-  it.skip('are inserted after the closing function braces for a function expression', () => {
+  it('are inserted after the closing function braces for a function expression', () => {
     check(`
       a = ->
-        b # c
+        arguments # c
       d
     `, `
       let a = function() {
-        return b; // c
+        return arguments; // c
       };
       d;
     `);
@@ -60,13 +60,12 @@ describe('semicolons', () => {
     `);
   });
 
-  it.skip('does not add them after `for` loops', () => {
+  it('does not add them after `for` loops', () => {
     check(`
       for a in b
         a
     `, `
-      for (let i = 0, a; i < b.length; i++) {
-        a = b[i];
+      for (let a of b) {
         a;
       }
     `);


### PR DESCRIPTION
This brings the number of skipped tests down from 42 to 22. Some of these just
worked without needing any modification, and others were working in spirit, but
needed to be tweaked to match the current output. I also moved some tests out of
decaffeinate_test.js to a more appropriate place, and removed some duplicate
tests.