### PR TITLE
fix: handle errors when getting code while patching a node

### DIFF
--- a/test/compound_assignment_test.js
+++ b/test/compound_assignment_test.js
@@ -422,6 +422,14 @@ describe('compound assignment', () => {
       `);
     });
 
+    it('handles existence assignment within a conditional', () => {
+      check(`
+        if a then b ?= c
+      `, `
+        if (a) { if (typeof b === 'undefined' || b === null) { var b = c; } }
+      `);
+    });
+
     it('handles simple computed member expression existence assignment', () => {
       check(`
         a[b] ?= 1


### PR DESCRIPTION
Fixes #649

magic-string doesn't allow slicing where either end is in a range that has been
removed, which occasionally can cause problems in `captureCodeForPatchOperation`
when we want to get the code added before the start index. Normally, we subtract
1 to find the snippet of code just before the start of the expression, but
really, subtracting any amount will work, so keep on subtracting one more until
magic-string doesn't throw an exception. This feels a bit fragile, and it's
possible that magic-string could expose a better API here to make the check more
robust, but at the very least, we'll throw an error if every index fails.