### PR TITLE
feat: change loops and loop expressions to be strictly correct by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Options:
   and `export`.
 * `--prefer-const`: Use `const` when possible in output code.
 * `--loose-default-params`: Convert CS default params to JS default params.
+* `--loose-for-expressions`: Do not wrap expression loop targets in `Array.from`.
+* `--loose-for-of`: Do not wrap JS `for...of` loop targets in `Array.from`.
 
 For more usages examples, see the output of `decaffeinate --help`.
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -52,6 +52,14 @@ function parseArguments(args: Array<string>): CLIOptions {
         baseOptions.looseDefaultParams = true;
         break;
 
+      case '--loose-for-expressions':
+        baseOptions.looseForExpressions = true;
+        break;
+
+      case '--loose-for-of':
+        baseOptions.looseForOf = true;
+        break;
+
       default:
         if (arg.startsWith('-')) {
           console.error(`Error: unrecognized option '${arg}'`);
@@ -172,10 +180,12 @@ function usage() {
   console.log();
   console.log('OPTIONS');
   console.log();
-  console.log('  -h, --help              Display this help message.');
-  console.log('  --keep-commonjs         Do not convert require and module.exports to import and export.');
-  console.log('  --prefer-const          Use the const keyword for variables when possible.');
-  console.log('  --loose-default-params  Convert CS default params to JS default params.');
+  console.log('  -h, --help               Display this help message.');
+  console.log('  --keep-commonjs          Do not convert require and module.exports to import and export.');
+  console.log('  --prefer-const           Use the const keyword for variables when possible.');
+  console.log('  --loose-default-params   Convert CS default params to JS default params.');
+  console.log('  --loose-for-expressions  Do not wrap expression loop targets in Array.from.');
+  console.log('  --loose-for-of           Do not wrap JS for...of loop targets in Array.from.');
   console.log();
   console.log('EXAMPLES');
   console.log();

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,8 @@ export type Options = {
   keepCommonJS: ?boolean,
   preferConst: ?boolean,
   looseDefaultParams: ?boolean,
+  looseForExpressions: ?boolean,
+  looseForOf: ?boolean,
 };
 
 const DEFAULT_OPTIONS = {
@@ -31,6 +33,8 @@ const DEFAULT_OPTIONS = {
   keepCommonJS: false,
   preferConst: false,
   looseDefaultParams: false,
+  looseForExpressions: false,
+  looseForOf: false,
 };
 
 type ConversionResult = {

--- a/test/continue_test.js
+++ b/test/continue_test.js
@@ -6,7 +6,7 @@ describe('continue', () => {
       for a in b
         continue
     `, `
-      for (let a of b) {
+      for (let a of Array.from(b)) {
         continue;
       }
     `);

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -82,7 +82,29 @@ describe('for loops', () => {
       for a in b
         a
     `, `
+      for (let a of Array.from(b)) {
+        a;
+      }
+    `);
+  });
+
+  it('skips Array.from when generating a JS for-of loop in loose mode', () => {
+    check(`
+      for a in b
+        a
+    `, `
       for (let a of b) {
+        a;
+      }
+    `, { looseForOf: true });
+  });
+
+  it('skips Array.from when iterating over an array literal', () => {
+    check(`
+      for a in [1, 2, 3]
+        a
+    `, `
+      for (let a of [1, 2, 3]) {
         a;
       }
     `);
@@ -151,7 +173,7 @@ describe('for loops', () => {
       for { a, b } in c
         a + b
     `, `
-      for (let { a, b } of c) {
+      for (let { a, b } of Array.from(c)) {
         a + b;
       }
     `);
@@ -326,7 +348,7 @@ describe('for loops', () => {
       for a in b when a.c
         a
     `, `
-      for (let a of b) {
+      for (let a of Array.from(b)) {
         if (a.c) {
           a;
         }
@@ -352,7 +374,7 @@ describe('for loops', () => {
     check(`
       for a in b when a.c then a
     `, `
-      for (let a of b) { if (a.c) { a; } }
+      for (let a of Array.from(b)) { if (a.c) { a; } }
     `);
   });
 
@@ -396,7 +418,7 @@ describe('for loops', () => {
       for e in list()
         break
     `, `
-      for (let e of list()) {
+      for (let e of Array.from(list())) {
         break;
       }
     `);
@@ -505,7 +527,7 @@ describe('for loops', () => {
     check(`
       e for e in l
     `, `
-      for (let e of l) { e; }
+      for (let e of Array.from(l)) { e; }
     `);
   });
 
@@ -543,7 +565,23 @@ describe('for loops', () => {
     check(`
       a(e for e in l)
     `, `
+      a(Array.from(l).map((e) => e));
+    `);
+  });
+
+  it('skips Array.from when using looseForExpressions', () => {
+    check(`
+      a(e for e in l)
+    `, `
       a(l.map((e) => e));
+    `, { looseForExpressions: true });
+  });
+
+  it('does not wrap in Array.from for for-in expressions over an array literal', () => {
+    check(`
+      a(b for b in [c, d])
+    `, `
+      a([c, d].map((b) => b));
     `);
   });
 
@@ -552,7 +590,7 @@ describe('for loops', () => {
       ->
         a for a in b
     `, `
-      () => b.map((a) => a);
+      () => Array.from(b).map((a) => a);
     `);
   });
 
@@ -560,7 +598,7 @@ describe('for loops', () => {
     check(`
       f(a for a in b when c)
     `, `
-      f(b.filter((a) => c).map((a) => a));
+      f(Array.from(b).filter((a) => c).map((a) => a));
     `);
   });
 
@@ -568,7 +606,7 @@ describe('for loops', () => {
     check(`
       f(a + i for a, i in b)
     `, `
-      f(b.map((a, i) => a + i));
+      f(Array.from(b).map((a, i) => a + i));
     `);
   });
 
@@ -576,7 +614,7 @@ describe('for loops', () => {
     check(`
       f({a: c, b: c} for c in d)
     `, `
-      f(d.map((c) => ({a: c, b: c})));
+      f(Array.from(d).map((c) => ({a: c, b: c})));
     `);
   });
 
@@ -644,7 +682,7 @@ describe('for loops', () => {
     `, `
       let x = (() => {
         let result = [];
-        for (let a of f()) {
+        for (let a of Array.from(f())) {
           let b = g(a);
           if (b > 3) {
             break;
@@ -729,7 +767,7 @@ describe('for loops', () => {
       () =>
         (() => {
           let result = [];
-          for (let a of b) {
+          for (let a of Array.from(b)) {
             let item;
             if (a) {
               item = b;
@@ -864,7 +902,7 @@ describe('for loops', () => {
           return a
     `, `
       (function() {
-        for (let a of b) {
+        for (let a of Array.from(b)) {
           return a;
         }
       });
@@ -878,7 +916,7 @@ describe('for loops', () => {
           -> return a
     `, `
       () =>
-        b.map((a) =>
+        Array.from(b).map((a) =>
           () => a)
       ;
     `);
@@ -888,7 +926,7 @@ describe('for loops', () => {
     check(`
       for a in b then a()
     `, `
-      for (let a of b) { a(); }
+      for (let a of Array.from(b)) { a(); }
     `);
   });
 
@@ -906,7 +944,7 @@ describe('for loops', () => {
         console.log('foo')
       )()
     `, `
-      for (let a of b) { (() => console.log('foo'))(); }
+      for (let a of Array.from(b)) { (() => console.log('foo'))(); }
     `);
   });
 
@@ -926,7 +964,7 @@ describe('for loops', () => {
         {x, y} = getPoint(entry)
         console.log x + ', ' + y;
     `, `
-      for (let entry of someArray) {
+      for (let entry of Array.from(someArray)) {
         let {x, y} = getPoint(entry);
         console.log(x + ', ' + y);
       }
@@ -938,7 +976,7 @@ describe('for loops', () => {
       for a in b when c
         d e
     `, `
-      for (let a of b) {
+      for (let a of Array.from(b)) {
         if (c) {
           d(e);
         }
@@ -950,7 +988,7 @@ describe('for loops', () => {
       for a in b c
         d()
     `, `
-      for (let a of b(c)) {
+      for (let a of Array.from(b(c))) {
         d();
       }
     `));
@@ -973,7 +1011,7 @@ describe('for loops', () => {
         c: d
         e: f
     `, `
-      let x = b.map((a) => ({
+      let x = Array.from(b).map((a) => ({
         c: d,
         e: f
       }));
@@ -986,7 +1024,7 @@ describe('for loops', () => {
     `, `
       let x = (() => {
         let result = [];
-        for (let a of b) {
+        for (let a of Array.from(b)) {
           break;
         }
         return result;
@@ -1003,7 +1041,7 @@ describe('for loops', () => {
     `, `
       let x = (() => {
         let result = [];
-        for (let a of b) {
+        for (let a of Array.from(b)) {
           let item;
           if (a) {
             item = a;
@@ -1036,7 +1074,7 @@ describe('for loops', () => {
     check(`
       a = (b for b in c when b not of e)
     `, `
-      let a = (c.filter((b) => !(b in e)).map((b) => b));
+      let a = (Array.from(c).filter((b) => !(b in e)).map((b) => b));
     `);
   });
 
@@ -1076,7 +1114,7 @@ describe('for loops', () => {
       for @a in b
         c
     `, `
-      for (this.a of b) {
+      for (this.a of Array.from(b)) {
         c;
       }
     `);

--- a/test/semicolon_test.js
+++ b/test/semicolon_test.js
@@ -65,7 +65,7 @@ describe('semicolons', () => {
       for a in b
         a
     `, `
-      for (let a of b) {
+      for (let a of Array.from(b)) {
         a;
       }
     `);

--- a/test/slice_test.js
+++ b/test/slice_test.js
@@ -48,7 +48,7 @@ describe('slice', () => {
     check(`
       a = (b for c in d when e)[...2]
     `, `
-      let a = (d.filter((c) => e).map((c) => b)).slice(0, 2);
+      let a = (Array.from(d).filter((c) => e).map((c) => b)).slice(0, 2);
     `);
   });
 });

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -397,7 +397,7 @@ describe('switch', () => {
           else
             e
     `, `
-      let x = b.map((a) =>
+      let x = Array.from(b).map((a) =>
         (() => { switch (a) {
           case 'c':
             return d;


### PR DESCRIPTION
Fixes #523

decaffeinate now uses `Array.from` in both JS for-of loops and when using
`map`/`filter`, which handles the case where the loop target is an array-like
object (with `length` and numerical indices) instead of a real array (which is
iterable and has `map` and `filter`).

I made two separate prefs for these, since it looks like there are many more
array-like objects in the wild without `map` and `filter` (or where the
semantics are different, e.g. jQuery collections) than there are array-like
objects that are not iterable. But both seem to exist, so to stay on the safe
side, I'm wrapping in `Array.from` by default in both cases. It may make sense
to enable `--loose-for-of` by default in the future if it's deemed safe enough.