### PR TITLE
feat: implement expansion and intermediate rest params

### DIFF
--- a/src/stages/normalize/index.js
+++ b/src/stages/normalize/index.js
@@ -4,6 +4,7 @@ import ClassPatcher from './patchers/ClassPatcher';
 import AssignOpPatcher from './patchers/AssignOpPatcher';
 import ConditionalPatcher from './patchers/ConditionalPatcher';
 import DoOpPatcher from './patchers/DoOpPatcher';
+import ExpansionPatcher from './patchers/ExpansionPatcher';
 import ForInPatcher from './patchers/ForInPatcher';
 import ForOfPatcher from './patchers/ForOfPatcher';
 import FunctionApplicationPatcher from './patchers/FunctionApplicationPatcher';
@@ -13,6 +14,7 @@ import ObjectInitialiserPatcher from './patchers/ObjectInitialiserPatcher';
 import ObjectInitialiserMemberPatcher from './patchers/ObjectInitialiserMemberPatcher';
 import PassthroughPatcher from '../../patchers/PassthroughPatcher';
 import ProgramPatcher from './patchers/ProgramPatcher';
+import SpreadPatcher from './patchers/SpreadPatcher';
 import TransformCoffeeScriptStage from '../TransformCoffeeScriptStage';
 import WhilePatcher from './patchers/WhilePatcher';
 import MemberAccessOpPatcher from './patchers/MemberAccessOpPatcher';
@@ -46,6 +48,9 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
       case 'DoOp':
         return DoOpPatcher;
 
+      case 'Expansion':
+        return ExpansionPatcher;
+
       case 'ForIn':
         return ForInPatcher;
 
@@ -75,6 +80,10 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
 
       case 'DefaultParam':
         return DefaultParamPatcher;
+
+      case 'Rest':
+      case 'Spread':
+        return SpreadPatcher;
 
       case 'ObjectInitialiser':
         return ObjectInitialiserPatcher;

--- a/src/stages/normalize/patchers/ExpansionPatcher.js
+++ b/src/stages/normalize/patchers/ExpansionPatcher.js
@@ -1,0 +1,3 @@
+import PassthroughPatcher from '../../../patchers/PassthroughPatcher';
+
+export default class ExpansionPatcher extends PassthroughPatcher {}

--- a/src/stages/normalize/patchers/SpreadPatcher.js
+++ b/src/stages/normalize/patchers/SpreadPatcher.js
@@ -1,0 +1,3 @@
+import PassthroughPatcher from '../../../patchers/PassthroughPatcher';
+
+export default class SpreadPatcher extends PassthroughPatcher {}


### PR DESCRIPTION
Fixes #107
Progress toward #268

This change works off of #646 to implement expansion and non-terminal rest for
parameters. The code change ended up being pretty straightforward: at the
normalize step, we just take the comma-separated list of arguments and move them
to an array destructure on the first line. This ends up playing nicely with the
other code handling default params and this assignment.

I'm not calling #268 closed quite yet because decaffeinate doesn't yet handle
nested expansions or intermediate rests, which I've seen in at least one
real-world case.