### PR TITLE
fix: change the default negate function to insert at contentStart

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -910,10 +910,14 @@ export default class NodePatcher {
   }
 
   /**
-   * Negates this patcher's node when patching.
+   * Negates this patcher's node when patching. Note that we add the `!` inside
+   * any parens, since it's generally unsafe to insert code outside our
+   * enclosing parens, and we need to handle the non-parenthesized case anyway.
+   * Subclasses that need to worry about precedence (e.g. binary operators)
+   * should override this method and do something more appropriate.
    */
   negate() {
-    this.insert(this.outerStart, '!');
+    this.insert(this.contentStart, '!');
   }
 
   /**

--- a/src/stages/main/patchers/IdentifierPatcher.js
+++ b/src/stages/main/patchers/IdentifierPatcher.js
@@ -1,10 +1,6 @@
 import PassthroughPatcher from './../../../patchers/PassthroughPatcher';
 
 export default class IdentifierPatcher extends PassthroughPatcher {
-  negate() {
-    this.insert(this.contentStart, '!');
-  }
-
   isRepeatable(): boolean {
     return true;
   }

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -278,6 +278,10 @@ describe('conditionals', () => {
     check(`a unless b`, `if (!b) { a; }`);
   });
 
+  it('allowed parenthesized member expressions in `unless`', () => {
+    check(`unless (a.b) then c`, `if (!a.b) { c; }`);
+  });
+
   it('pushes returns into `if` statements', () => {
     check(`
       ->

--- a/test/try_test.js
+++ b/test/try_test.js
@@ -210,4 +210,12 @@ describe('try', () => {
       let x = ((() => { try { return a; } catch (b) { return c; } })());
     `);
   });
+
+  it('handles a try expression as an unless condition', () => {
+    check(`
+      unless (try a catch b then c) then d
+    `, `
+      if (!(() => { try { return a; } catch (b) { return c; } })()) { d; }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #678

Previously, the default behavior was to insert at `outerStart`, which would
usually crash if the expression was surrounded by parens, since `outerStart` is
outside the editing bounds in that case. We can't rely on having parens anyway,
so any subclasses should (and already do) add extra parens if necessary.