### PR TITLE
fix: wrap loop components in parens in the normalize stage if necessary

### DIFF
--- a/src/stages/main/patchers/ForInPatcher.js
+++ b/src/stages/main/patchers/ForInPatcher.js
@@ -263,6 +263,13 @@ export default class ForInPatcher extends ForPatcher {
     this.patchBodyAndFilter();
   }
 
+  getLoopHeaderEnd() {
+    return Math.max(
+      this.step ? this.step.outerEnd : -1,
+      super.getLoopHeaderEnd()
+    );
+  }
+
   requiresExtractingTarget() {
     return (
       !this.shouldPatchAsInitTestUpdateLoop() &&

--- a/src/stages/main/patchers/ForPatcher.js
+++ b/src/stages/main/patchers/ForPatcher.js
@@ -114,8 +114,8 @@ export default class ForPatcher extends LoopPatcher {
    * @protected
    */
   removeThenToken() {
-    let index = this.indexOfSourceTokenBetweenPatchersMatching(
-      this.target, this.body,
+    let index = this.indexOfSourceTokenBetweenSourceIndicesMatching(
+      this.getLoopHeaderEnd(), this.body.outerStart,
       token => token.type === SourceType.THEN
     );
     if (index) {
@@ -123,6 +123,18 @@ export default class ForPatcher extends LoopPatcher {
       let nextToken = this.sourceTokenAtIndex(index.next());
       this.remove(thenToken.start, nextToken.start);
     }
+  }
+
+  /**
+   * Get the last known index of the loop header, just before the `then` token
+   * or the body. This can be overridden to account for additional loop header
+   * elements.
+   */
+  getLoopHeaderEnd() {
+    return Math.max(
+      this.filter ? this.filter.outerEnd : -1,
+      this.target.outerEnd,
+    );
   }
 
   getTargetCode(): string {

--- a/src/stages/main/patchers/WhilePatcher.js
+++ b/src/stages/main/patchers/WhilePatcher.js
@@ -20,6 +20,13 @@ export default class WhilePatcher extends LoopPatcher {
     this.guard = guard;
   }
 
+  initialize() {
+    this.condition.setRequiresExpression();
+    if (this.guard !== null) {
+      this.guard.setRequiresExpression();
+    }
+  }
+
   /**
    * ( 'while' | 'until' ) CONDITION ('when' GUARD)? 'then' BODY
    * ( 'while' | 'until' ) CONDITION ('when' GUARD)? NEWLINE INDENT BODY
@@ -45,7 +52,7 @@ export default class WhilePatcher extends LoopPatcher {
     if (this.node.isUntil) {
       this.condition.negate();
     }
-    this.condition.patch();
+    this.condition.patch({ needsParens: false });
 
     if (this.guard) {
       let guardNeedsParens = !this.guard.isSurroundedByParentheses();
@@ -67,7 +74,7 @@ export default class WhilePatcher extends LoopPatcher {
         );
 
       }
-      this.guard.patch();
+      this.guard.patch({ needsParens: false });
 
       // `while (a) {\n  if (b` → `while (a) {\n  if (b) {`
       //                                               ^^^

--- a/src/stages/normalize/patchers/ForInPatcher.js
+++ b/src/stages/normalize/patchers/ForInPatcher.js
@@ -16,4 +16,11 @@ export default class ForInPatcher extends ForPatcher {
     }
     super.patchAsExpression();
   }
+
+  surroundThenUsagesInParens() {
+    if (this.step && this.slice(this.step.contentStart, this.step.contentEnd).includes('then')) {
+      this.step.surroundInParens();
+    }
+    super.surroundThenUsagesInParens();
+  }
 }

--- a/src/stages/normalize/patchers/ForPatcher.js
+++ b/src/stages/normalize/patchers/ForPatcher.js
@@ -51,6 +51,7 @@ export default class ForPatcher extends NodePatcher {
    * @private
    */
   normalize() {
+    this.surroundThenUsagesInParens();
     let forToken = this.getForToken();
     let forThroughEnd = this.slice(forToken.start, this.contentEnd);
     let startUntilFor = this.slice(this.contentStart, this.body.outerEnd);
@@ -59,6 +60,22 @@ export default class ForPatcher extends NodePatcher {
       this.contentEnd,
       `${forThroughEnd} then ${startUntilFor}`
     );
+  }
+
+  /**
+   * Defensively wrap expressions in parens if they might contain a `then`
+   * token, since that would mess up the parsing when we rearrange the for loop.
+   *
+   * This method can be subclassed to account for additional fields.
+   */
+  surroundThenUsagesInParens() {
+    if (this.slice(this.target.contentStart, this.target.contentEnd).includes('then')) {
+      this.target.surroundInParens();
+    }
+    if (this.filter &&
+      this.slice(this.filter.contentStart, this.filter.contentEnd).includes('then')) {
+      this.filter.surroundInParens();
+    }
   }
 
   /**

--- a/src/stages/normalize/patchers/WhilePatcher.js
+++ b/src/stages/normalize/patchers/WhilePatcher.js
@@ -51,6 +51,9 @@ export default class WhilePatcher extends NodePatcher {
       this.condition.outerStart,
       this.condition.outerEnd
     );
+    if (patchedCondition.includes('then') && !this.condition.isSurroundedByParentheses()) {
+      patchedCondition = `(${patchedCondition})`;
+    }
     let patchedBody = this.slice(
       this.body.outerStart,
       this.body.outerEnd
@@ -59,6 +62,9 @@ export default class WhilePatcher extends NodePatcher {
       this.guard.outerStart,
       this.guard.outerEnd
     ) : null;
+    if (patchedGuard !== null && patchedGuard.includes('then') && !this.guard.isSurroundedByParentheses()) {
+      patchedGuard = `(${patchedGuard})`;
+    }
     let whileToken = this.node.isUntil ? 'until' : 'while';
     this.overwrite(
       this.contentStart,

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1202,4 +1202,28 @@ describe('for loops', () => {
       for (let step = c(d), asc = step > 0, i = asc ? 0 : b.length - 1; asc ? i < b.length : i >= 0; i += step) { let a = b[i]; a; }
     `);
   });
+
+  it('handles a condition containing "then" within a post-for', () => {
+    check(`
+      a for a in b when if c then d
+    `, `
+      for (let a of Array.from(b)) { if (c ? d : undefined) { a; } }
+    `);
+  });
+
+  it('handles a target containing "then" within a post-for', () => {
+    check(`
+      a for a in if b then c
+    `, `
+      for (let a of Array.from((b ? c : undefined))) { a; }
+    `);
+  });
+
+  it('handles a step containing "then" within a post-for', () => {
+    check(`
+      a for a in b by if c then d
+    `, `
+      for (let step = c ? d : undefined, asc = step > 0, i = asc ? 0 : b.length - 1; asc ? i < b.length : i >= 0; i += step) { let a = b[i]; a; }
+    `);
+  });
 });

--- a/test/while_test.js
+++ b/test/while_test.js
@@ -356,4 +356,28 @@ describe('while', () => {
       });
     `);
   });
+
+  it('handles a condition containing "then" within a post-while', () => {
+    check(`
+      2 while if 1 then 0
+    `, `
+      while (1 ? 0 : undefined) { 2; }
+    `);
+  });
+
+  it('does not add additional parens around a condition containing "then"', () => {
+    check(`
+      2 while (if 1 then 0)
+    `, `
+      while (1 ? 0 : undefined) { 2; }
+    `);
+  });
+
+  it('handles a guard containing "then" within a post-while', () => {
+    check(`
+      a while b when if c then d
+    `, `
+      while (b) { if (c ? d : undefined) { a; } }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #663

We want to avoid an unparenthesized `then` token in a `while` condition, since
that will confuse the CoffeeScript parser. Ideally, maybe we'd tokenize the new
condition that results from the normalize step, or detect this case in some
other fancy way, but an easy approach that works is to just see if `then` is a
substring of the expression code, and defensively wrap in parens if so.

The same issue comes up for `for` as well, so take a similar approach there.

These tests also exposed some issues with `for` and `while` patching in general,
mainly that we weren't setting fields to be expressions when we should have, and
we were using too lenient of a range when finding the `then` token after a loop.