### PR TITLE
feat: implement soaked prefix operations

### DIFF
--- a/src/stages/main/patchers/SoakedDynamicMemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/SoakedDynamicMemberAccessOpPatcher.js
@@ -19,7 +19,11 @@ export default class SoakedDynamicMemberAccessOpPatcher extends DynamicMemberAcc
       this.registerHelper('__guard__', GUARD_HELPER);
       let soakContainer = findSoakContainer(this);
       let varName = soakContainer.claimFreeBinding('x');
-      this.overwrite(this.expression.outerEnd, this.indexingExpr.outerStart, `, ${varName} => ${varName}[`);
+      let prefix = this.slice(soakContainer.contentStart, this.contentStart);
+      if (prefix.length > 0) {
+        this.remove(soakContainer.contentStart, this.contentStart);
+      }
+      this.overwrite(this.expression.outerEnd, this.indexingExpr.outerStart, `, ${varName} => ${prefix}${varName}[`);
       soakContainer.insert(soakContainer.contentStart, '__guard__(');
       soakContainer.insert(soakContainer.contentEnd, ')');
     }

--- a/src/stages/main/patchers/SoakedFunctionApplicationPatcher.js
+++ b/src/stages/main/patchers/SoakedFunctionApplicationPatcher.js
@@ -68,10 +68,14 @@ export default class SoakedFunctionApplicationPatcher extends FunctionApplicatio
     let callStartToken = this.getCallStartToken();
     let soakContainer = findSoakContainer(this);
     let varName = soakContainer.claimFreeBinding('o');
+    let prefix = this.slice(soakContainer.contentStart, this.contentStart);
+    if (prefix.length > 0) {
+      this.remove(soakContainer.contentStart, this.contentStart);
+    }
     // Since memberName is always a valid identifier, we can put it in a string
     // literal without worrying about escaping.
     this.overwrite(fn.expression.outerEnd, callStartToken.end,
-      `, '${memberName}', ${varName} => ${varName}.${memberName}(`);
+      `, '${memberName}', ${varName} => ${prefix}${varName}.${memberName}(`);
     soakContainer.insert(soakContainer.contentStart, '__guardMethod__(');
     soakContainer.insert(soakContainer.contentEnd, ')');
   }
@@ -91,9 +95,13 @@ export default class SoakedFunctionApplicationPatcher extends FunctionApplicatio
     let soakContainer = findSoakContainer(this);
     let objVarName = soakContainer.claimFreeBinding('o');
     let methodVarName = soakContainer.claimFreeBinding('m');
+    let prefix = this.slice(soakContainer.contentStart, this.contentStart);
+    if (prefix.length > 0) {
+      this.remove(soakContainer.contentStart, this.contentStart);
+    }
     this.overwrite(expression.outerEnd, indexingExpr.outerStart, `, `);
     this.overwrite(indexingExpr.outerEnd, callStartToken.end,
-      `, (${objVarName}, ${methodVarName}) => ${objVarName}[${methodVarName}](`);
+      `, (${objVarName}, ${methodVarName}) => ${prefix}${objVarName}[${methodVarName}](`);
     soakContainer.insert(soakContainer.contentStart, '__guardMethod__(');
     soakContainer.insert(soakContainer.contentEnd, ')');
   }
@@ -103,7 +111,11 @@ export default class SoakedFunctionApplicationPatcher extends FunctionApplicatio
     let callStartToken = this.getCallStartToken();
     let soakContainer = findSoakContainer(this);
     let varName = soakContainer.claimFreeBinding('f');
-    this.overwrite(this.fn.outerEnd, callStartToken.end, `, ${varName} => ${varName}(`);
+    let prefix = this.slice(soakContainer.contentStart, this.contentStart);
+    if (prefix.length > 0) {
+      this.remove(soakContainer.contentStart, this.contentStart);
+    }
+    this.overwrite(this.fn.outerEnd, callStartToken.end, `, ${varName} => ${prefix}${varName}(`);
     soakContainer.insert(soakContainer.contentStart, '__guardFunc__(');
     soakContainer.insert(soakContainer.contentEnd, ')');
   }

