### PR TITLE
refactor: rework makeRepeatable to be more integrated with patching

### DIFF
--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -397,15 +397,15 @@ actually edits `a().b ||= c` to become:
 
 [locaop]: https://github.com/decaffeinate/decaffeinate/blob/master/src/stages/main/patchers/LogicalOpCompoundAssignOpPatcher.js
 
-How does this work? This is accomplished by the `makeRepeatable` method on
+How does this work? This is accomplished by the `patchRepeatable` method on
 patchers. It is responsible for editing its node to store the side-effecty parts
-in a temporary variable and return the source code needed to reference the same
-value again. For simple values like integers and non-interpolated strings, they
-make no edits and simply return their original source. Each patcher is
+in a temporary variable and returning the source code needed to reference the
+same value again. For simple values like integers and non-interpolated strings,
+they make no edits and simply return their original source. Each patcher is
 responsible for implementing both `isRepeatable` to determine whether it is safe
-to repeat the source as-is, and if it could ever return `false`, a
-`makeRepeatable` override as well. See [`MemberAccessOpPatcher`][maop] for an
-example.
+to repeat the source as-is. The `patchAsRepeatableExpression` method can be
+overridden to provide a custom behavior for making the expression repeatable.
+See [`MemberAccessOpPatcher`][maop] for an example.
 
 [maop]: https://github.com/decaffeinate/decaffeinate/blob/master/src/stages/main/patchers/MemberAccessOpPatcher.js
 

--- a/src/patchers/PassthroughPatcher.js
+++ b/src/patchers/PassthroughPatcher.js
@@ -9,15 +9,13 @@ export default class PassthroughPatcher extends NodePatcher {
     this.children = children;
   }
 
