### PR TITLE
fix: add parens when instructed when patching assignment operators

### DIFF
--- a/src/stages/main/patchers/AssignOpPatcher.js
+++ b/src/stages/main/patchers/AssignOpPatcher.js
@@ -28,12 +28,19 @@ export default class AssignOpPatcher extends NodePatcher {
     this.insert(this.innerEnd, ')');
   }
 
-  patchAsExpression() {
+  patchAsExpression({ needsParens=false }={}) {
+    let shouldAddParens = needsParens && !this.isSurroundedByParentheses();
+    if (shouldAddParens) {
+      this.insert(this.outerStart, '(');
+    }
     if (this.isExpansionAssignment()) {
       this.patchExpansionAssignment();
     } else {
       this.assignee.patch();
       this.expression.patch();
+    }
+    if (shouldAddParens) {
+      this.insert(this.outerEnd, ')');
     }
   }
 

--- a/src/stages/main/patchers/LogicalOpCompoundAssignOpPatcher.js
+++ b/src/stages/main/patchers/LogicalOpCompoundAssignOpPatcher.js
@@ -1,7 +1,12 @@
 import CompoundAssignOpPatcher from './CompoundAssignOpPatcher';
 
 export default class LogicalOpCompoundAssignOpPatcher extends CompoundAssignOpPatcher {
-  patchAsExpression() {
+  patchAsExpression({ needsParens=false }={}) {
+    let shouldAddParens = needsParens && !this.isSurroundedByParentheses();
+    if (shouldAddParens) {
+      this.insert(this.outerStart, '(');
+    }
+
     let operator = this.getOperatorToken();
 
     // `a &&= b` → `a && b`
@@ -23,11 +28,15 @@ export default class LogicalOpCompoundAssignOpPatcher extends CompoundAssignOpPa
     // `a && (a = b` → `a && (a = b)`
     //                             ^
     this.insert(this.expression.outerEnd, ')');
+
+    if (shouldAddParens) {
+      this.insert(this.outerEnd, ')');
+    }
   }
 
-  patchAsStatement() {
+  patchAsStatement(options={}) {
     if (this.lhsHasSoakOperation()) {
-      this.patchAsExpression();
+      this.patchAsExpression(options);
       return;
     }
 

--- a/test/binary_operator_test.js
+++ b/test/binary_operator_test.js
@@ -244,4 +244,33 @@ describe('binary operators', () => {
       }
     `);
   });
+
+  it('adds parens around an assignment combined with a logical operator', () => {
+    check(`
+      a and b = c
+    `, `
+      let b;
+      a && (b = c);
+    `);
+  });
+
+  it('adds parens around a compound existence assignment combined with a logical operator', () => {
+    check(`
+      b = 1
+      a and b ?= c
+    `, `
+      let b = 1;
+      a && (b != null ? b : (b = c));
+    `);
+  });
+
+  it('adds parens around a compound logical assignment combined with a logical operator', () => {
+    check(`
+      b = 1
+      a and b or= c
+    `, `
+      let b = 1;
+      a && (b || (b = c));
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #611

Unlike JavaScript, CoffeeScript binds assignment operators tighter than most
binary operators (for reasons that I haven't quite been able to figure out by
reading the source code; the operators table has assignment at lower precedence,
but it's also right-associative, so maybe that affects things, or maybe there's
other code to decide precedence). We already were passing a `needsParens` flag
to children of binary operators, but assignment operators were ignoring that
flag, so no parens were added, so the JS precedence rules would be used. To
avoid this issue, we can simply respect that flag when patching all types of
assignment operators, which ends up fixing the issue without changing the output
of any existing tests.