### PR TITLE
fix: patch the step before rearranging loops in the normalize stage

### DIFF
--- a/src/stages/normalize/patchers/ForInPatcher.js
+++ b/src/stages/normalize/patchers/ForInPatcher.js
@@ -11,9 +11,9 @@ export default class ForInPatcher extends ForPatcher {
   }
 
   patchAsExpression() {
-    super.patchAsExpression();
     if (this.step) {
       this.step.patch();
     }
+    super.patchAsExpression();
   }
 }

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1194,4 +1194,12 @@ describe('for loops', () => {
       }
     `);
   });
+
+  it('handles implicit function calls in the loop step', () => {
+    check(`
+      a for a in b by c d
+    `, `
+      for (let step = c(d), asc = step > 0, i = asc ? 0 : b.length - 1; asc ? i < b.length : i >= 0; i += step) { let a = b[i]; a; }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #661

When rearranging a node, we should patch the children first, then work with the
patched results. For for-in loops in particular, we were patching the step after
everything else, so patching the step could cause magic-string problems. An easy
fix is to just reorder it so we patch the step first.