### PR TITLE
fix: make edit bounds checking within an array more lenient

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -415,7 +415,8 @@ export default class NodePatcher {
     // comma/paren to the next comma/paren), so loosen the restriction to the
     // entire function.
     if (boundingPatcher.parent &&
-        this.isNodeFunctionApplication(boundingPatcher.parent.node)) {
+        (this.isNodeFunctionApplication(boundingPatcher.parent.node) ||
+        boundingPatcher.parent.node.type === 'ArrayInitialiser')) {
       boundingPatcher = boundingPatcher.parent;
     }
     if (this.allowPatchingOuterBounds()) {

--- a/test/object_test.js
+++ b/test/object_test.js
@@ -360,4 +360,19 @@ describe('objects', () => {
       ({x() { return x; }});
     `);
   });
+
+  it('handles an implicit object inside an array', () => {
+    check(`
+      [
+        a: b
+        c: d
+      ]
+    `, `
+      [{
+        a: b,
+        c: d
+      }
+      ];
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #740

I think fixes a regression from #719.

The assertion that we edit with bounds should be a little more lenient than the
code that limits writing to the bounding patcher. We already had a case for that
for function parameters, so add one for array elements as well.

The resulting code in the test is a bit ugly, but at least it doesn't crash.