### PR TITLE
fix: handle the case where a try body is null

### DIFF
--- a/test/try_test.js
+++ b/test/try_test.js
@@ -203,6 +203,42 @@ describe('try', () => {
     `);
   });
 
+  it('handles try within a function with all blocks empty', () => {
+    check(`
+      ->
+        try
+        catch err
+        finally
+    `, `
+      (function() {
+        try {}
+        catch (err) {}
+        finally {}
+      });
+    `);
+  });
+
+  it('handles try by itself', () => {
+    check(`
+      try
+    `, `
+      try {} catch (error) {}
+    `);
+  });
+
+  it('handles try with a non-empty catch', () => {
+    check(`
+      try
+      catch
+        a
+    `, `
+      try {}
+      catch (error) {
+        a;
+      }
+    `);
+  });
+
   it('handles a try expression wrapped in parens', () => {
     check(`
       x = (try a catch b then c)


### PR DESCRIPTION
Fixes #665

The code in TryPatcher was assuming that the try body always exists, but it
turns out that's not true, so we need to add null checks in various places.