### PR TITLE
fix: un-break CLI by changing detect-indent import to a form recognized by rollup

### DIFF
--- a/src/utils/determineIndent.ts
+++ b/src/utils/determineIndent.ts
@@ -1,4 +1,4 @@
-import detectIndent = require('detect-indent');
+const detectIndent = require('detect-indent');
 
 const DEFAULT_INDENT = '  ';
 

--- a/tslint.json
+++ b/tslint.json
@@ -11,7 +11,6 @@
     "no-any": true,
     "no-namespace": true,
     "no-internal-module": true,
-    "no-var-requires": true,
     "no-var-keyword": true,
     "prefer-for-of": true,
     "typedef": [true, "parameter", "property-declaration"],


### PR DESCRIPTION
This fixes a consistent crash caused by #735 where any non-trivial file would
fail due to `detectIndent` not being defined. From what I can tell, rollup can't
handle the `import detectIndent = require('detect-indent');` line and was just
ignoring it, so `detect-indent` was never pulled in and everything broke when it
tried to use that method.

A little ironic that this would have been caught by tests were it not for #712.
But probably it's still fine to leave the tests as testing the source code and
not the dist build.