### PR TITLE
feat: handle soaked prototype access

### DIFF
--- a/src/stages/main/patchers/MemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/MemberAccessOpPatcher.js
@@ -73,17 +73,23 @@ export default class MemberAccessOpPatcher extends NodePatcher {
       return lastToken;
     }
 
-    let dotIndex = this.indexOfSourceTokenAfterSourceTokenIndex(
-      this.expression.outerEndTokenIndex,
-      SourceType.DOT
+    let dotIndex = this.indexOfSourceTokenBetweenSourceIndicesMatching(
+      this.expression.outerEnd, this.outerEnd - 1, token => token.type === SourceType.DOT
     );
+
 
     if (!dotIndex) {
       let firstIndex = this.contentStartTokenIndex;
       let firstToken = this.sourceTokenAtIndex(firstIndex);
-
       if (firstToken.type === SourceType.AT) {
         // e.g. `@a`, so it's okay that there's no dot
+        return null;
+      }
+
+      let expressionLastIndex = this.expression.contentEndTokenIndex;
+      let expressionLastToken = this.sourceTokenAtIndex(expressionLastIndex);
+      if (expressionLastToken.type === SourceType.PROTO) {
+        // e.g. a?::b, parsed as (a?::)b, so the dot before the b is implicit.
         return null;
       }
 

--- a/src/stages/main/patchers/SoakedMemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/SoakedMemberAccessOpPatcher.js
@@ -17,10 +17,16 @@ export default class SoakedMemberAccessOpPatcher extends MemberAccessOpPatcher {
   patchAsExpression() {
     if (!this._shouldSkipSoakPatch) {
       this.registerHelper('__guard__', GUARD_HELPER);
-      let memberNameToken = this.getMemberNameSourceToken();
+
       let soakContainer = findSoakContainer(this);
       let varName = soakContainer.claimFreeBinding('x');
-      this.overwrite(this.expression.outerEnd, memberNameToken.start, `, ${varName} => ${varName}.`);
+      if (this.isShorthandPrototype()) {
+        this.overwrite(this.expression.outerEnd, this.contentEnd, `, ${varName} => ${varName}.prototype`);
+      } else {
+        let memberNameToken = this.getMemberNameSourceToken();
+        this.overwrite(this.expression.outerEnd, memberNameToken.start, `, ${varName} => ${varName}.`);
+      }
+
       soakContainer.insert(soakContainer.contentStart, '__guard__(');
       soakContainer.insert(soakContainer.contentEnd, ')');
     }

--- a/test/soaked_test.js
+++ b/test/soaked_test.js
@@ -346,6 +346,17 @@ describe('soaked expressions', () => {
       `);
     });
 
+    it('handles soaked prototype access', () => {
+      check(`
+        a?::b
+      `, `
+        __guard__(a, x => x.prototype.b);
+        function __guard__(value, transform) {
+          return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+        }
+      `);
+    });
+
     it('correctly handles normal soaked access', () => {
       validate(`
         a = {b: 5}


### PR DESCRIPTION
Fixes #691

This gets parsed as two nested accesses, one for the `a?::` and one for the `b`
(with an implicit preceding `.`), so I also needed to change some of the normal
member access code to handle that. I think this will also make the
`ProtoMemberAccessOp` node type unnecessary.