### PR TITLE
feat: handle complex function parameters

### DIFF
--- a/src/stages/normalize/patchers/FunctionPatcher.js
+++ b/src/stages/normalize/patchers/FunctionPatcher.js
@@ -1,6 +1,10 @@
+import ArrayInitialiserPatcher from './ArrayInitialiserPatcher';
+import DefaultParamPatcher from './DefaultParamPatcher';
 import ExpansionPatcher from './ExpansionPatcher';
+import IdentifierPatcher from './IdentifierPatcher';
 import RestPatcher from './SpreadPatcher';
 import NodePatcher from './../../../patchers/NodePatcher';
+import canPatchAssigneeToJavaScript from '../../../utils/canPatchAssigneeToJavaScript';
 import stripSharedIndent from '../../../utils/stripSharedIndent';
 
 import type { PatcherContext } from './../../../patchers/types';
@@ -23,36 +27,37 @@ export default class FunctionPatcher extends NodePatcher {
       this.insert(this.body.contentStart, ' ');
     }
 
-    let expansionIndex = this.getExpansionIndex();
+    let firstRestParamIndex = this.getFirstRestParamIndex();
     let assignments = [];
     for (let [i, parameter] of this.parameters.entries()) {
-      if (expansionIndex === -1 || i < expansionIndex) {
+      if (firstRestParamIndex === -1 || i < firstRestParamIndex) {
         assignments.push(...this.patchParameterAndGetAssignments(parameter));
       } else {
         parameter.patch();
       }
     }
 
-    if (expansionIndex !== -1) {
-      if (expansionIndex === this.parameters.length - 1) {
-        // Just get rid of the ... at the end (this case isn't exercised for
-        // rest params at the end since those just become regular JS).
-        if (expansionIndex === 0) {
+    if (firstRestParamIndex !== -1) {
+      if (firstRestParamIndex === this.parameters.length - 1 &&
+          this.parameters[this.parameters.length - 1] instanceof ExpansionPatcher) {
+        // Just get rid of the ... at the end if it's there.
+        if (firstRestParamIndex === 0) {
           this.remove(this.parameters[0].contentStart, this.parameters[0].contentEnd);
         } else {
           this.remove(
-            this.parameters[expansionIndex - 1].outerEnd,
+            this.parameters[firstRestParamIndex - 1].outerEnd,
             this.parameters[this.parameters.length - 1].outerEnd
           );
         }
       } else {
         // Move expansion or intermediate rest params into an array destructure
         // on the first line.
-        let candidateName = expansionIndex === 0 ? 'args' : 'rest';
+        let candidateName = firstRestParamIndex === 0 ? 'args' : 'rest';
         let paramName = this.claimFreeBinding(candidateName);
-        let restParamsStart = this.parameters[expansionIndex].outerStart;
-        let restParamsEnd = this.parameters[this.parameters.length - 1].outerEnd;
+        let restParamsStart = this.parameters[firstRestParamIndex].contentStart;
+        let restParamsEnd = this.parameters[this.parameters.length - 1].contentEnd;
         let paramCode = this.slice(restParamsStart, restParamsEnd);
+        paramCode = this.fixGeneratedAssigneeWhitespace(paramCode);
         this.overwrite(restParamsStart, restParamsEnd, `${paramName}...`);
         assignments.push(`[${paramCode}] = ${paramName}`);
       }
@@ -137,12 +142,39 @@ export default class FunctionPatcher extends NodePatcher {
   }
 
   /**
-   * Get the index of the expansion node or rest param, if any.
+   * Get the index of the first parameter that will be included in the rest
+   * parameters (if any). All parameters from this point forward will be moved
+   * to an array destructure at the start of the function.
+   *
+   * The main stage handles the fully general case for array destructuring,
+   * including things like nested expansions and defaults, so anything requiring
+   * that level of generality should be extracted to an array destructure.
+   * Simpler cases that only use param defaults and this-assignment are better
+   * off being handled as normal parameters if we can get away with it. Also,
+   * any array destructure in a parameter needs to be extracted so that we can
+   * properly wrap it in Array.from.
    */
-  getExpansionIndex(): number {
-    for (let i = 0 ; i < this.parameters.length; i++) {
-      if (this.parameters[i] instanceof ExpansionPatcher ||
-          (i < this.parameters.length - 1 && this.parameters[i] instanceof RestPatcher)) {
+  getFirstRestParamIndex(): number {
+    for (let i = 0; i < this.parameters.length; i++) {
+      let parameter = this.parameters[i];
+
+      // We have separate code to handle relatively simple default params that
+      // results in better code, so use that.
+      if (parameter instanceof DefaultParamPatcher &&
+          canPatchAssigneeToJavaScript(parameter.param.node)) {
+        continue;
+      }
+
+      // A rest assignment at the very end can be converted correctly as long as
+      // it does not expand the rest array in a complicated way.
+      if (i === this.parameters.length - 1 &&
+        parameter instanceof RestPatcher &&
+        parameter.expression instanceof IdentifierPatcher) {
+        continue;
+      }
+
+      if (parameter instanceof ArrayInitialiserPatcher ||
+          !canPatchAssigneeToJavaScript(parameter.node)) {
         return i;
       }
     }

--- a/src/stages/normalize/patchers/SpreadPatcher.js
+++ b/src/stages/normalize/patchers/SpreadPatcher.js
@@ -1,3 +1,13 @@
+import NodePatcher from '../../../patchers/NodePatcher';
 import PassthroughPatcher from '../../../patchers/PassthroughPatcher';
 
-export default class SpreadPatcher extends PassthroughPatcher {}
+import type {PatcherContext} from '../../../patchers/types';
+
+export default class SpreadPatcher extends PassthroughPatcher {
+  expression: NodePatcher;
+
+  constructor(patcherContext: PatcherContext, expression: NodePatcher) {
+    super(patcherContext, expression);
+    this.expression = expression;
+  }
+}

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -114,10 +114,15 @@ describe('classes', () => {
           constructor: ([@a = 1], {test: @b = 2}, @c) ->
       `, `
         class A {
-          constructor([a = 1], {test: b = 2}, c) {
-            this.a = a;
-            this.b = b;
-            this.c = c;
+          constructor(...args) {
+            let array, obj, val, val1;
+            array = args[0],
+              val = array[0],
+              this.a = val != null ? val : 1,
+              obj = args[1],
+              val1 = obj.test,
+              this.b = val1 != null ? val1 : 2,
+              this.c = args[2];
           }
         }
       `);

--- a/test/expansion_test.js
+++ b/test/expansion_test.js
@@ -151,6 +151,46 @@ describe('expansion', () => {
     `);
   });
 
+  it('handles an expansion node in a parameter array destructure', () => {
+    check(`
+      (a, [..., b], c) ->
+        d
+    `, `
+      (function(a, ...rest) {
+        let array = rest[0], b = array[array.length - 1], c = rest[1];
+        return d;
+      });
+    `);
+  });
+
+  it('handles a complex single argument', () => {
+    check(`
+      fn = ([a,b]) -> {a:a,b:b}
+    `, `
+      let fn = function(...args) { let [a,b] = Array.from(args[0]); return {a,b}; };
+    `);
+  });
+
+  it('handles a complex parameter list with varying indentation', () => {
+    check(`
+      f = (a, b, ..., {
+        c,
+        d,
+        e,
+      }) ->
+        f
+    `, `
+      var f = function(a, b, ...rest) {
+        let {
+          c,
+          d,
+          e,
+        } = rest[rest.length - 1];
+        return f;
+      };
+    `);
+  });
+
   it('allows getting elements from an unsafe-to-repeat list', () => {
     check(`
       [a, b, ..., c, d] = getArray()


### PR DESCRIPTION
Fixes #756

Currently, this is implemented by taking the first parameter that can't be
converted in a straightforward way and moving everything from there later to a
rest param in the normalize step. This lets us reuse code for complex
assignments in the main stage. This certainly has some room for improvement,
since in some cases it would be nice to do complex assignments without using
rest params, but code like this is probably rare enough that it's not worth
worrying about too much.