### PR TITLE
feat: implement splice operations

### DIFF
--- a/test/slice_test.js
+++ b/test/slice_test.js
@@ -1,4 +1,5 @@
 import check from './support/check';
+import validate from './support/validate';
 
 describe('slice', () => {
   it('changes exclusive slices with any range values into a call to `.slice` directly', () => {
@@ -50,5 +51,92 @@ describe('slice', () => {
     `, `
       let a = (Array.from(d).filter((c) => e).map((c) => b)).slice(0, 2);
     `);
+  });
+
+  it('handles an exclusive splice with both bounds specified', () => {
+    check(`
+      a[b...c] = d
+    `, `
+      a.splice(b, c - b, ...Array.from(d)), d;
+    `);
+  });
+
+  it('handles an inclusive splice with both bounds specified', () => {
+    check(`
+      a[b..c] = d
+    `, `
+      a.splice(b, c - b + 1, ...Array.from(d)), d;
+    `);
+  });
+
+  it('handles an exclusive splice with the first bound specified', () => {
+    check(`
+      a[b...] = c
+    `, `
+      a.splice(b, 9e9, ...Array.from(c)), c;
+    `);
+  });
+
+  it('handles an inclusive splice with the first bound specified', () => {
+    check(`
+      a[b..] = c
+    `, `
+      a.splice(b, 9e9, ...Array.from(c)), c;
+    `);
+  });
+
+  it('handles an exclusive splice with the last bound specified', () => {
+    check(`
+      a[...b] = c
+    `, `
+      a.splice(0, b, ...Array.from(c)), c;
+    `);
+  });
+
+  it('handles an inclusive splice with the last bound specified', () => {
+    check(`
+      a[..b] = c
+    `, `
+      a.splice(0, b + 1, ...Array.from(c)), c;
+    `);
+  });
+
+  it('handles an exclusive splice over an unbounded range', () => {
+    check(`
+      a[...] = b
+    `, `
+      a.splice(0, 9e9, ...Array.from(b)), b;
+    `);
+  });
+
+  it('handles an inclusive splice over an unbounded range', () => {
+    check(`
+      a[..] = b
+    `, `
+      a.splice(0, 9e9, ...Array.from(b)), b;
+    `);
+  });
+
+  it('extracts the array into a variable if necessary', () => {
+    check(`
+      a[b...c] = d()
+    `, `
+      let ref;
+      a.splice(b, c - b, ...Array.from(ref = d())), ref;
+    `);
+  });
+
+  it('allows overwriting with an array', () => {
+    validate(`
+      o = ['a', 'b', 'c', 'd']
+      o[1...3] = ['e', 'f']
+    `, ['a', 'e', 'f', 'd']);
+  });
+
+  it('allows overwriting with an individual element', () => {
+    validate(`
+      o = ['a', 'b', 'c', 'd']
+      o[1...3] = 'e';
+    `, ['a', 'e', 'd']);
   });
 });

--- a/test/support/validate.js
+++ b/test/support/validate.js
@@ -2,7 +2,7 @@ import * as babel from 'babel-core';
 import * as vm from 'vm';
 import { compile } from 'decaffeinate-coffeescript';
 import { convert, PatchError } from '../..';
-import { strictEqual } from 'assert';
+import { deepEqual } from 'assert';
 
 /**
  * validate takes coffee-script as input with code that sets the variable
@@ -48,7 +48,7 @@ function runValidation(source: string, expectedOutput: ?any) {
   let coffeeOutput = runCodeAndExtract(coffeeES5);
   let decaffeinateOutput = runCodeAndExtract(decaffeinateES5);
   try {
-    strictEqual(decaffeinateOutput, coffeeOutput);
+    deepEqual(decaffeinateOutput, coffeeOutput);
   } catch (err) {
     // add some additional context for debugging
     err.message = `Additional Debug:
@@ -70,6 +70,6 @@ ${err.message}`;
   }
 
   if (expectedOutput !== undefined) {
-    strictEqual(decaffeinateOutput, expectedOutput);
+    deepEqual(decaffeinateOutput, expectedOutput);
   }
 }


### PR DESCRIPTION
Fixes #668

This is heavily based off of the slice patching code, with some modifications.
It's also a little strange in that the slice patcher patches only part of the
slice call and the assign op patcher patches the rest, but that seemed like the
cleanest way to do it with the way things are structured now.