### PR TITLE
fix: only use assignment-style repeatable expressions when necessary

### DIFF
--- a/src/patchers/types.js
+++ b/src/patchers/types.js
@@ -36,6 +36,7 @@ export type PatcherContext = {
 export type RepeatableOptions = {
   parens: ?boolean,
   ref: ?string,
+  isForAssignment: ?boolean,
 };
 
 export type SourceType = number;

--- a/src/stages/main/patchers/DynamicMemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/DynamicMemberAccessOpPatcher.js
@@ -28,11 +28,15 @@ export default class DynamicMemberAccessOpPatcher extends NodePatcher {
    * save the value of the member access because this could be used as the LHS
    * of an assignment.
    */
-  patchAsRepeatableExpression(repeatableOptions: RepeatableOptions={}, patchOptions={}): string {  // eslint-disable-line no-unused-vars
-    this.expression.setRequiresRepeatableExpression({ parens: true, ref: 'base' });
-    this.indexingExpr.setRequiresRepeatableExpression({ ref: 'name' });
-    this.patchAsExpression();
-    return `${this.expression.getRepeatCode()}[${this.indexingExpr.getRepeatCode()}]`;
+  patchAsRepeatableExpression(repeatableOptions: RepeatableOptions={}, patchOptions={}): string {
+    if (repeatableOptions.isForAssignment) {
+      this.expression.setRequiresRepeatableExpression({ isForAssignment: true, parens: true, ref: 'base' });
+      this.indexingExpr.setRequiresRepeatableExpression({ ref: 'name' });
+      this.patchAsExpression();
+      return `${this.expression.getRepeatCode()}[${this.indexingExpr.getRepeatCode()}]`;
+    } else {
+      return super.patchAsRepeatableExpression(repeatableOptions, patchOptions);
+    }
   }
 
   /**

--- a/src/stages/main/patchers/LogicalOpCompoundAssignOpPatcher.js
+++ b/src/stages/main/patchers/LogicalOpCompoundAssignOpPatcher.js
@@ -12,7 +12,7 @@ export default class LogicalOpCompoundAssignOpPatcher extends CompoundAssignOpPa
       this.isOrOp() ? `||` : `&&`
     );
 
-    let assigneeAgain = this.assignee.patchRepeatable();
+    let assigneeAgain = this.assignee.patchRepeatable({ isForAssignment: true });
 
     // `a && b` → `a && (a = b`
     //                  ^^^^^
@@ -26,6 +26,11 @@ export default class LogicalOpCompoundAssignOpPatcher extends CompoundAssignOpPa
   }
 
   patchAsStatement() {
+    if (this.lhsHasSoakOperation()) {
+      this.patchAsExpression();
+      return;
+    }
+
     // `a &&= b` → `if (a &&= b`
     //              ^^^^
     this.insert(this.contentStart, 'if (');
@@ -34,7 +39,7 @@ export default class LogicalOpCompoundAssignOpPatcher extends CompoundAssignOpPa
       this.assignee.negate();
     }
 
-    let assigneeAgain = this.assignee.patchRepeatable();
+    let assigneeAgain = this.assignee.patchRepeatable({ isForAssignment: true });
 
     // `if (a &&= b` → `if (a) { a = b`
     //       ^^^^^           ^^^^^^^^

--- a/src/stages/main/patchers/MemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/MemberAccessOpPatcher.js
@@ -46,10 +46,13 @@ export default class MemberAccessOpPatcher extends NodePatcher {
    * repeatable if it isn't already.
    */
   patchAsRepeatableExpression(repeatableOptions: RepeatableOptions={}, patchOptions={}): string {  // eslint-disable-line no-unused-vars
-    this.expression.setRequiresRepeatableExpression({ parens: true, ref: 'base' });
-    this.patchAsExpression();
-    let expressionCode = this.expression.getRepeatCode();
-    return `${expressionCode}.${this.getFullMemberName()}`;
+    if (repeatableOptions.isForAssignment) {
+      this.expression.setRequiresRepeatableExpression({ isForAssignment: true, parens: true, ref: 'base' });
+      this.patchAsExpression();
+      return `${this.expression.getRepeatCode()}.${this.getFullMemberName()}`;
+    } else {
+      return super.patchAsRepeatableExpression(repeatableOptions, patchOptions);
+    }
   }
 
   hasImplicitOperator(): boolean {

--- a/test/binary_operator_test.js
+++ b/test/binary_operator_test.js
@@ -125,6 +125,15 @@ describe('binary operators', () => {
     `);
   });
 
+  it('handles binary existence operator with a this-access on the left side', () => {
+    check(`
+      (@a.b ? c)
+    `, `
+      (this.a.b != null ? this.a.b : c);
+    `);
+  });
+
+
   it('handles binary existence operator with an unsafe-to-repeat member expression as a statement', () => {
     check(`
       a() ? b

--- a/test/soaked_test.js
+++ b/test/soaked_test.js
@@ -481,4 +481,78 @@ describe('soaked expressions', () => {
       }
     `);
   });
+
+  it('handles a soaked access used with an existence operator', () => {
+    check(`
+      a = b()?.c ? d
+    `, `
+      let left;
+      let a = (left = __guard__(b(), x => x.c)) != null ? left : d;
+      function __guard__(value, transform) {
+        return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+      }
+    `);
+  });
+
+  it('handles a soaked dynamic access used with an existence operator', () => {
+    check(`
+      a = b()?[c()] ? d
+    `, `
+      let left;
+      let a = (left = __guard__(b(), x => x[c()])) != null ? left : d;
+      function __guard__(value, transform) {
+        return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+      }
+    `);
+  });
+
+  it('handles a soaked access used with an existence assignment operator', () => {
+    check(`
+      a()?.b ?= c
+    `, `
+      let base;
+      __guard__((base = a()), x => x.b != null ? base.b : (base.b = c));
+      function __guard__(value, transform) {
+        return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+      }
+    `);
+  });
+
+  it('handles a soaked dynamic access used with an existence assignment operator', () => {
+    check(`
+      a()?[b()] ?= d
+    `, `
+      let base;
+      let name;
+      __guard__((base = a()), x => x[name = b()] != null ? base[name] : (base[name] = d));
+      function __guard__(value, transform) {
+        return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+      }
+    `);
+  });
+
+  it('handles a soaked access used with a logical assignment operator', () => {
+    check(`
+      a()?.b and= c
+    `, `
+      let base;
+      __guard__((base = a()), x => x.b && (base.b = c));
+      function __guard__(value, transform) {
+        return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+      }
+    `);
+  });
+
+  it('handles a soaked dynamic access used with a logical assignment operator', () => {
+    check(`
+      a()?[b()] and= d
+    `, `
+      let base;
+      let name;
+      __guard__((base = a()), x => x[name = b()] && (base[name] = d));
+      function __guard__(value, transform) {
+        return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #592

Patching for soak operations is a bit fragile because the `__guard__(` and the
close-paren are inserted in code outside of the soak operation itself. This is
made more complicated with repeatable expressions, since both want to surround
the code in similar ways.

In member access expressions (including soaked member access), the code to make
the expression repeatable needed more complexity to make it so the repeated
result is still a valid assignee, but this complexity was only needed in two
assignment cases. To limit problems caused by this approach, and make the code a
little nicer in some cases, the behavior is now opt-in: when making an
expression repeatable, you can pass an `isForAssignment` flag to indicate that
the patching needs to be done in a way that the repeated code is valid to assign
to, not just valid to use an expression.

The problem from #592 doesn't come up for assignments because the soak container
(as evaluated by `findSoakContainer`) includes the whole assignment expression,
so code isn't being inserted in a conflicting way. So this doesn't feel like an
excellent solution, but it works in all cases that I know. Maybe in the future,
`__guard__` patching will need to be changed to always patch in order (or
replaced with another approach), but this works for now.

Also fix an issue where the fix for #512 needed to be applied to logical
compound assignment operators as well.