### PR TITLE
feat: overhaul assignment patching to allow nested destructuring

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babylon": "^6.12.0",
     "coffee-lex": "^6.0.0",
     "decaffeinate-coffeescript": "^1.10.0-patch12",
-    "decaffeinate-parser": "^13.0.2",
+    "decaffeinate-parser": "^13.0.3",
     "detect-indent": "^4.0.0",
     "esnext": "^3.0.10",
     "lines-and-columns": "^1.1.5",

--- a/src/stages/main/patchers/ArrayInitialiserPatcher.js
+++ b/src/stages/main/patchers/ArrayInitialiserPatcher.js
@@ -1,3 +1,4 @@
+import ExpansionPatcher from './ExpansionPatcher';
 import NodePatcher from './../../../patchers/NodePatcher';
 import type { PatcherContext } from './../../../patchers/types';
 import { SourceType } from 'coffee-lex';
@@ -17,6 +18,13 @@ export default class ArrayInitialiserPatcher extends NodePatcher {
   patchAsExpression() {
     this.members.forEach((member, i, members) => {
       let isLast = i === members.length - 1;
+
+      // An expansion in a final position is a no-op, so just remove it.
+      if (isLast && member instanceof ExpansionPatcher) {
+        this.remove(members[i - 1].outerEnd, member.outerEnd);
+        return;
+      }
+
       let needsComma = !isLast && !member.hasSourceTokenAfter(SourceType.COMMA);
       member.patch();
       if (needsComma) {

--- a/src/stages/main/patchers/ModuloOpCompoundAssignOpPatcher.js
+++ b/src/stages/main/patchers/ModuloOpCompoundAssignOpPatcher.js
@@ -26,4 +26,8 @@ export default class ModuloOpCompoundAssignOpPatcher extends CompoundAssignOpPat
       this.insert(this.outerEnd, ')');
     }
   }
+
+  patchAsStatement() {
+    this.patchAsExpression();
+  }
 }

--- a/src/stages/main/patchers/SlicePatcher.js
+++ b/src/stages/main/patchers/SlicePatcher.js
@@ -85,6 +85,10 @@ export default class SlicePatcher extends NodePatcher {
     this.overwrite(indexEnd.start, indexEnd.end, ')');
   }
 
+  getInitialSpliceCode(): string {
+    return this.captureCodeForPatchOperation(() => this.patchAsSpliceExpressionStart());
+  }
+
   /**
    * Patch into the first part of a splice expression. For example,
    *

--- a/src/utils/canPatchAssigneeToJavaScript.js
+++ b/src/utils/canPatchAssigneeToJavaScript.js
@@ -1,0 +1,38 @@
+import type { Node } from '../patchers/types';
+
+/**
+ * Determine if the given assignee (array destructure, object destructure, rest,
+ * etc.) can be translated to JavaScript directly. If not, we'll need to expand
+ * the assignee into repeated assignments.
+ *
+ * Notably, we cannot patch default values (assignment operations) to JavaScript
+ * since CS falls back to the default if the value is undefined or null, while
+ * JS falls back to the default if the value only if the value is undefined.
+ */
+export default function canPatchAssigneeToJavaScript(node: Node, isTopLevel: boolean = true): boolean {
+  if ([
+        'Identifier', 'MemberAccessOp', 'SoakedMemberAccessOp', 'ProtoMemberAccessOp',
+        'DynamicMemberAccessOp', 'SoakedDynamicMemberAccessOp', 'SoakedProtoMemberAccessOp',
+      ].indexOf(node.type) > -1) {
+    return true;
+  }
+  if (node.type === 'ArrayInitialiser') {
+    // Nested array destructures can't convert cleanly because we need to wrap
+    // them in Array.from.
+    if (!isTopLevel) {
+      return false;
+    }
+    return node.members.every((member, i) => {
+      let isFinalExpansion = (i === node.members.length - 1) &&
+          ['Spread', 'Rest', 'Expansion'].indexOf(member.type) > -1;
+      return isFinalExpansion || canPatchAssigneeToJavaScript(member, false);
+    });
+  }
+  if (node.type === 'ObjectInitialiser') {
+    return node.members.every(node => canPatchAssigneeToJavaScript(node, false));
+  }
+  if (node.type === 'ObjectInitialiserMember') {
+    return canPatchAssigneeToJavaScript(node.expression, false);
+  }
+  return false;
+}

--- a/test/declaration_test.js
+++ b/test/declaration_test.js
@@ -87,7 +87,7 @@ describe('declarations', () => {
   });
 
   it('adds variable declarations for destructuring array assignment', () => {
-    check(`[a] = b`, `let [a] = b;`);
+    check(`[a] = b`, `let [a] = Array.from(b);`);
   });
 
   it('adds variable declarations for destructuring object assignment', () => {
@@ -100,7 +100,7 @@ describe('declarations', () => {
       [a] = b
     `, `
       let a = 1;
-      [a] = b;
+      [a] = Array.from(b);
     `);
   });
 
@@ -121,7 +121,7 @@ describe('declarations', () => {
     `, `
       let b;
       let a = 1;
-      [a, b] = c;
+      [a, b] = Array.from(c);
     `);
   });
 

--- a/test/slice_test.js
+++ b/test/slice_test.js
@@ -57,7 +57,7 @@ describe('slice', () => {
     check(`
       a[b...c] = d
     `, `
-      a.splice(b, c - b, ...[].concat(d)), d;
+      a.splice(b, c - b, ...[].concat(d));
     `);
   });
 
@@ -65,7 +65,7 @@ describe('slice', () => {
     check(`
       a[b..c] = d
     `, `
-      a.splice(b, c - b + 1, ...[].concat(d)), d;
+      a.splice(b, c - b + 1, ...[].concat(d));
     `);
   });
 
@@ -73,7 +73,7 @@ describe('slice', () => {
     check(`
       a[b...] = c
     `, `
-      a.splice(b, 9e9, ...[].concat(c)), c;
+      a.splice(b, 9e9, ...[].concat(c));
     `);
   });
 
@@ -81,7 +81,7 @@ describe('slice', () => {
     check(`
       a[b..] = c
     `, `
-      a.splice(b, 9e9, ...[].concat(c)), c;
+      a.splice(b, 9e9, ...[].concat(c));
     `);
   });
 
@@ -89,7 +89,7 @@ describe('slice', () => {
     check(`
       a[...b] = c
     `, `
-      a.splice(0, b, ...[].concat(c)), c;
+      a.splice(0, b, ...[].concat(c));
     `);
   });
 
@@ -97,7 +97,7 @@ describe('slice', () => {
     check(`
       a[..b] = c
     `, `
-      a.splice(0, b + 1, ...[].concat(c)), c;
+      a.splice(0, b + 1, ...[].concat(c));
     `);
   });
 
@@ -105,7 +105,7 @@ describe('slice', () => {
     check(`
       a[...] = b
     `, `
-      a.splice(0, 9e9, ...[].concat(b)), b;
+      a.splice(0, 9e9, ...[].concat(b));
     `);
   });
 
@@ -113,16 +113,27 @@ describe('slice', () => {
     check(`
       a[..] = b
     `, `
-      a.splice(0, 9e9, ...[].concat(b)), b;
+      a.splice(0, 9e9, ...[].concat(b));
+    `);
+  });
+
+  it('does not extract the RHS if it is not necessary', () => {
+    check(`
+      a[b..c] = d()
+    `, `
+      a.splice(b, c - b + 1, ...[].concat(d()));
     `);
   });
 
   it('extracts the array into a variable if necessary', () => {
     check(`
-      a[b...c] = d()
+      =>
+        return a[b...c] = d()
     `, `
-      let ref;
-      a.splice(b, c - b, ...[].concat(ref = d())), ref;
+      () => {
+        let ref;
+        return ref = d(), a.splice(b, c - b, ...[].concat(ref)), ref;
+      };
     `);
   });
 


### PR DESCRIPTION
Fixes #268

CoffeeScript assignment has some differences from JavaScript assignment in a few
ways:
* CoffeeScript allows the expansion operator (`...`).
* CoffeeScript allows intermediate rest assignments.
* CoffeeScript allows splice operations at any point in an assignment.
* CoffeeScript destructure defaults will fall back to the default if the value
  is `null` or `undefined`, unlike JS, which only falls back if the value is
  `undefined`.
* CoffeeScript array destructuring happens by accessing `arr[0]`, etc, while
  JavaScript destructuring uses the iterable protocol.

Assignment patching now has two code paths: the "normal" patching code path, and
the "expanded" code path. We use the normal code path when possible, which
translates the assignee in a straightforward way, but if any part of the
assignee can't be normally tranformed, we use the expanded code path as a
fallback. The expanded code path generally rewrites the assignment as a sequence
of intermediate assignments. Both code paths wrap the expression in `Array.from`
when the assignee is an array destructure.

For the expanded code path, we give up on attempting to do precise patching due
to the complex recursive nature of the problem. Instead, we generate a big
string of code and replace everything with that string. Since this can destroy
formatting, we prefer the normal code path when possible rather than making it a
special case of the expanded code path.

Note that this does not yet handle arbitrary parameters and loop assignees. The
plan is to change those to assignment statements in the normalize stage in a
later commit.