### PR TITLE
fix: update esnext and fix a scoping issue introduced by the bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "decaffeinate-coffeescript": "^1.10.0-patch5",
     "decaffeinate-parser": "^6.0.0",
     "detect-indent": "^4.0.0",
-    "esnext": "^3.0.7",
+    "esnext": "^3.0.9",
     "lines-and-columns": "^1.1.5",
     "magic-string": "^0.17.0",
     "repeating": "^2.0.0"

--- a/src/stages/main/patchers/LoopPatcher.js
+++ b/src/stages/main/patchers/LoopPatcher.js
@@ -101,7 +101,7 @@ export default class LoopPatcher extends NodePatcher {
 
     if (this.willPatchAsExpression() && !this.allBodyCodePathsPresent()) {
       let itemBinding = this.getResultArrayElementBinding();
-      this.body.insertStatementsAtIndex([`var ${itemBinding}`], 0);
+      this.body.insertStatementsAtIndex([`let ${itemBinding}`], 0);
       this.body.patch({ leftBrace: false, rightBrace: false });
       this.body.insertStatementsAtIndex(
         [`${this.getResultArrayBinding()}.push(${itemBinding})`],

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -560,7 +560,7 @@ describe('conditionals', () => {
       let x = (() => {
         let result = [];
         for (let i = 0; i < b.length; i++) {
-          let a = b[i];
+          var a = b[i];
           let y = 
             (() => {
             if (a) {

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -420,7 +420,7 @@ describe('switch', () => {
       let x = (() => {
         let result = [];
         for (let i = 0; i < b.length; i++) {
-          let a = b[i];
+          var a = b[i];
           let y = (() => { switch (a) {
             case 'c':
               return d;


### PR DESCRIPTION
decaffeinate's code for handling IIFE-style loop expressions would insert a
`var` declaration for a temporary variable to receive the value for the current
iteration. But a `var` declaration is actually wrong, because in some cases it
would end up with the previous loop iteration's value, so we should generate
`let` instead.