### PR TITLE
fix: properly remove the `then` token in try statements

### DIFF
--- a/src/stages/main/patchers/TryPatcher.js
+++ b/src/stages/main/patchers/TryPatcher.js
@@ -191,9 +191,6 @@ export default class TryPatcher extends NodePatcher {
    * @private
    */
   getThenTokenIndex(): ?SourceTokenListIndex {
-    if (!this.catchBody) {
-      return null;
-    }
     let searchStart;
     if (this.catchAssignee) {
       searchStart = this.catchAssignee.outerEnd;
@@ -203,8 +200,17 @@ export default class TryPatcher extends NodePatcher {
       searchStart = this.getTryToken().end;
     }
 
+    let searchEnd;
+    if (this.catchBody) {
+      searchEnd = this.catchBody.outerStart;
+    } else if (this.finallyBody) {
+      searchEnd = this.finallyBody.outerStart;
+    } else {
+      searchEnd = this.contentEnd;
+    }
+
     return this.indexOfSourceTokenBetweenSourceIndicesMatching(
-      searchStart, this.catchBody.outerStart,
+      searchStart, searchEnd,
       token => token.type === SourceType.THEN
     );
   }

--- a/test/try_test.js
+++ b/test/try_test.js
@@ -239,6 +239,14 @@ describe('try', () => {
     `);
   });
 
+  it('handles empty try, catch, and finally all on one line', () => {
+    check(`
+      try catch err then finally
+    `, `
+      try {} catch (err) {} finally {}
+    `);
+  });
+
   it('handles a try expression wrapped in parens', () => {
     check(`
       x = (try a catch b then c)


### PR DESCRIPTION
Fixes #680

Looks like `then` can appear even if the catch block is null.