### PR TITLE
chore: ignore jsonlint in .flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,7 @@
 .*/config-chain/.*
 .*/npmconf/.*
 .*/semantic-release/.*
+.*/jsonlint/.*
 
 [include]
 


### PR DESCRIPTION
This makes it possible to `npm link` in the decaffeinate-coffeescript package
without flow errors.