### PR TITLE
fix: handle \u2028 and \u2029 characters in strings and regexes

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babylon": "^6.12.0",
     "coffee-lex": "^5.0.0",
     "decaffeinate-coffeescript": "^1.10.0-patch5",
-    "decaffeinate-parser": "^11.0.0",
+    "decaffeinate-parser": "^11.0.1",
     "detect-indent": "^4.0.0",
     "esnext": "^3.0.9",
     "lines-and-columns": "^1.1.5",

--- a/src/stages/main/index.js
+++ b/src/stages/main/index.js
@@ -43,6 +43,7 @@ import OfOpPatcher from './patchers/OfOpPatcher';
 import PassthroughPatcher from './../../patchers/PassthroughPatcher';
 import ProgramPatcher from './patchers/ProgramPatcher';
 import ProtoMemberAccessOpPatcher from './patchers/ProtoMemberAccessOpPatcher';
+import RegexPatcher from './patchers/RegexPatcher';
 import RangePatcher from './patchers/RangePatcher';
 import RestPatcher from './patchers/RestPatcher';
 import ReturnPatcher from './patchers/ReturnPatcher';
@@ -91,7 +92,6 @@ export default class MainStage extends TransformCoffeeScriptStage {
       case 'PreIncrementOp':
       case 'PreDecrementOp':
       case 'Quasi':
-      case 'Regex':
         return PassthroughPatcher;
 
       case 'Break':
@@ -199,6 +199,9 @@ export default class MainStage extends TransformCoffeeScriptStage {
 
       case 'ModuloOp':
         return ModuloOpPatcher;
+
+      case 'Regex':
+        return RegexPatcher;
 
       case 'Heregex':
         return HeregexPatcher;

--- a/src/stages/main/patchers/HeregexPatcher.js
+++ b/src/stages/main/patchers/HeregexPatcher.js
@@ -18,7 +18,7 @@ export default class HeregexPatcher extends InterpolatedPatcher {
     }
 
     this.patchInterpolations();
-    this.removePadding();
+    this.processContents();
     this.escapeQuasis(/^\\\s/, ['`', '${', '\\']);
   }
 }

--- a/src/stages/main/patchers/RegexPatcher.js
+++ b/src/stages/main/patchers/RegexPatcher.js
@@ -1,0 +1,8 @@
+import NodePatcher from '../../../patchers/NodePatcher';
+import escapeSpecialWhitespaceInRange from '../../../utils/escapeSpecialWhitespaceInRange';
+
+export default class RegexPatcher extends NodePatcher {
+  patchAsExpression() {
+    escapeSpecialWhitespaceInRange(this.contentStart + 1, this.contentEnd - 1, this);
+  }
+}

--- a/src/stages/main/patchers/StringPatcher.js
+++ b/src/stages/main/patchers/StringPatcher.js
@@ -30,7 +30,7 @@ export default class StringPatcher extends InterpolatedPatcher {
     }
 
     this.patchInterpolations();
-    this.removePadding();
+    this.processContents();
     if (escapeStrings.length > 0) {
       this.escapeQuasis(/^\\/, escapeStrings);
     }

--- a/src/utils/escapeSpecialWhitespaceInRange.js
+++ b/src/utils/escapeSpecialWhitespaceInRange.js
@@ -1,0 +1,31 @@
+/* @flow */
+
+import type NodePatcher from '../patchers/NodePatcher';
+
+function isAlreadyEscaped(i: number, start: number, patcher: NodePatcher): boolean {
+  let numLeadingBackslashes = 0;
+  while (i - numLeadingBackslashes - 1 >= start &&
+      patcher.context.source[i - numLeadingBackslashes - 1] === '\\') {
+    numLeadingBackslashes++;
+  }
+  return numLeadingBackslashes % 2 === 1;
+}
+
+export default function exportSpecialWhitespaceInRange(start: number, end: number, patcher: NodePatcher) {
+  for (let i = start; i < end; i++) {
+    let unicodeSequence = null;
+    if (patcher.context.source[i] === '\u2028') {
+      unicodeSequence = 'u2028';
+    } else if (patcher.context.source[i] === '\u2029') {
+      unicodeSequence = 'u2029';
+    } else {
+      continue;
+    }
+
+    if (isAlreadyEscaped(i, start, patcher)) {
+      patcher.overwrite(i, i + 1, unicodeSequence);
+    } else {
+      patcher.overwrite(i, i + 1, `\\${unicodeSequence}`);
+    }
+  }
+}

--- a/test/regular_expression_test.js
+++ b/test/regular_expression_test.js
@@ -64,4 +64,68 @@ describe('regular expressions', () => {
   it('allows escaping spaces in heregexes', () => {
     check(`///a\\ b\\\tc\\\nd///`, `new RegExp(\`a b\tc\nd\`);`);
   });
+
+  it('escapes \\u2028 within regexes', () => {
+    check(`
+      /\u2028/
+      `, `
+      /\\u2028/;
+    `);
+  });
+
+  it('escapes \\u2029 within regexes', () => {
+    check(`
+      /\u2029/
+      `, `
+      /\\u2029/;
+    `);
+  });
+
+  it('uses the existing escape character for escaped \\u2028 within regexes', () => {
+    check(`
+      /\\\u2028/
+      `, `
+      /\\u2028/;
+    `);
+  });
+
+  it('leaves an escaped backslash when an escaped backslash is followed by \\u2028 within regexes', () => {
+    check(`
+      /\\\\\u2028/
+      `, `
+      /\\\\\\u2028/;
+    `);
+  });
+
+  it('removes \\u2028 within heregexes', () => {
+    check(`
+      ///\u2028///
+      `, `
+      new RegExp(\`\`);
+    `);
+  });
+
+  it('removes \\u2029 within heregexes', () => {
+    check(`
+      ///\u2029///
+      `, `
+      new RegExp(\`\`);
+    `);
+  });
+
+  it('handles escaped \\u2028 within heregexes', () => {
+    check(`
+      ///\\\u2028///
+      `, `
+      new RegExp(\`\\u2028\`);
+    `);
+  });
+
+  it('handles escaped \\u2029 within heregexes', () => {
+    check(`
+      ///\\\u2029///
+      `, `
+      new RegExp(\`\\u2029\`);
+    `);
+  });
 });

--- a/test/string_test.js
+++ b/test/string_test.js
@@ -120,4 +120,36 @@ describe('strings', () => {
       b\`;
     `);
   });
+
+  it('escapes \\u2028 within strings', () => {
+    check(`
+      '\u2028'
+      `, `
+      '\\u2028';
+    `);
+  });
+
+  it('escapes \\u2029 within strings', () => {
+    check(`
+      '\u2029'
+      `, `
+      '\\u2029';
+    `);
+  });
+
+  it('uses the existing escape character for escaped \\u2028', () => {
+    check(`
+      '\\\u2028'
+      `, `
+      '\\u2028';
+    `);
+  });
+
+  it('leaves an escaped backslash when an escaped backslash is followed by \\u2028', () => {
+    check(`
+      '\\\\\u2028'
+      `, `
+      '\\\\\\u2028';
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #672

For the most part we can just do some overwrite operations on regions of code
that we know are string contents, but we also need to be careful to avoid
inserting `\u2028` if there's already a backslash there, since otherwise the
resulting string will be `\\u2028`.