### PR TITLE
chore: change test code to point at source rather than dist code

### DIFF
--- a/test/support/check.js
+++ b/test/support/check.js
@@ -1,6 +1,6 @@
 import PatchError from '../../src/utils/PatchError';
 import stripSharedIndent from '../../src/utils/stripSharedIndent';
-import { convert } from '../../';
+import { convert } from '../../src/index';
 import { strictEqual } from 'assert';
 
 export default function check(source, expected, options={}) {

--- a/test/support/validate.js
+++ b/test/support/validate.js
@@ -1,7 +1,7 @@
 import * as babel from 'babel-core';
 import * as vm from 'vm';
 import { compile } from 'decaffeinate-coffeescript';
-import { convert, PatchError } from '../..';
+import { convert, PatchError } from '../../src/index';
 import { deepEqual } from 'assert';
 
 /**


### PR DESCRIPTION
I've been working on top of this diff for a while since it makes my dev workflow
easier, so I figured I'd send a PR since maybe it's a nice change in general.
Importing from `src/index` directly means that you can run `mocha` directly
without building each time (which is especially nice for tests within WebStorm),
and loading the source files directly means that debugging through source files
just works. The downside is that if rollup did end up introducing correctness
issues, the tests now wouldn't catch them. But decaffeinate-parser and
coffee-lex use this strategy as well, so it seems ok.

I kept the `"pretest": "npm run build",` line in package.json since I think it's
still useful to verify that build, lint, and flow all work, especially in CI.