### PR TITLE
fix: don't patch past the end of the expression in insertStatementsAtIndex

### DIFF
--- a/src/stages/main/patchers/BlockPatcher.js
+++ b/src/stages/main/patchers/BlockPatcher.js
@@ -139,6 +139,7 @@ export default class BlockPatcher extends NodePatcher {
       let insertionPoint = terminatorTokenIndex ?
         this.sourceTokenAtIndex(terminatorTokenIndex).start :
         lastStatement.outerEnd;
+      insertionPoint = Math.min(insertionPoint, this.getBoundingPatcher().innerEnd);
       let indent = lastStatement.getIndent();
       statements.forEach(line => this.insert(insertionPoint, `${separator}${indent}${line}`));
     } else {

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -572,4 +572,56 @@ describe('function calls', () => {
         );
     `);
   });
+
+  it('maintains CALL_END location for a nested dynamic member access', () => {
+    check(`
+      a ->
+        for b in c
+          if d
+            e[f]
+      
+      g
+    `, `
+      a(() =>
+        (() => {
+          let result = [];
+          for (let b of Array.from(c)) {
+            let item;
+            if (d) {
+              item = e[f];
+            }
+            result.push(item);
+          }
+          return result;
+        })());
+      
+      g;
+    `);
+  });
+
+  it('maintains CALL_END location around a nested conditional', () => {
+    check(`
+      a(->
+        for b in c
+          if d
+            e)
+      
+      f
+    `, `
+      a(() =>
+        (() => {
+          let result = [];
+          for (let b of Array.from(c)) {
+            let item;
+            if (d) {
+              item = e;
+            }
+            result.push(item);
+          }
+          return result;
+        })());
+      
+      f;
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #648

Various code paths use `getBoundingPatcher` to determine the latest index that
we can safely patch code, which is especially important when a line ends with
close-parens and/or close-braces that close outer nodes. The
`insertStatementsAtIndex` method can be used to add a line to the end of a
block, but it wasn't doing this check, so in some cases it would incorrectly
insert the new line after a close paren that's supposed to be after the block.