### PR TITLE
chore: ignore these packages wherever they appear

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,7 +1,7 @@
 [ignore]
-<PROJECT_ROOT>/node_modules/config-chain/.*
-<PROJECT_ROOT>/node_modules/npmconf/.*
-<PROJECT_ROOT>/node_modules/semantic-release/.*
+.*/config-chain/.*
+.*/npmconf/.*
+.*/semantic-release/.*
 
 [include]
 


### PR DESCRIPTION
This can happen, for example, when doing an `npm link` with a package that has these packages as development dependencies.