### PR TITLE
fix: change EqualityPatcher to respect the needsParens flag

### DIFF
--- a/src/stages/main/patchers/EqualityPatcher.js
+++ b/src/stages/main/patchers/EqualityPatcher.js
@@ -8,15 +8,13 @@ import { SourceType } from 'coffee-lex';
 export default class EqualityPatcher extends BinaryOpPatcher {
   negated: boolean = false;
 
-  patchAsExpression() {
-    this.left.patch();
+  patchOperator() {
     let compareToken = this.getCompareToken();
     this.overwrite(
       compareToken.start,
       compareToken.end,
       this.getCompareOperator()
     );
-    this.right.patch();
   }
 
   getCompareOperator(): string {

--- a/test/chained_comparison_test.js
+++ b/test/chained_comparison_test.js
@@ -89,7 +89,7 @@ describe('chained comparison', () => {
       unless a < b <= c
         d
     `, `
-      if (a >= b || b > c) {
+      if ((a >= b) || b > c) {
         d;
       }
     `);

--- a/test/comparison_test.js
+++ b/test/comparison_test.js
@@ -27,9 +27,18 @@ describe('comparisons', () => {
       unless a < b && b > c
         d
     `, `
-      if (a >= b || b <= c) {
+      if ((a >= b) || (b <= c)) {
         d;
       }
+    `);
+  });
+
+  it('puts parens around an assignment within a comparison operator', () => {
+    check(`
+      a is b = c
+    `, `
+      let b;
+      a === (b = c);
     `);
   });
 });

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -77,9 +77,9 @@ describe('functions', () => {
         let today = new Date();
         let fullYear = 2000 + parseInt(year);
         return (/^\\d{1,2}$/.test(month)) && (/^\\d{1,2}$/.test(year)) &&
-          (month >= 1 && month <= 12) &&
-          fullYear >= today.getFullYear() &&
-          (fullYear !== today.getFullYear() || month > today.getMonth()); // Date.month is 0 indexed
+          ((month >= 1) && (month <= 12)) &&
+          (fullYear >= today.getFullYear()) &&
+          ((fullYear !== today.getFullYear()) || (month > today.getMonth())); // Date.month is 0 indexed
       };
 
       export { validExpirationDate };

--- a/test/logical_operator_test.js
+++ b/test/logical_operator_test.js
@@ -21,7 +21,7 @@ describe('`and` operator', () => {
     check(`
       a is b and c is d
     `, `
-      a === b && c === d;
+      (a === b) && (c === d);
     `);
   });
 
@@ -58,7 +58,7 @@ describe('`or` operator', () => {
     check(`
       a is b or c is d
     `, `
-      a === b || c === d;
+      (a === b) || (c === d);
     `);
   });
 


### PR DESCRIPTION
Fixes #656

`EqualityPatcher` already extended `BinaryOpPatcher`, and `BinaryOpPatcher`
already exposes a way to customize operator patching, so we can just use that
and we'll also pull in the needsParens behavior (importantly, telling child
assignment expressions to add parens). This adds parens in a few cases where
they're unnecessary, which is arguably a little uglier, but eslint has an
auto-fixer for this with the no-extra-parens rule, so that probably handles
typical use cases if people care.