### PR TITLE
fix: don't generate identifier names that are reserved words

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,7 @@
   "parser": "babel-eslint",
   "extends": "eslint:recommended",
   "env": {
+    "es6": true,
     "node": true,
     "mocha": true
   },
@@ -11,7 +12,7 @@
     "strict": 0,
     "no-console": 0,
     "quotes": [2, "single", {"avoidEscape": true, "allowTemplateLiterals": true}],
-    "no-use-before-define": [2, "nofunc"],
+    "no-use-before-define": [2, {"functions": false, "classes": false}],
     "eqeqeq": 2,
     "babel/object-shorthand": 1,
     "babel/generator-star-spacing": 1,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babylon": "^6.12.0",
     "coffee-lex": "^5.0.0",
     "decaffeinate-coffeescript": "^1.10.0-patch5",
-    "decaffeinate-parser": "^9.0.3",
+    "decaffeinate-parser": "^9.0.4",
     "detect-indent": "^4.0.0",
     "esnext": "^3.0.9",
     "lines-and-columns": "^1.1.5",

--- a/src/utils/isReservedWord.js
+++ b/src/utils/isReservedWord.js
@@ -1,0 +1,36 @@
+/* @flow */
+
+// Taken from various constants in the CoffeeScript lexer:
+// https://github.com/jashkenas/coffeescript/blob/master/src/lexer.coffee
+const RESERVED_WORDS = new Set([
+  // JS_KEYWORDS
+  'true', 'false', 'null', 'this',
+  'new', 'delete', 'typeof', 'in', 'instanceof',
+  'return', 'throw', 'break', 'continue', 'debugger', 'yield',
+  'if', 'else', 'switch', 'for', 'while', 'do', 'try', 'catch', 'finally',
+  'class', 'extends', 'super',
+  'import', 'export', 'default',
+  // COFFEE_KEYWORDS
+  'undefined', 'Infinity', 'NaN',
+  'then', 'unless', 'until', 'loop', 'of', 'by', 'when',
+  // COFFEE_ALIASES
+  'and', 'or', 'is', 'isnt', 'not', 'yes', 'no', 'on', 'off',
+  // RESERVED
+  'case', 'default', 'function', 'var', 'void', 'with', 'const', 'let', 'enum',
+  'export', 'import', 'native', 'implements', 'interface', 'package', 'private',
+  'protected', 'public', 'static',
+  // STRICT_PROSCRIBED
+  'arguments', 'eval',
+  // Mentioned in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Future_reserved_keywords
+  'await',
+]);
+
+/**
+ * Determine if the given string is a reserved word in either CoffeeScript or
+ * JavaScript, useful to avoid generating variables with these names. Sometimes
+ * we generate CoffeeScript and sometimes JavaScript, so just avoid names that
+ * are reserved in either language.
+ */
+export default function isReservedWord(name: string): boolean {
+  return RESERVED_WORDS.has(name);
+}

--- a/src/utils/resolveToPatchError.js
+++ b/src/utils/resolveToPatchError.js
@@ -31,6 +31,9 @@ export default function resolveToPatchError(err: any, content: string , stageNam
     let lineMap = new LinesAndColumns(content);
     let firstIndex = lineMap.indexForLocation({line: first_line, column: first_column});
     let lastIndex = lineMap.indexForLocation({line: last_line, column: last_column}) + 1;
+    if (!lastIndex && lastIndex !== 0) {
+      lastIndex = firstIndex + 1;
+    }
     if (firstIndex !== null && firstIndex !== undefined && lastIndex !== null && lastIndex !== undefined) {
       return makePatchError(firstIndex, lastIndex, content);
     }

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -318,4 +318,14 @@ describe('functions', () => {
       bar) => baz;
     `)
   );
+
+  it('handles a this-assign parameter with a reserved word name', () =>
+    check(`
+      (@case) ->
+    `, `
+      (function(case1) {
+        this.case = case1;
+      });
+    `)
+  );
 });


### PR DESCRIPTION
Fixes #666

Also add some additional error checking to avoid an infinite loop when trying
variable names, and make error formatting more robust to handle a NaN end index,
which apparently comes up sometimes. Also tweak the eslint config to allow
`new Set`.