### PR TITLE
fix: do not insert code outside array elements

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -888,6 +888,8 @@ export default class NodePatcher {
       if (this.isNodeFunctionApplication(this.parent.node) &&
           this.parent.node.arguments.some(arg => arg === this.node)) {
         return this;
+      } else if (this.parent.node.type === 'ArrayInitialiser') {
+        return this;
       }
       return this.parent.getBoundingPatcher();
     } else {

--- a/test/array_test.js
+++ b/test/array_test.js
@@ -120,4 +120,17 @@ describe('arrays', () => {
       }))];
     `);
   });
+
+  it('keeps array elements inserting within the array', () =>
+    check(`
+      [->
+        a
+        b]
+    `, `
+      [function() {
+        a;
+        return b;
+      }];
+    `)
+  );
 });


### PR DESCRIPTION
Ensure that array elements are considered bounding patchers. This prevents, for example, appending trailing `}` for functions outside the array.

Closes #716