### PR TITLE
fix: avoid out-of-order patching in manually bound functions

### DIFF
--- a/src/stages/main/patchers/ManuallyBoundFunctionPatcher.js
+++ b/src/stages/main/patchers/ManuallyBoundFunctionPatcher.js
@@ -5,9 +5,9 @@ import FunctionPatcher from './FunctionPatcher';
  */
 export default class ManuallyBoundFunctionPatcher extends FunctionPatcher {
   patchAsStatement(options={}) {
-    this.insert(this.contentStart, '(');
+    this.insert(this.innerStart, '(');
     super.patchAsExpression(options);
-    this.insert(this.contentEnd, '.bind(this))');
+    this.insert(this.innerEnd, '.bind(this))');
   }
 
   patchAsExpression(options={}) {
@@ -17,7 +17,7 @@ export default class ManuallyBoundFunctionPatcher extends FunctionPatcher {
     // some other way. In practice, this happens when patching class methods;
     // code will be added to the constructor to bind the method properly.
     if (!options.method) {
-      this.insert(this.contentEnd, '.bind(this)');
+      this.insert(this.innerEnd, '.bind(this)');
     }
   }
 

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -133,6 +133,20 @@ describe('functions', () => {
     `);
   });
 
+  it('handles a nested conditional in a fat arrow function referencing arguments', () => {
+    check(`
+      a =>
+        if b
+          c arguments
+    `, `
+      a(function() {
+        if (b) {
+          return c(arguments);
+        }
+      }.bind(this));
+    `);
+  });
+
   it('turns expression-style fat arrow functions referencing `arguments` into regular functions with a `bind` call', () => {
     check(`
       x = => arguments[0] + this


### PR DESCRIPTION
Fixes #579

The function patching code was in some cases inserting a `}` at `innerEnd` and
then inserting `.bind(this)` at `contentEnd`. Usually those are the same (and
this is a rare case anyway, so it didn't come up much), but in the example in #579,
`innerEnd` was after the newline and `contentEnd` was before, so `.bind(this)`
was being added to early. To fix, I changed the `.bind(this)` code to go at
`innerEnd`, which generally follows the rule that patching should go in order.