### PR TITLE
fix: don't use `map` when a loop assignee can't safely be a parameter

### DIFF
--- a/src/utils/Scope.js
+++ b/src/utils/Scope.js
@@ -13,10 +13,12 @@ type Bindings = { [key: string]: Node };
 export default class Scope {
   parent: ?Scope;
   bindings: Bindings;
+  containerNode: Node;
 
-  constructor(parent: ?Scope=null) {
+  constructor(containerNode: Node, parent: ?Scope=null) {
     this.parent = parent;
     this.bindings = Object.create(parent ? parent.bindings : null);
+    this.containerNode = containerNode;
   }
 
   getBinding(name: string): ?Node {

--- a/src/utils/countVariableUsages.js
+++ b/src/utils/countVariableUsages.js
@@ -1,0 +1,17 @@
+/* @flow */
+
+import traverse from './traverse';
+import type Node from '../patchers/types';
+
+/**
+ * Gets the number of usages of the given name in the given node.
+ */
+export default function countVariableUsages(node: Node, name: string): number {
+  let numUsages = 0;
+  traverse(node, child => {
+    if (child.type === 'Identifier' && child.data === name) {
+      numUsages += 1;
+    }
+  });
+  return numUsages;
+}

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -17,13 +17,13 @@ export default function parse(source: string): Node {
 function attachScope(node: Node) {
   switch (node.type) {
     case 'Program':
-      node.scope = new Scope();
+      node.scope = new Scope(node);
       break;
 
     case 'Function':
     case 'BoundFunction':
     case 'GeneratorFunction':
-      node.scope = new Scope(node.parentNode.scope);
+      node.scope = new Scope(node, node.parentNode.scope);
       break;
 
     default:

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -585,6 +585,58 @@ describe('for loops', () => {
     `);
   });
 
+  it('does not use map when the value assignee is used externally', () => {
+    check(`
+      a(for e in l
+        e)
+      console.log e
+    `, `
+      let e;
+      a((() => {
+        let result = [];
+        for (e of Array.from(l)) {
+          result.push(e);
+        }
+        return result;
+      })());
+      console.log(e);
+    `);
+  });
+
+  it('does not use map when the key assignee is used externally', () => {
+    check(`
+      a(for e, i in l
+        e)
+      console.log i
+    `, `
+      let i;
+      a((() => {
+        let result = [];
+        for (i = 0; i < l.length; i++) {
+          let e = l[i];
+          result.push(e);
+        }
+        return result;
+      })());
+      console.log(i);
+    `);
+  });
+
+  it('does not use map when the loop assignee is not an identifier', () => {
+    check(`
+      a(for @e in l
+        @e)
+    `, `
+      a((() => {
+        let result = [];
+        for (this.e of Array.from(l)) {
+          result.push(this.e);
+        }
+        return result;
+      })());
+    `);
+  });
+
   it('handles for-in loops used as an implicit return', () => {
     check(`
       ->

--- a/test/utils/Scope_test.js
+++ b/test/utils/Scope_test.js
@@ -5,41 +5,42 @@ import Scope from '../../src/utils/Scope';
 describe('Scope', function() {
   let A = {};
   let A2 = {};
+  let containerNode = {};
 
   it('has no bindings by default', () => {
-    let scope = new Scope();
+    let scope = new Scope(containerNode);
     strictEqual(scope.getBinding('a'), null);
   });
 
   it('allows declaring a binding by giving it a node', () => {
-    let scope = new Scope();
+    let scope = new Scope(containerNode);
     scope.declares('a', A);
     strictEqual(scope.getBinding('a'), A);
   });
 
   it('can get bindings from a parent scope', () => {
-    let parent = new Scope();
-    let scope = new Scope(parent);
+    let parent = new Scope(containerNode);
+    let scope = new Scope(containerNode, parent);
 
     parent.declares('a', A);
     strictEqual(scope.getBinding('a'), A);
   });
 
   it('accepts assignments for new bindings which become declarations', () => {
-    let scope = new Scope();
+    let scope = new Scope(containerNode);
     scope.assigns('a', A);
     strictEqual(scope.getBinding('a'), A);
   });
 
   it('ignores assignments for existing bindings', () => {
-    let scope = new Scope();
+    let scope = new Scope(containerNode);
     scope.assigns('a', A);
     scope.assigns('a', A2);
     strictEqual(scope.getBinding('a'), A);
   });
 
   it('processes assignments by binding all LHS identifiers', () => {
-    let scope = new Scope();
+    let scope = new Scope(containerNode);
 
     scope.processNode(statement('a = 1'));
     ok(scope.getBinding('a'), `\`a\` should be bound in: ${scope}`);
@@ -50,47 +51,47 @@ describe('Scope', function() {
   });
 
   it('processes functions by binding all its parameters', () => {
-    let scope = new Scope();
+    let scope = new Scope(containerNode);
     scope.processNode(statement('(a, b) ->'));
     ok(scope.getBinding('a'), `\`a\` should be bound in: ${scope}`);
     ok(scope.getBinding('b'), `\`b\` should be bound in: ${scope}`);
   });
 
   it('processes bound functions by binding all its parameters', () => {
-    let scope = new Scope();
+    let scope = new Scope(containerNode);
     scope.processNode(statement('(a, b) =>'));
     ok(scope.getBinding('a'), `\`a\` should be bound in: ${scope}`);
     ok(scope.getBinding('b'), `\`b\` should be bound in: ${scope}`);
   });
 
   it('processes functions with default parameters', () => {
-    let scope = new Scope();
+    let scope = new Scope(containerNode);
     scope.processNode(statement('(a=0) ->'));
     ok(scope.getBinding('a'), `\`a\` should be bound in: ${scope}`);
   });
 
   it('processes functions with rest parameters', () => {
-    let scope = new Scope();
+    let scope = new Scope(containerNode);
     scope.processNode(statement('(a...) ->'));
     ok(scope.getBinding('a'), `\`a\` should be bound in: ${scope}`);
   });
 
   it('processes functions with destructured object parameters', () => {
-    let scope = new Scope();
+    let scope = new Scope(containerNode);
     scope.processNode(statement('({a, b}) ->'));
     ok(scope.getBinding('a'), `\`a\` should be bound in: ${scope}`);
     ok(scope.getBinding('b'), `\`b\` should be bound in: ${scope}`);
   });
 
   it('processes functions with destructured array parameters', () => {
-    let scope = new Scope();
+    let scope = new Scope(containerNode);
     scope.processNode(statement('([a, b]) ->'));
     ok(scope.getBinding('a'), `\`a\` should be bound in: ${scope}`);
     ok(scope.getBinding('b'), `\`b\` should be bound in: ${scope}`);
   });
 
   it('processes for-of loops by binding key and value assignees', () => {
-    let scope = new Scope();
+    let scope = new Scope(containerNode);
     scope.processNode(statement('for key, {a, b, c: [d, e]} of object\n  key'));
     ['key', 'a', 'b', 'd', 'e'].forEach(name =>
         ok(scope.getBinding(name), `\`${name}\` should be bound in: ${scope}`)
@@ -98,7 +99,7 @@ describe('Scope', function() {
   });
 
   it('processes for-in loops by binding value assignees', () => {
-    let scope = new Scope();
+    let scope = new Scope(containerNode);
     scope.processNode(statement('for [a, {b, c}, d] in array\n  a'));
     ['a', 'b', 'c', 'd'].forEach(name =>
         ok(scope.getBinding(name), `\`${name}\` should be bound in: ${scope}`)
@@ -107,13 +108,13 @@ describe('Scope', function() {
 
   describe('claimFreeBinding', () => {
     it('returns "ref" if nothing is defined', () => {
-      let scope = new Scope();
+      let scope = new Scope(containerNode);
       let node = statement('ref');
       strictEqual(scope.claimFreeBinding(node), 'ref');
     });
 
     it('adds a counter to the end of the binding if the binding is already taken', () => {
-      let scope = new Scope();
+      let scope = new Scope(containerNode);
       let node = statement('ref = ref1 = 0');
       scope.processNode(node);
       scope.processNode(node.expression);
@@ -121,14 +122,14 @@ describe('Scope', function() {
     });
 
     it('allows a base other than the default to be given', () => {
-      let scope = new Scope();
+      let scope = new Scope(containerNode);
       let node = statement('error = null');
       scope.processNode(node);
       strictEqual(scope.claimFreeBinding(node, 'error'), 'error1');
     });
 
     it('registers the claimed binding for subsequent calls', () => {
-      let scope = new Scope();
+      let scope = new Scope(containerNode);
       let node = statement('0');
       scope.claimFreeBinding(node);
       scope.claimFreeBinding(node);
@@ -136,7 +137,7 @@ describe('Scope', function() {
     });
 
     it('allows specifying multiple names to try', () => {
-      let scope = new Scope();
+      let scope = new Scope(containerNode);
       let node = statement('i = 0');
       scope.processNode(node);
       strictEqual(scope.claimFreeBinding(node, ['i', 'j', 'k']), 'j');

--- a/test/utils/countVariableUsages_test.js
+++ b/test/utils/countVariableUsages_test.js
@@ -1,0 +1,16 @@
+import { strictEqual } from 'assert';
+import { parse } from 'decaffeinate-parser';
+import countVariableUsages from '../../src/utils/countVariableUsages';
+
+describe('countVariableUsages', function() {
+  it('does simple counting within a program', () => {
+    let ast = parse(`
+      x = 1
+      for x in y
+        console.log x
+    `);
+    strictEqual(countVariableUsages(ast, 'x'), 3);
+    strictEqual(countVariableUsages(ast, 'y'), 1);
+    strictEqual(countVariableUsages(ast, 'z'), 0);
+  });
+});


### PR DESCRIPTION
Fixes #635

In some cases, we would change a variable to a parameter when converting an
expression-style loop, and this caused other usages to be invalid. In other
cases, there could be loop assignees like `@a` that aren't valid parameters (at
least not without additional work). To avoid these cases, we can add an
additional check when deciding patching style, where we only proceed if all
assignees are just identifiers and if those identifiers are only used within the
loop itself.