### PR TITLE
fix: add a null check when converting for-own to Object.keys

### DIFF
--- a/src/stages/main/patchers/ForOfPatcher.js
+++ b/src/stages/main/patchers/ForOfPatcher.js
@@ -57,9 +57,9 @@ export default class ForOfPatcher extends ForPatcher {
       //                            ^^^^^^^^^^^^
       this.insert(this.target.outerStart, 'Object.keys(');
 
-      // `for (k of o` → `for (k of Object.keys(o)) {`
-      //                                         ^^^^
-      this.insert(this.target.outerEnd, ')) {');
+      // `for (k of Object.keys(o` → `for (k of Object.keys(o || {})) {`
+      //                                                     ^^^^^^^^^^
+      this.insert(this.target.outerEnd, ' || {})) {');
     } else {
       // `for (k of o` → `for (k in o`
       //         ^^              ^^

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -856,7 +856,7 @@ describe('for loops', () => {
       for own key of list
         console.log key
     `, `
-      for (let key of Object.keys(list)) {
+      for (let key of Object.keys(list || {})) {
         console.log(key);
       }
     `);
@@ -867,7 +867,7 @@ describe('for loops', () => {
       for own key of getObject()
         console.log key
     `, `
-      for (let key of Object.keys(getObject())) {
+      for (let key of Object.keys(getObject() || {})) {
         console.log(key);
       }
     `);
@@ -878,7 +878,7 @@ describe('for loops', () => {
       for own key, value of list
         console.log key, value
     `, `
-      for (let key of Object.keys(list)) {
+      for (let key of Object.keys(list || {})) {
         let value = list[key];
         console.log(key, value);
       }
@@ -891,7 +891,7 @@ describe('for loops', () => {
         console.log key, value
     `, `
       let object = getObject();
-      for (let key of Object.keys(object)) {
+      for (let key of Object.keys(object || {})) {
         let value = object[key];
         console.log(key, value);
       }
@@ -903,7 +903,7 @@ describe('for loops', () => {
       for own key of list when key[0] is '_'
         console.log key
     `, `
-      for (let key of Object.keys(list)) {
+      for (let key of Object.keys(list || {})) {
         if (key[0] === '_') {
           console.log(key);
         }
@@ -915,7 +915,7 @@ describe('for loops', () => {
     check(`
       for own a of b then a
     `, `
-      for (let a of Object.keys(b)) { a; }
+      for (let a of Object.keys(b || {})) { a; }
     `);
   });
 
@@ -930,7 +930,7 @@ describe('for loops', () => {
       a((() => {
         let result = [];
         let object = obj();
-        for (let k of Object.keys(object)) {
+        for (let k of Object.keys(object || {})) {
           let v = object[k];
           if (x) {
             let item;


### PR DESCRIPTION
Fixes #644

For `null` and `undefined`, this causes the loop to not iterate, which is
consistent with CoffeeScript. For `false`, `0`, `''`, and `NaN`, the behavior
was already to not iterate, so the behavior is unchanged.