### PR TITLE
fix: use patchAndGetCode when patching loop steps

### DIFF
--- a/src/stages/main/patchers/ForInPatcher.js
+++ b/src/stages/main/patchers/ForInPatcher.js
@@ -555,9 +555,8 @@ class Step {
     };
     if (patcher) {
       apply(patcher);
-      patcher.patch();
       this.isLiteral = root.node.type === 'Int' || root.node.type === 'Float';
-      this.init = patcher.slice(patcher.contentStart, patcher.contentEnd);
+      this.init = patcher.patchAndGetCode();
       if (this.isLiteral) {
         this.update = root.slice(root.contentStart, root.contentEnd);
         this.number = root.node.data;

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1226,4 +1226,16 @@ describe('for loops', () => {
       for (let step = c ? d : undefined, asc = step > 0, i = asc ? 0 : b.length - 1; asc ? i < b.length : i >= 0; i += step) { let a = b[i]; a; }
     `);
   });
+
+  it('handles a complicated step', () => {
+    check(`
+      for a in b by c * d / e
+        f
+    `, `
+      for (let step = (c * d) / e, asc = step > 0, i = asc ? 0 : b.length - 1; asc ? i < b.length : i >= 0; i += step) {
+        let a = b[i];
+        f;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #708

This ensures that we include any open-parens at the start of the expression.