### PR TITLE
fix: properly patch try expressions surrounded by parens

### DIFF
--- a/src/stages/main/patchers/TryPatcher.js
+++ b/src/stages/main/patchers/TryPatcher.js
@@ -116,27 +116,13 @@ export default class TryPatcher extends NodePatcher {
     // Make our children return since we're wrapping in a function.
     this.setImplicitlyReturns();
 
-    let needsParens = !this.isSurroundedByParentheses();
-    if (needsParens) {
-      // `a = try b()` → `a = (try b()`
-      //                      ^
-      this.insert(this.outerStart, '(');
-    }
-    // `a = (try b()` → `a = (() => { try b()`
-    //                        ^^^^^^^^
-    this.insert(this.outerStart, '() => { ');
+    // `a = try b()` → `a = (() => { try b()`
+    //                      ^^^^^^^^^
+    this.insert(this.contentStart, '(() => { ');
     this.patchAsStatement();
-    // `a = (() => { try { b(); } catch (error) {}` → `a = (() => { try { b(); } catch (error) {} }`
-    //                                                                                           ^^
-    this.insert(this.outerEnd, ' }');
-    if (needsParens) {
-      // `a = (() => { try { b(); } catch (error) {} }` → `a = (() => { try { b(); } catch (error) {} })`
-      //                                                                                               ^
-      this.insert(this.outerEnd, ')');
-    }
-    // `a = (() => { try { b(); } catch (error) {} })` → `a = (() => { try { b(); } catch (error) {} })()`
-    //                                                                                                 ^^
-    this.insert(this.outerEnd, '()');
+    // `a = (() => { try { b(); } catch (error) {}` → `a = (() => { try { b(); } catch (error) {} })()`
+    //                                                                                           ^^^^^
+    this.insert(this.contentEnd, ' })()');
   }
 
   setImplicitlyReturns() {

--- a/test/try_test.js
+++ b/test/try_test.js
@@ -189,7 +189,6 @@ describe('try', () => {
     `);
   });
 
-
   it('handles try with an empty catch block with a catch variable and an empty finally block', () => {
     check(`
       try
@@ -201,6 +200,14 @@ describe('try', () => {
         something();
       } catch (err) {}
       finally {}
+    `);
+  });
+
+  it('handles a try expression wrapped in parens', () => {
+    check(`
+      x = (try a catch b then c)
+    `, `
+      let x = ((() => { try { return a; } catch (b) { return c; } })());
     `);
   });
 });


### PR DESCRIPTION
Fixes #658

There were two problems:
* We were inserting the IIFE code at `outerStart` and `outerEnd`, but that means
  that the parens would end up inside the IIFE, which wouldn't work. Instead,
  insert at `contentStart` and `contentEnd`.
* There was a special case for if the expression was surrounded by parens, but
  if so, it would skip wrapping the arrow function in parens. But arrow
  functions need to always be in parens, so we'll always need them, and it's
  simpler and correct to just get rid of that case. We could potentially
  repurpose the existing expression parens to use in the IIFE, but that seems
  like it's probably not worth it.