### PR TITLE
feat: implement strictly-correct `in` patching by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Options:
 * `--loose-default-params`: Convert CS default params to JS default params.
 * `--loose-for-expressions`: Do not wrap expression loop targets in `Array.from`.
 * `--loose-for-of`: Do not wrap JS `for...of` loop targets in `Array.from`.
+* `--loose-includes`: Do not wrap in `Array.from` when converting `in` to `includes`.
 
 For more usages examples, see the output of `decaffeinate --help`.
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -60,6 +60,10 @@ function parseArguments(args: Array<string>): CLIOptions {
         baseOptions.looseForOf = true;
         break;
 
+      case '--loose-includes':
+        baseOptions.looseIncludes = true;
+        break;
+
       default:
         if (arg.startsWith('-')) {
           console.error(`Error: unrecognized option '${arg}'`);
@@ -186,6 +190,7 @@ function usage() {
   console.log('  --loose-default-params   Convert CS default params to JS default params.');
   console.log('  --loose-for-expressions  Do not wrap expression loop targets in Array.from.');
   console.log('  --loose-for-of           Do not wrap JS for...of loop targets in Array.from.');
+  console.log('  --loose-includes         Do not wrap in Array.from when converting in to includes.');
   console.log();
   console.log('EXAMPLES');
   console.log();

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ export type Options = {
   looseDefaultParams: ?boolean,
   looseForExpressions: ?boolean,
   looseForOf: ?boolean,
+  looseIncludes: ?boolean,
 };
 
 const DEFAULT_OPTIONS = {
@@ -35,6 +36,7 @@ const DEFAULT_OPTIONS = {
   looseDefaultParams: false,
   looseForExpressions: false,
   looseForOf: false,
+  looseIncludes: false,
 };
 
 type ConversionResult = {

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -363,7 +363,7 @@ describe('function calls', () => {
         )
     `, `
       a =>
-        !b.map(a, e => e).includes(a)
+        !Array.from(b.map(a, e => e)).includes(a)
       ;
     `);
   });

--- a/test/soaked_test.js
+++ b/test/soaked_test.js
@@ -464,7 +464,7 @@ describe('soaked expressions', () => {
     check(`
       a?.b in c
     `, `
-      c.includes(__guard__(a, x => x.b));
+      Array.from(c).includes(__guard__(a, x => x.b));
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
@@ -475,7 +475,7 @@ describe('soaked expressions', () => {
     check(`
       a in b?.c
     `, `
-      __guard__(b, x => x.c).includes(a);
+      Array.from(__guard__(b, x => x.c)).includes(a);
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }


### PR DESCRIPTION
Fixes #636

There was already code to optionally surround in parens, so we just needed a new
case to optionally surround in `Array.from(` and `)`. As with other `Array.from`
usages, I added a flag to disable this behavior if people are confident that
they're only working with arrays or otherwise objects that have `includes`.

Also go through some old tests and fix their names to better reflect what's
actually done.