### PR TITLE
fix: correctly handle splice operations on an individual element

### DIFF
--- a/src/stages/main/patchers/AssignOpPatcher.js
+++ b/src/stages/main/patchers/AssignOpPatcher.js
@@ -65,12 +65,12 @@ export default class AssignOpPatcher extends NodePatcher {
     // `a[b...c] = d` → `a.splice(b, c - b = d`
     //   ^                ^^^^^^^^^^^^^^^^
     slicePatcher.patchAsSpliceExpressionStart();
-    // `a.splice(b, c - b = d` → `a.splice(b, c - b, ...Array.from(d`
-    //                   ^^^                       ^^^^^^^^^^^^^^^^
-    this.overwrite(slicePatcher.outerEnd, this.expression.outerStart, ', ...Array.from(');
+    // `a.splice(b, c - b = d` → `a.splice(b, c - b, ...[].concat(d`
+    //                   ^^^                       ^^^^^^^^^^^^^^^
+    this.overwrite(slicePatcher.outerEnd, this.expression.outerStart, ', ...[].concat(');
     let expressionRef = this.expression.patchRepeatable();
-    // `a.splice(b, c - b, ...Array.from(d` → `a.splice(b, c - b, ...Array.from(d)), d`
-    //                                                                           ^^^^^
+    // `a.splice(b, c - b, ...[].concat(d` → `a.splice(b, c - b, ...[].concat(d)), d`
+    //                                                                         ^^^^^
     this.insert(this.expression.outerEnd, `)), ${expressionRef}`);
   }
 

--- a/test/slice_test.js
+++ b/test/slice_test.js
@@ -57,7 +57,7 @@ describe('slice', () => {
     check(`
       a[b...c] = d
     `, `
-      a.splice(b, c - b, ...Array.from(d)), d;
+      a.splice(b, c - b, ...[].concat(d)), d;
     `);
   });
 
@@ -65,7 +65,7 @@ describe('slice', () => {
     check(`
       a[b..c] = d
     `, `
-      a.splice(b, c - b + 1, ...Array.from(d)), d;
+      a.splice(b, c - b + 1, ...[].concat(d)), d;
     `);
   });
 
@@ -73,7 +73,7 @@ describe('slice', () => {
     check(`
       a[b...] = c
     `, `
-      a.splice(b, 9e9, ...Array.from(c)), c;
+      a.splice(b, 9e9, ...[].concat(c)), c;
     `);
   });
 
@@ -81,7 +81,7 @@ describe('slice', () => {
     check(`
       a[b..] = c
     `, `
-      a.splice(b, 9e9, ...Array.from(c)), c;
+      a.splice(b, 9e9, ...[].concat(c)), c;
     `);
   });
 
@@ -89,7 +89,7 @@ describe('slice', () => {
     check(`
       a[...b] = c
     `, `
-      a.splice(0, b, ...Array.from(c)), c;
+      a.splice(0, b, ...[].concat(c)), c;
     `);
   });
 
@@ -97,7 +97,7 @@ describe('slice', () => {
     check(`
       a[..b] = c
     `, `
-      a.splice(0, b + 1, ...Array.from(c)), c;
+      a.splice(0, b + 1, ...[].concat(c)), c;
     `);
   });
 
@@ -105,7 +105,7 @@ describe('slice', () => {
     check(`
       a[...] = b
     `, `
-      a.splice(0, 9e9, ...Array.from(b)), b;
+      a.splice(0, 9e9, ...[].concat(b)), b;
     `);
   });
 
@@ -113,7 +113,7 @@ describe('slice', () => {
     check(`
       a[..] = b
     `, `
-      a.splice(0, 9e9, ...Array.from(b)), b;
+      a.splice(0, 9e9, ...[].concat(b)), b;
     `);
   });
 
@@ -122,21 +122,21 @@ describe('slice', () => {
       a[b...c] = d()
     `, `
       let ref;
-      a.splice(b, c - b, ...Array.from(ref = d())), ref;
+      a.splice(b, c - b, ...[].concat(ref = d())), ref;
     `);
   });
 
   it('allows overwriting with an array', () => {
     validate(`
       o = ['a', 'b', 'c', 'd']
-      o[1...3] = ['e', 'f']
-    `, ['a', 'e', 'f', 'd']);
+      o[1...3] = ['Hello', 'World']
+    `, ['a', 'Hello', 'World', 'd']);
   });
 
   it('allows overwriting with an individual element', () => {
     validate(`
       o = ['a', 'b', 'c', 'd']
-      o[1...3] = 'e';
-    `, ['a', 'e', 'd']);
+      o[1...3] = 'Hello';
+    `, ['a', 'Hello', 'd']);
   });
 });


### PR DESCRIPTION
Fixes #751

I mistakenly thought `Array.from` would do what I want, but it actually just
happens to work for single-character strings because `Array.from('a')` is
`['a']`. Instead, we should use `concat` like CoffeeScript does (which has its
own rules about when to keep something an array and when to treat the arg as a
single element). I also made the tests a little more interesting to expose this
case.