### PR TITLE
feat: more intelligently handle invalid constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Options:
 * `--loose-for-expressions`: Do not wrap expression loop targets in `Array.from`.
 * `--loose-for-of`: Do not wrap JS `for...of` loop targets in `Array.from`.
 * `--loose-includes`: Do not wrap in `Array.from` when converting `in` to `includes`.
+* `--allow-invalid-constructors`: Don't error when constructors use `this`
+  before super or omit the `super` call in a subclass.
+* `--enable-babel-constructor-workaround`: Use a hacky babel-specific workaround
+  to allow `this` before `super` in constructors.
 
 For more usages examples, see the output of `decaffeinate --help`.
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -64,6 +64,14 @@ function parseArguments(args: Array<string>): CLIOptions {
         baseOptions.looseIncludes = true;
         break;
 
+      case '--allow-invalid-constructors':
+        baseOptions.allowInvalidConstructors = true;
+        break;
+
+      case '--enable-babel-constructor-workaround':
+        baseOptions.enableBabelConstructorWorkaround = true;
+        break;
+
       default:
         if (arg.startsWith('-')) {
           console.error(`Error: unrecognized option '${arg}'`);
@@ -191,6 +199,12 @@ function usage() {
   console.log('  --loose-for-expressions  Do not wrap expression loop targets in Array.from.');
   console.log('  --loose-for-of           Do not wrap JS for...of loop targets in Array.from.');
   console.log('  --loose-includes         Do not wrap in Array.from when converting in to includes.');
+  console.log('  --allow-invalid-constructors');
+  console.log('                           Don\'t error when constructors use this before super or omit');
+  console.log('                           the super call in a subclass.');
+  console.log('  --enable-babel-constructor-workaround');
+  console.log('                           Use a hacky babel-specific workaround to allow this before');
+  console.log('                           super in constructors.');
   console.log();
   console.log('EXAMPLES');
   console.log();

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,8 @@ export type Options = {
   looseForExpressions: ?boolean,
   looseForOf: ?boolean,
   looseIncludes: ?boolean,
+  allowInvalidConstructors: ?boolean,
+  enableBabelConstructorWorkaround: ?boolean,
 };
 
 const DEFAULT_OPTIONS = {
@@ -37,6 +39,8 @@ const DEFAULT_OPTIONS = {
   looseForExpressions: false,
   looseForOf: false,
   looseIncludes: false,
+  allowInvalidConstructors: false,
+  enableBabelConstructorWorkaround: false,
 };
 
 type ConversionResult = {

--- a/src/stages/main/patchers/BlockPatcher.js
+++ b/src/stages/main/patchers/BlockPatcher.js
@@ -141,12 +141,18 @@ export default class BlockPatcher extends NodePatcher {
         lastStatement.outerEnd;
       insertionPoint = Math.min(insertionPoint, this.getBoundingPatcher().innerEnd);
       let indent = lastStatement.getIndent();
-      statements.forEach(line => this.insert(insertionPoint, `${separator}${indent}${line}`));
+      statements.forEach(line => {
+        let sep = line.trim().startsWith('//') ? '\n' : separator;
+        this.insert(insertionPoint, `${sep}${indent}${line}`);
+      });
     } else {
       let statementToInsertBefore = this.statements[index];
       let insertionPoint = statementToInsertBefore.outerStart;
       let indent = statementToInsertBefore.getIndent();
-      statements.forEach(line => this.insert(insertionPoint, `${line}${separator}${indent}`));
+      statements.forEach(line => {
+        let sep = line.trim().startsWith('//') ? '\n' : separator;
+        this.insert(insertionPoint, `${line}${sep}${indent}`);
+      });
     }
   }
 

--- a/src/stages/main/patchers/ClassBlockPatcher.js
+++ b/src/stages/main/patchers/ClassBlockPatcher.js
@@ -3,6 +3,8 @@ import ClassAssignOpPatcher from './ClassAssignOpPatcher';
 import ConstructorPatcher from './ConstructorPatcher';
 import NodePatcher from './../../../patchers/NodePatcher';
 import adjustIndent from '../../../utils/adjustIndent';
+import babelConstructorWorkaroundLines from '../../../utils/babelConstructorWorkaroundLines';
+import getInvalidConstructorErrorMessage from '../../../utils/getInvalidConstructorErrorMessage';
 import type ClassPatcher from './ClassPatcher';
 import type { Node } from './../../../patchers/types';
 
@@ -17,13 +19,25 @@ export default class ClassBlockPatcher extends BlockPatcher {
     if (!this.hasConstructor()) {
       let boundMethods = this.boundInstanceMethods();
       if (boundMethods.length > 0) {
+        let isSubclass = this.getClassPatcher().isSubclass();
+        if (isSubclass && !this.shouldAllowInvalidConstructors()) {
+          throw this.error(getInvalidConstructorErrorMessage(
+            'Cannot automatically convert a subclass that uses bound methods.'
+          ));
+        }
+
         let { source } = this.context;
         let insertionPoint = this.statements[0].outerStart;
         let methodIndent = adjustIndent(source, insertionPoint, 0);
         let methodBodyIndent = adjustIndent(source, insertionPoint, 1);
         let constructor = '';
-        if (this.getClassPatcher().isSubclass()) {
-          constructor += `constructor(...args) {\n${methodBodyIndent}super(...args);\n`;
+        if (isSubclass) {
+          constructor += `constructor(...args) {\n`;
+          if (this.shouldEnableBabelWorkaround()) {
+            for (let line of babelConstructorWorkaroundLines) {
+              constructor += `${methodBodyIndent}${line}\n`;
+            }
+          }
         } else {
           constructor += `constructor() {\n`;
         }
@@ -31,11 +45,22 @@ export default class ClassBlockPatcher extends BlockPatcher {
           let key = source.slice(method.key.contentStart, method.key.contentEnd);
           constructor += `${methodBodyIndent}this.${key} = this.${key}.bind(this);\n`;
         });
+        if (isSubclass) {
+          constructor += `${methodBodyIndent}super(...args)\n`;
+        }
         constructor += `${methodIndent}}\n\n${methodIndent}`;
         this.insert(insertionPoint, constructor);
       }
     }
     super.patch(options);
+  }
+
+  shouldAllowInvalidConstructors() {
+    return this.options.allowInvalidConstructors || this.options.enableBabelConstructorWorkaround;
+  }
+
+  shouldEnableBabelWorkaround() {
+    return this.options.enableBabelConstructorWorkaround;
   }
   
   getClassPatcher(): ClassPatcher {

--- a/src/stages/main/patchers/ConstructorPatcher.js
+++ b/src/stages/main/patchers/ConstructorPatcher.js
@@ -1,5 +1,9 @@
+import ClassPatcher from './ClassPatcher';
 import ObjectBodyMemberPatcher from './ObjectBodyMemberPatcher';
+import babelConstructorWorkaroundLines from '../../../utils/babelConstructorWorkaroundLines';
+import getInvalidConstructorErrorMessage from '../../../utils/getInvalidConstructorErrorMessage';
 import traverse from '../../../utils/traverse';
+import { isFunction } from '../../../utils/types';
 import type FunctionPatcher from './FunctionPatcher';
 import type NodePatcher from '../../../patchers/NodePatcher';
 import type { PatcherContext } from './../../../patchers/types';
@@ -13,45 +17,113 @@ export default class ConstructorPatcher extends ObjectBodyMemberPatcher {
   }
 
   patch(options={}) {
-    let boundMethods = this.parent.boundInstanceMethods();
-    let bindings = boundMethods.map(method => {
-      let key = this.context.source.slice(method.key.contentStart, method.key.contentEnd);
-      return `this.${key} = this.${key}.bind(this)`;
-    });
+    this.checkForConstructorErrors();
 
-    if (bindings.length > 0 && this.expression.body) {
-      let indexOfSuperStatement = this.getIndexOfSuperStatement(this.expression.body.statements);
-      // Work around some magic-string issues by carefully deciding patching
-      // order. If we're adding statements to the start, patch the function
-      // first so the statements are patched after the initial function code. If
-      // we're adding statements to the end, patch the function last so we don't
-      // end up adding statements after the close-brace.
-      if (indexOfSuperStatement < 0) {
-        super.patch(options);
-        this.expression.body.insertStatementsAtIndex(bindings, 0);
-      } else {
-        this.expression.body.insertStatementsAtIndex(bindings, indexOfSuperStatement + 1);
-        super.patch(options);
-      }
-    } else if (bindings.length > 0) {
-      super.patch();
-      // As a special case, if there's no function body but we still want to
-      // generate bindings, overwrite the function body with the desired
-      // contents, since it's sort of hard to insert contents in the middle of
-      // the generated {}.
-      let indent = this.getIndent();
-      let bodyIndent = this.getIndent(1);
-      let arrowToken = this.expression.getArrowToken();
-
-      let bindingLines = bindings.map(binding => `${bodyIndent}${binding}\n`);
-      let bodyCode = `{\n${bindingLines.join('')}${indent}}`;
-      this.overwrite(arrowToken.start, this.expression.outerEnd, bodyCode);
+    if (this.expression.body) {
+      let linesToInsert = this.getLinesToInsert();
+      this.expression.body.insertStatementsAtIndex(linesToInsert, 0);
+      super.patch(options);
     } else {
       super.patch(options);
+      let linesToInsert = this.getLinesToInsert();
+      if (linesToInsert.length > 0) {
+        // As a special case, if there's no function body but we still want to
+        // generate bindings, overwrite the function body with the desired
+        // contents, since it's sort of hard to insert contents in the middle of
+        // the generated {}.
+        let indent = this.getIndent();
+        let bodyIndent = this.getIndent(1);
+        let arrowToken = this.expression.getArrowToken();
+
+        let fullLines = linesToInsert.map(line => `${bodyIndent}${line}\n`);
+        let bodyCode = `{\n${fullLines.join('')}${indent}}`;
+        this.overwrite(arrowToken.start, this.expression.outerEnd, bodyCode);
+      }
     }
   }
 
-  getIndexOfSuperStatement(statements) {
+  getLinesToInsert(): Array<string> {
+    let lines = [];
+    if (this.shouldAddBabelWorkaround()) {
+      lines = lines.concat(babelConstructorWorkaroundLines);
+    }
+    lines = lines.concat(this.getBindings());
+    return lines;
+  }
+
+  /**
+   * Give an up-front error if this is a subclass that either omits the `super`
+   * call or uses `this` before `super`.
+   */
+  checkForConstructorErrors() {
+    if (this.options.allowInvalidConstructors ||
+        this.options.enableBabelConstructorWorkaround) {
+      return;
+    }
+
+    let errorMessage = this.getInvalidConstructorMessage();
+    if (errorMessage) {
+      throw this.error(getInvalidConstructorErrorMessage(errorMessage));
+    }
+  }
+
+  shouldAddBabelWorkaround(): boolean {
+    return this.options.enableBabelConstructorWorkaround &&
+      this.getInvalidConstructorMessage() !== null;
+  }
+
+  /**
+   * Return a string with an error if this constructor is invalid (generally one
+   * that uses this before super). Otherwise return null.
+   */
+  getInvalidConstructorMessage(): ?string {
+    if (!this.isSubclass()) {
+      return null;
+    }
+
+    // Any bindings would ideally go before the super call, so if there are any,
+    // we'll need this before super.
+    if (this.getBindings().length > 0) {
+      return 'Cannot automatically convert a subclass that uses bound methods.';
+    }
+
+    let superIndex = this.getIndexOfSuperStatement();
+    let thisIndex = this.getIndexOfFirstThisStatement();
+
+    if (superIndex === -1) {
+      return 'Cannot automatically convert a subclass with a constructor that does not call super.';
+    }
+    if (thisIndex >= 0 && thisIndex <= superIndex) {
+      return 'Cannot automatically convert a subclass with a constructor that uses `this` before `super`.';
+    }
+    return null;
+  }
+
+  getBindings(): Array<string> {
+    if (!this._bindings) {
+      let boundMethods = this.parent.boundInstanceMethods();
+      let bindings = boundMethods.map(method => {
+        let key = this.context.source.slice(method.key.contentStart, method.key.contentEnd);
+        return `this.${key} = this.${key}.bind(this)`;
+      });
+      this._bindings = bindings;
+    }
+    return this._bindings;
+  }
+
+  isSubclass() {
+    let enclosingClass = this.parent.parent;
+    if (!(enclosingClass instanceof ClassPatcher)) {
+      throw this.error('Expected grandparent of ConstructorPatcher to be ClassPatcher.');
+    }
+    return enclosingClass.isSubclass();
+  }
+
+  getIndexOfSuperStatement() {
+    if (!this.expression.body) {
+      return -1;
+    }
+    let statements = this.expression.body.statements;
     for (let i = 0; i < statements.length; i++) {
       let callsSuper = false;
       traverse(statements[i].node, child => {
@@ -67,6 +139,32 @@ export default class ConstructorPatcher extends ObjectBodyMemberPatcher {
         }
       });
       if (callsSuper) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  getIndexOfFirstThisStatement() {
+    if (!this.expression.body) {
+      return -1;
+    }
+    let statements = this.expression.body.statements;
+    for (let i = 0; i < statements.length; i++) {
+      let usesThis = false;
+      traverse(statements[i].node, child => {
+        if (usesThis) {
+          // Already found it, skip this one.
+          return false;
+        } else if (child.type === 'This') {
+          // Found it.
+          usesThis = true;
+        } else if (child.type === 'Class' || isFunction(child)) {
+          // Don't go into other classes or functions.
+          return false;
+        }
+      });
+      if (usesThis) {
         return i;
       }
     }

--- a/src/stages/normalize/patchers/FunctionPatcher.js
+++ b/src/stages/normalize/patchers/FunctionPatcher.js
@@ -16,6 +16,13 @@ export default class FunctionPatcher extends NodePatcher {
   }
 
   patchAsExpression() {
+    // Make sure there is at least one character of whitespace between the ->
+    // and the body, since otherwise the main stage can run into subtle
+    // magic-string issues later.
+    if (this.body && !this.slice(this.body.contentStart - 1, this.body.contentStart).match(/\s/)) {
+      this.insert(this.body.contentStart, ' ');
+    }
+
     // To avoid knowledge of all the details how assignments can be nested in nodes,
     // we add a callback to the function node before patching the parameters and remove it afterwards.
     // This is detected and used by the MemberAccessOpPatcher to claim a free binding for this parameter

--- a/src/utils/babelConstructorWorkaroundLines.ts
+++ b/src/utils/babelConstructorWorkaroundLines.ts
@@ -1,0 +1,29 @@
+/**
+ * A code snippet that can be placed at the top of a constructor to allow the
+ * constructor to use `this` before `super`, at least when run through babel.
+ *
+ * This makes use of two techniques:
+ * - babel does a static analysis check to make sure that all `this` accesses
+ *   at least have a chance of happening after the first `super` call. We can
+ *   wrap a super call in an `if (false)` at the top to silence this check
+ *   without changing the runtime behavior (and later super calls will still
+ *   work).
+ * - babel compiles `this` usages in constructors to a separate variable,
+ *   usually called `_this`, which gets assigned in the `super` line. However,
+ *   the assignment to `_this` only happens when `super` actually runs, so it
+ *   will normally be undefined before the `super` call. We can make `_this`
+ *   resolve to `this` before the constructor by running `eval('_this = this;')`
+ *   to escape babel's rewriting. However, the variable is not always called
+ *   `_this`. We can still get the right variable name, though, but making an
+ *   arrow function using `this`, calling `toString`, and parsing the variable
+ *   name from it.
+ */
+export default [
+  '{',
+  '  // Hack: trick babel into allowing this before super.',
+  '  if (false) { super(); }',
+  '  let thisFn = (() => { this }).toString();',
+  "  let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();",
+  '  eval(`${thisName} = this;`);',
+  '}',
+];

--- a/src/utils/getInvalidConstructorErrorMessage.ts
+++ b/src/utils/getInvalidConstructorErrorMessage.ts
@@ -1,0 +1,25 @@
+import stripSharedIndent from "./stripSharedIndent";
+
+export default function getInvalidConstructorErrorMessage(firstSentence: string): string {
+  return stripSharedIndent(`
+    ${firstSentence}
+    
+    JavaScript requires all subclass constructors to call \`super\` and to do so
+    before the first use of \`this\`, so the following cases cannot be converted
+    automatically:
+    * Constructors in subclasses that use \`this\` before \`super\`.
+    * Constructors in subclasses that omit the \`super\` call.
+    * Subclasses that use \`=>\` method syntax to automatically bind methods.
+    
+    To convert these cases to JavaScript anyway, run decaffeinate with
+    --allow-invalid-constructors. You will then need to fix these cases after the
+    conversion to JavaScript. Alternatively, you may want to first edit your
+    CoffeeScript code to avoid the above cases, so that decaffeinate can run without
+    this error message.
+    
+    If you are using babel, you can run decaffeinate with
+    --enable-babel-constructor-workaround to generate babel-specific code to allow
+    constructors that don't call \`super\`. Note that this approach is fragile and
+    may break in future versions of babel.
+  `);
+}

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -70,7 +70,8 @@ export function isDynamicMemberAccessOp(node: Node): boolean {
  * Determines whether a node represents a function, i.e. `->` or `=>`.
  */
 export function isFunction(node: Node, allowBound: boolean=true): boolean {
-  return node.type === 'Function' || node.type === 'GeneratorFunction' || (allowBound && node.type === 'BoundFunction');
+  return node.type === 'Function' || node.type === 'GeneratorFunction' ||
+    (allowBound && (node.type === 'BoundFunction' || node.type === 'BoundGeneratorFunction'));
 }
 
 /**

--- a/test/support/assertError.js
+++ b/test/support/assertError.js
@@ -1,0 +1,18 @@
+import PatchError from '../../src/utils/PatchError';
+import stripSharedIndent from '../../src/utils/stripSharedIndent';
+import { convert } from '../../src/index';
+import { ok } from 'assert';
+
+export default function assertError(source, expectedErrorText, options={}) {
+  if (source[0] === '\n') { source = stripSharedIndent(source); }
+
+  try {
+    convert(source, options);
+    ok(false, 'Expected an error to be thrown');
+  } catch (err) {
+    if (PatchError.detect(err) && err.message.includes(expectedErrorText)) {
+      return;
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
Fixes #591
Fixes #726

A major difference between CoffeeScript and JavaScript class constructors is
that JavaScript class constructors require you to call `super` and require it
to be called before the first use of `this` (when the class is a subclass).
This has caused two significant issues in decaffeinate:
* CS code that uses `this` before `super` or omits `super` will convert to code
  that is rejected by babel. This happened for 11 files in my codebase.
* Subclasses that use bound methods will put the binding code after the `super`
  call, while the CoffeeScript semantics are to put it before the `super` call.
  This caused (at least) two correctness issues in my codebase, only one of
  which was caught the tests. (Both of these were backbone subclasses where the
  `initialize` method gets called before the super call ends.)

Since there doesn't seem to be a great answer to this problem, this commit
provides three options for how to handle it:
* Give an error rather than generating incorrect code. This is the default
  behavior. If a constructor uses `this` before `super` or omits `super`, or if
  a subclass uses a bound method, then decaffeinate gives an error for the file
  explaining the issue and the different options. This flags the issue for
  people not aware of it, and gives people a chance to change their CoffeeScript
  code to not have these issues (e.g. rewriting constructors and/or changing
  bound methods to explicit bindings).
* `--allow-invalid-constructors` generates JS code even if `this` is used before
  `super` in the constructor, and it generates code that would be correct if JS
  allowed it (method bindings at the start of the constructor). Technically, this
  code is syntactically valid, but will crash at runtime in a JS interpreter and
  will be rejected by babel. The intention here is that it may be useful to
  convert the code anyway and fix the invalid constructors later, e.g. moving
  the binding lines after doing a sanity check.
* `--enable-babel-constructor-workaround` generates the same invalid code, but
  also puts a code snippet at the top of each constructor that tricks babel into
  allowing `this` before `super` in constructors (even at runtime). This works
  because babel doesn't use fully-compliant JS classes, and it's certainly a
  hack that might break due to a change in babel, but as far as I can tell, it's
  completely correct as long as you're using babel. This is especially useful as
  a way to automatically convert a project and run all of the tests, but
  probably shouldn't be used in production or at least should be removed as soon
  as possible if it is.

Notably, there is no longer a way to put method bindings after the super call.
This both makes the implementation simpler and is more in line with "either
generate correct code or give an error". There could be an option for this in
the future, but really, I think it's best for people to manually check that
reordering the constructor is ok.

Another possible future option is to generate classes the same way that
CoffeeScript does, or do some other less hacky trick to allow `this` before
`super`. But JS classes fundamentally don't allow this, and CS classes can't
extend JS classes, so it seems like the only 100% safe way to do this is to
NEVER generate JS classes, which seems like it would be more work and defeat a
lot of the purpose of decaffeinate.