-  patch() {
-    this.withPrettyErrors(() => {
-      this.children.forEach(child => {
-        if (Array.isArray(child)) {
-          child.forEach(child => child && child.patch());
-        } else if (child) {
-          child.patch();
-        }
-      });
+  patchAsExpression() {
+    this.children.forEach(child => {
+      if (Array.isArray(child)) {
+        child.forEach(child => child && child.patch());
+      } else if (child) {
+        child.patch();
+      }
     });
   }
 

--- a/src/patchers/types.js
+++ b/src/patchers/types.js
@@ -33,7 +33,7 @@ export type PatcherContext = {
   options: Options;
 };
 
-export type MakeRepeatableOptions = {
+export type RepeatableOptions = {
   parens: ?boolean,
   ref: ?string,
 };

--- a/src/stages/main/patchers/ChainedComparisonOpPatcher.js
+++ b/src/stages/main/patchers/ChainedComparisonOpPatcher.js
@@ -22,16 +22,18 @@ export default class ChainedComparisonOpPatcher extends NodePatcher {
   }
 
   patchAsExpression() {
+    for (let operand of this.getMiddleOperands()) {
+      operand.setRequiresRepeatableExpression({ parens: true, ref: 'middle' });
+    }
     this.expression.patch();
-    this.getMiddleOperands().forEach(middle => {
-      let middleAgain = middle.makeRepeatable({ parens: true, ref: 'middle' });
+    for (let operand of this.getMiddleOperands()) {
       // `a < b < c` → `a < b && b < c`
       //                     ^^^^^
       this.insert(
-        middle.outerEnd,
-        ` ${this.negated ? '||' : '&&'} ${middleAgain}`
+        operand.outerEnd,
+        ` ${this.negated ? '||' : '&&'} ${operand.getRepeatCode()}`
       );
-    });
+    }
   }
 
   /**

--- a/src/stages/main/patchers/ExistsOpCompoundAssignOpPatcher.js
+++ b/src/stages/main/patchers/ExistsOpCompoundAssignOpPatcher.js
@@ -9,8 +9,7 @@ export default class ExistsOpCompoundAssignOpPatcher extends CompoundAssignOpPat
       // `a ?= b` → `typeof a ?= b`
       //             ^^^^^^^
       this.insert(this.assignee.outerStart, `typeof `);
-      this.assignee.patch();
-      assigneeAgain = this.assignee.makeRepeatable();
+      assigneeAgain = this.assignee.patchRepeatable();
       // `typeof a ? b` → `typeof a !== 'undefined' && a !== null ? a ?= b`
       //                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       this.insert(
@@ -18,8 +17,7 @@ export default class ExistsOpCompoundAssignOpPatcher extends CompoundAssignOpPat
         ` !== 'undefined' && ${assigneeAgain} !== null ? ${assigneeAgain}`
       );
     } else {
-      this.assignee.patch();
-      assigneeAgain = this.assignee.makeRepeatable();
+      assigneeAgain = this.assignee.patchRepeatable();
       // `a.b ?= b` → `a.b != null ? a.b ?= b`
       //                  ^^^^^^^^^^^^^^
       this.insert(this.assignee.outerEnd, ` != null ? ${assigneeAgain}`);
@@ -46,8 +44,7 @@ export default class ExistsOpCompoundAssignOpPatcher extends CompoundAssignOpPat
       // `a ?= b` → `if (typeof a ?= b`
       //             ^^^^^^^^^^^
       this.insert(this.assignee.outerStart, `if (typeof `);
-      this.assignee.patch();
-      assigneeAgain = this.assignee.makeRepeatable();
+      assigneeAgain = this.assignee.patchRepeatable();
       // `if (typeof a ?= b` → `if (typeof a === 'undefined' || a === null) { ?= b`
       //                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       this.insert(
@@ -58,8 +55,7 @@ export default class ExistsOpCompoundAssignOpPatcher extends CompoundAssignOpPat
       // `a.b ?= b` → `if (a.b ?= b`
       //               ^^^^
       this.insert(this.assignee.outerStart, `if (`);
-      this.assignee.patch();
-      assigneeAgain = this.assignee.makeRepeatable();
+      assigneeAgain = this.assignee.patchRepeatable();
       // `if (a.b ?= b` → `if (a.b == null) { ?= b`
       //                          ^^^^^^^^^^^
       this.insert(this.assignee.outerEnd, ` == null) {`);

--- a/src/stages/main/patchers/ExistsOpPatcher.js
+++ b/src/stages/main/patchers/ExistsOpPatcher.js
@@ -14,8 +14,7 @@ export default class ExistsOpPatcher extends BinaryOpPatcher {
       // `a ? b` → `typeof a ? b`
       //            ^^^^^^^
       this.insert(this.contentStart, `typeof `);
-      let leftAgain = this.left.makeRepeatable({ parens: true, ref: 'left' });
-      this.left.patch();
+      let leftAgain = this.left.patchRepeatable({ parens: true, ref: 'left' });
       // `typeof a ? b` → `typeof a !== 'undefined' && a !== null ? a : b`
       //          ^^^              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       this.overwrite(
@@ -24,8 +23,7 @@ export default class ExistsOpPatcher extends BinaryOpPatcher {
         ` !== 'undefined' && ${leftAgain} !== null ? ${leftAgain} : `
       );
     } else {
-      let leftAgain = this.left.makeRepeatable({ parens: true, ref: 'left' });
-      this.left.patch();
+      let leftAgain = this.left.patchRepeatable({ parens: true, ref: 'left' });
       // `a.b ? c` → `a.b != null ? a.b : c`
       //     ^^^         ^^^^^^^^^^^^^^^^^
       this.overwrite(
@@ -48,9 +46,8 @@ export default class ExistsOpPatcher extends BinaryOpPatcher {
     // `a ? b` → `if (a ? b`
     //            ^^^
     this.insert(this.contentStart, `if (`);
-    this.left.patch();
     if (needsTypeofCheck) {
-      let leftAgain = this.left.makeRepeatable();
+      let leftAgain = this.left.patchRepeatable();
       // `if (a ? b` → `if (typeof a ? b`
       //                    ^^^^^^^
       this.insert(this.contentStart, `typeof `);
@@ -62,6 +59,7 @@ export default class ExistsOpPatcher extends BinaryOpPatcher {
         ` === 'undefined' || ${leftAgain} === null) { `
       );
     } else {
+      this.left.patch();
       // `if (a.b ? b.c` → `if (a.b == null) { b.c`
       //         ^^^               ^^^^^^^^^^^^
       this.overwrite(

--- a/src/stages/main/patchers/LogicalOpCompoundAssignOpPatcher.js
+++ b/src/stages/main/patchers/LogicalOpCompoundAssignOpPatcher.js
@@ -12,8 +12,7 @@ export default class LogicalOpCompoundAssignOpPatcher extends CompoundAssignOpPa
       this.isOrOp() ? `||` : `&&`
     );
 
-    let assigneeAgain = this.assignee.makeRepeatable();
-    this.assignee.patch();
+    let assigneeAgain = this.assignee.patchRepeatable();
 
     // `a && b` → `a && (a = b`
     //                  ^^^^^
@@ -35,8 +34,7 @@ export default class LogicalOpCompoundAssignOpPatcher extends CompoundAssignOpPa
       this.assignee.negate();
     }
 
-    let assigneeAgain = this.assignee.makeRepeatable();
-    this.assignee.patch();
+    let assigneeAgain = this.assignee.patchRepeatable();
 
     // `if (a &&= b` → `if (a) { a = b`
     //       ^^^^^           ^^^^^^^^

--- a/src/stages/main/patchers/MemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/MemberAccessOpPatcher.js
@@ -1,5 +1,5 @@
 import NodePatcher from './../../../patchers/NodePatcher';
-import type { MakeRepeatableOptions, PatcherContext, SourceToken } from './../../../patchers/types';
+import type { RepeatableOptions, PatcherContext, SourceToken } from './../../../patchers/types';
 import { SourceType } from 'coffee-lex';
 
 export default class MemberAccessOpPatcher extends NodePatcher {
@@ -39,6 +39,17 @@ export default class MemberAccessOpPatcher extends NodePatcher {
       //          ^
       this.insert(this.expression.outerEnd, '.');
     }
+  }
+
+  /**
+   * We can make member accesses repeatable by making the base expression
+   * repeatable if it isn't already.
+   */
+  patchAsRepeatableExpression(repeatableOptions: RepeatableOptions={}, patchOptions={}): string {  // eslint-disable-line no-unused-vars
+    this.expression.setRequiresRepeatableExpression({ parens: true, ref: 'base' });
+    this.patchAsExpression();
+    let expressionCode = this.expression.getRepeatCode();
+    return `${expressionCode}.${this.getFullMemberName()}`;
   }
 
   hasImplicitOperator(): boolean {
@@ -109,15 +120,6 @@ export default class MemberAccessOpPatcher extends NodePatcher {
    */
   isRepeatable(): boolean {
     return this.expression.isRepeatable();
-  }
-
-  /**
-   * We can make member accesses repeatable by making the base expression
-   * repeatable if it isn't already.
-   */
-  makeRepeatable(options: MakeRepeatableOptions = {}) { // eslint-disable-line no-unused-vars
-    let expression = this.expression.makeRepeatable({ parens: true, ref: 'base' });
-    return `${expression}.${this.getFullMemberName()}`;
   }
 
   /**

--- a/src/stages/main/patchers/ObjectInitialiserMemberPatcher.js
+++ b/src/stages/main/patchers/ObjectInitialiserMemberPatcher.js
@@ -46,13 +46,7 @@ export default class ObjectInitialiserMemberPatcher extends ObjectBodyMemberPatc
         this.insert(key.outerStart, '[');
       }
 
-      let valueCode;
-      if (key.isRepeatable()) {
-        valueCode = key.patchAndGetCode();
-      } else {
-        key.patch();
-        valueCode = key.makeRepeatable();
-      }
+      let valueCode = key.patchRepeatable();
 
       if (isComputed) {
         this.insert(key.outerEnd, ']');

--- a/src/stages/main/patchers/ThisPatcher.js
+++ b/src/stages/main/patchers/ThisPatcher.js
@@ -1,5 +1,4 @@
 import NodePatcher from './../../../patchers/NodePatcher';
-import type { MakeRepeatableOptions } from '../../../patchers/types';
 
 export default class ThisPatcher extends NodePatcher {
   patchAsExpression() {
@@ -14,9 +13,5 @@ export default class ThisPatcher extends NodePatcher {
 
   isRepeatable(): boolean {
     return true;
-  }
-
-  makeRepeatable(options: MakeRepeatableOptions = {}): string { // eslint-disable-line no-unused-vars
-    return 'this';
   }
 }

--- a/test/chained_comparison_test.js
+++ b/test/chained_comparison_test.js
@@ -47,6 +47,15 @@ describe('chained comparison', () => {
     `);
   });
 
+  it('handles an intermediate expression with nontrivial patching', () => {
+    check(`
+      a < (b ? c) < d
+    `, `
+      let middle;
+      a < ((middle = typeof b !== 'undefined' && b !== null ? b : c)) && middle < d;
+    `);
+  });
+
   it('is fine being used in an expression context', () => {
     check(`
       if a < b < c


### PR DESCRIPTION
Progress toward #592

Previously, `makeRepeatable` was a function that you would call around the time
of `patch` (sometimes before, sometimes after) that would sometimes do some
magic-string operations to extract the expression into a variable. However,
this had some problems:
* To be friendly with magic-string, all code should be patched in order, meaning
  that some of the `makeRepeatable` code should run before patching the node and
  some should run after, rather than them being separate operations.
* Because there was no obvious relation between patching and `makeRepeatable`,
  the `isRepeatable` case couldn't assume that the code was already patched and
  just returned the old CoffeeScript code, which only worked in simple cases
  like identifiers. Even if the expression was already patched, getting the
  accurate code after patching is hard; getting the code while patching, like in
  `patchAndGetCode`, is more reasonable.
* `ThisPatcher` needed a special case to work around some of these issues
  (particularly related to the fact that sometimes the CoffeeScript code is just
  `@`).

The new way of thinking about `makeRepeatable` is similar to
`setRequiresExpression` and `setImplicitlyReturns`: you call
`setRequiresRepeatableExpression` to inform the patcher that whenever it runs
its patching code, it must do so in a way that the expression is repeatable, and
the code to access the value again is then accessible as `getRepeatCode`. The
new `patchRepeatable` method is a new external-facing method that roughly
replaces `makeRepeatable` and also does patching at the same time, so most cases
could be moved to just use that.

While I'm generally not a big fan of the stateful style of doing things, it
ended up being the most reasonable approach I could think of, especially when
dealing with patchers like `ChainedComparisonOpPatcher` that want to run the
regular patching code with some modifications, then access the repeat code for
expressions relatively deep within the AST.