--- a/src/stages/main/patchers/SoakedMemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/SoakedMemberAccessOpPatcher.js
@@ -20,11 +20,15 @@ export default class SoakedMemberAccessOpPatcher extends MemberAccessOpPatcher {
 
       let soakContainer = findSoakContainer(this);
       let varName = soakContainer.claimFreeBinding('x');
+      let prefix = this.slice(soakContainer.contentStart, this.contentStart);
+      if (prefix.length > 0) {
+        this.remove(soakContainer.contentStart, this.contentStart);
+      }
       if (this.isShorthandPrototype()) {
-        this.overwrite(this.expression.outerEnd, this.contentEnd, `, ${varName} => ${varName}.prototype`);
+        this.overwrite(this.expression.outerEnd, this.contentEnd, `, ${varName} => ${prefix}${varName}.prototype`);
       } else {
         let memberNameToken = this.getMemberNameSourceToken();
-        this.overwrite(this.expression.outerEnd, memberNameToken.start, `, ${varName} => ${varName}.`);
+        this.overwrite(this.expression.outerEnd, memberNameToken.start, `, ${varName} => ${prefix}${varName}.`);
       }
 
       soakContainer.insert(soakContainer.contentStart, '__guard__(');

--- a/src/utils/findSoakContainer.js
+++ b/src/utils/findSoakContainer.js
@@ -71,10 +71,12 @@ function canParentHandleSoak(patcher: NodePatcher): boolean {
       && patcher.parent.assignee === patcher) {
     return true;
   }
-  if (['PostIncrementOp', 'PostDecrementOp'].indexOf(patcher.parent.node.type) >= 0) {
+  if ([
+        'PostIncrementOp', 'PostDecrementOp', 'PreIncrementOp', 'PreDecrementOp', 'DeleteOp'
+      ].indexOf(patcher.parent.node.type) >= 0) {
     return true;
   }
-  if (['PreIncrementOp', 'PreDecrementOp', 'DeleteOp'].indexOf(patcher.parent.node.type) >= 0) {
+  if ([].indexOf(patcher.parent.node.type) >= 0) {
     throw patcher.parent.error(
       'Expressions like `++a?.b`, `--a?.b`, and `delete a?.b` are not supported yet.'
     );

--- a/test/soaked_test.js
+++ b/test/soaked_test.js
@@ -313,7 +313,7 @@ describe('soaked expressions', () => {
       `);
     });
 
-    it.skip('keeps prefix ++ within soak expressions', () => {
+    it('keeps prefix ++ within soak expressions', () => {
       check(`
         ++a?.b
       `, `
@@ -324,7 +324,70 @@ describe('soaked expressions', () => {
       `);
     });
 
-    it.skip('keeps prefix -- within soak expressions', () => {
+    it('keeps prefix ++ within soaked dynamic accesses', () => {
+      check(`
+        ++a?[b]
+      `, `
+        __guard__(a, x => ++x[b]);
+        function __guard__(value, transform) {
+          return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+        }
+      `);
+    });
+
+    it('keeps prefix ++ within soaked dynamic accesses where the LHS is surrounded by parens', () => {
+      check(`
+        ++(a)?[b]
+      `, `
+        __guard__((a), x => ++x[b]);
+        function __guard__(value, transform) {
+          return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+        }
+      `);
+    });
+
+    it('keeps prefix ++ within soaked function calls', () => {
+      check(`
+        ++a?(b).c
+      `, `
+        __guardFunc__(a, f => ++f(b).c);
+        function __guardFunc__(func, transform) {
+          return typeof func === 'function' ? transform(func) : undefined;
+        }
+      `);
+    });
+
+    it('keeps prefix ++ within soaked method calls', () => {
+      check(`
+        ++a.b?(c).d
+      `, `
+        __guardMethod__(a, 'b', o => ++o.b(c).d);
+        function __guardMethod__(obj, methodName, transform) {
+          if (typeof obj !== 'undefined' && obj !== null && typeof obj[methodName] === 'function') {
+            return transform(obj, methodName);
+          } else {
+            return undefined;
+          }
+        }
+      `);
+    });
+
+    it('keeps prefix ++ within soaked dynamic method calls', () => {
+      check(`
+        ++a[b]?(c).d
+      `, `
+        __guardMethod__(a, b, (o, m) => ++o[m](c).d);
+        function __guardMethod__(obj, methodName, transform) {
+          if (typeof obj !== 'undefined' && obj !== null && typeof obj[methodName] === 'function') {
+            return transform(obj, methodName);
+          } else {
+            return undefined;
+          }
+        }
+      `);
+    });
+
+    it('keeps prefix -- within soak expressions', () => {
       check(`
         --a?.b
       `, `
@@ -335,7 +398,7 @@ describe('soaked expressions', () => {
       `);
     });
 
-    it.skip('keeps delete within soak expressions', () => {
+    it('keeps delete within soak expressions', () => {
       check(`
         delete a?.b
       `, `


### PR DESCRIPTION
Fixes #699

This ended up not being so bad: we can just get the from the start of the soak
container to the start of the soak operation and move it to within the guard
call.