### PR TITLE
fix: evaluate parameter assignments in order

### DIFF
--- a/test/class_test.js
+++ b/test/class_test.js
@@ -522,8 +522,8 @@ describe('classes', () => {
         (@a, b = @c) ->
       `, `
         (function(a, b) {
-          if (b == null) { b = this.c; }
           this.a = a;
+          if (b == null) { b = this.c; }
         });
       `);
     });
@@ -538,12 +538,13 @@ describe('classes', () => {
       `, { looseDefaultParams: true });
     });
 
-    it.skip('uses correct value for default param when reusing an already implicitly assigned param', () => {
+    it('uses correct value for default param when reusing an already implicitly assigned param', () => {
       check(`
         (@a, b = @a) ->
       `, `
-        (function(a, b = a) {
+        (function(a, b) {
           this.a = a;
+          if (b == null) { b = this.a; }
         });
       `);
     });

--- a/test/expansion_test.js
+++ b/test/expansion_test.js
@@ -49,8 +49,7 @@ describe('expansion', () => {
       (..., a = 1) ->
     `, `
       (function(...args) {
-        let a = args[args.length - 1];
-        if (a == null) { a = 1; }
+        let val = args[args.length - 1], a = val != null ? val : 1;
       });
     `);
   });
@@ -60,13 +59,12 @@ describe('expansion', () => {
       (..., @a) ->
     `, `
       (function(...args) {
-        let a = args[args.length - 1];
-        this.a = a;
+        this.a = args[args.length - 1];
       });
     `);
   });
 
-  it('deconflicts names in the expansion param case', () => {
+  it('does not create name conflicts in the expansion param case', () => {
     check(`
       a = 1
       (..., @a) ->
@@ -75,8 +73,7 @@ describe('expansion', () => {
     `, `
       let a = 1;
       (function(...args) {
-        let a1 = args[args.length - 1];
-        this.a = a1;
+        this.a = args[args.length - 1];
         console.log(a);
       });
     `);

--- a/test/parameter_assignment_test.js
+++ b/test/parameter_assignment_test.js
@@ -9,21 +9,24 @@ describe('parameter assignment', () => {
     `);
   });
 
-  it.skip('allows assigning to a `this` property', () => {
-    // FIXME: This should not return the assignment value.
+  it('allows assigning to a `this` property', () => {
     check(`
       (@a) ->
     `, `
-      (function(a) { return this.a = a; });
+      (function(a) {
+        this.a = a;
+      });
     `);
   });
 
-  it.skip('allows assigning to multiple `this` properties', () => {
-    // FIXME: This should not return the assignment value.
+  it('allows assigning to multiple `this` properties', () => {
     check(`
       (@a, @b) ->
     `, `
-      (function(a, b) { return this.a = a, this.b = b; });
+      (function(a, b) {
+        this.a = a;
+        this.b = b;
+      });
     `);
   });
 
@@ -90,23 +93,28 @@ describe('parameter assignment', () => {
     `);
   });
 
-  it.skip('works as expected for struct-like class constructors', () => {
+  it('works as expected for struct-like class constructors', () => {
     check(`
       class Point
         constructor: (@x, @y) ->
     `, `
       class Point {
-        constructor(x, y) { this.x = x, this.y = y; }
+        constructor(x, y) {
+          this.x = x;
+          this.y = y;
+        }
       }
     `);
   });
 
-  it.skip('works with default parameters', () => {
-    // FIXME: This should not return the assignment value.
+  it('works with default parameters', () => {
     check(`
       (@a=1) ->
     `, `
-      (function(a=1) { return this.a = a; });
+      (function(a) {
+        if (a == null) { a = 1; }
+        this.a = a;
+      });
     `);
   });
 


### PR DESCRIPTION
Fixes #755

Now, instead of inserting all default param assignments followed by all `this`
assignments, we generate the new assignment lines in parameter order. This also
makes the normalize FunctionPatcher arguably a little cleaner because it pulls
out the code for individual parameter patching into its own function. Also,
since array destructuring works fully now, we can skip default and this assign
for parameters that will get extracted as rest params.