### PR TITLE
fix: insert close-paran without breaking member access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 npm-debug.log
+.idea/

--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -1168,4 +1168,12 @@ export default class NodePatcher {
       receiver = receiver.parent;
     }
   }
+
+  /**
+   * Gets the first "interesting token" in the indexed range (default range is `this` + parent)
+   */
+  getFirstSemanticToken(from: number=this.contentStart, to: number=this.parent.contentEnd): ?SourceToken {
+    let nextSemanticIdx = this.indexOfSourceTokenBetweenSourceIndicesMatching(from, to, isSemanticToken);
+    return nextSemanticIdx && this.sourceTokenAtIndex(nextSemanticIdx);
+  }
 }

--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.js
@@ -82,7 +82,13 @@ export default class FunctionApplicationPatcher extends NodePatcher {
     let { args } = this;
     let lastArg = args[args.length - 1];
     if (lastArg.isMultiline()) {
-      this.insert(this.contentEnd, `\n${this.getIndent()})`);
+      // The CoffeeScript compiler will sometimes reject `.` that is starting a new line following a `)` token
+      let nextSemanticToken = this.getFirstSemanticToken(this.contentEnd);
+      if (nextSemanticToken && nextSemanticToken.type === SourceType.DOT) {
+        this.insert(nextSemanticToken.start, ')');
+      } else {
+        this.insert(this.contentEnd, `\n${this.getIndent()})`);
+      }
       return;
     }
 

--- a/test/member_access_test.js
+++ b/test/member_access_test.js
@@ -92,4 +92,49 @@ describe('member access', () => {
       a[b ? c : d];
     `);
   });
+
+  it('handles access to object constructed with multiline args 1', () => {
+    check(`
+      P -> 
+        foo
+      .then
+    `, `
+      P(() => foo).then;
+    `);
+  });
+
+  it('handles access to object constructed with multiline args 2', () => {
+    check(`
+      Q -> P -> 
+        foo
+      .then
+    `, `
+      Q(() => P(() => foo).then
+       );
+    `);
+  });
+
+  it('handles access to object constructed with multiline args 3', () => {
+    check(`
+      Q -> P -> 
+        foo
+        
+      .then
+    `, `
+      Q(() => P(() => foo).then
+       );
+    `);
+  });
+
+  it('handles access to object constructed with multiline args 4', () => {
+    check(`
+      Q -> P ->
+          foo
+          
+         .then
+    `, `
+      Q(() => P(() => foo).then
+       );
+    `);
+  });
 });


### PR DESCRIPTION
I didn't bother with a bug. I just added a test (previously failing).
[eval](http://decaffeinate-project.org/repl/#?evaluate=true&stage=full&code=Q%20-%3E%20P%20-%3E%0D%0A%20%20foo%0D%0A.then%20(bar)%20-%3E%0D%0A%20%20bar)