### PR TITLE
fix: defer the soak close-paren until after the soak container is patched

### DIFF
--- a/src/stages/main/patchers/DynamicMemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/DynamicMemberAccessOpPatcher.js
@@ -33,6 +33,7 @@ export default class DynamicMemberAccessOpPatcher extends NodePatcher {
       this.expression.setRequiresRepeatableExpression({ isForAssignment: true, parens: true, ref: 'base' });
       this.indexingExpr.setRequiresRepeatableExpression({ ref: 'name' });
       this.patchAsExpression();
+      this.commitDeferredSuffix();
       return `${this.expression.getRepeatCode()}[${this.indexingExpr.getRepeatCode()}]`;
     } else {
       return super.patchAsRepeatableExpression(repeatableOptions, patchOptions);

--- a/src/stages/main/patchers/MemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/MemberAccessOpPatcher.js
@@ -45,6 +45,7 @@ export default class MemberAccessOpPatcher extends NodePatcher {
     if (repeatableOptions.isForAssignment) {
       this.expression.setRequiresRepeatableExpression({ isForAssignment: true, parens: true, ref: 'base' });
       this.patchAsExpression();
+      this.commitDeferredSuffix();
       return `${this.expression.getRepeatCode()}.${this.getFullMemberName()}`;
     } else {
       return super.patchAsRepeatableExpression(repeatableOptions, patchOptions);

--- a/src/stages/main/patchers/SoakedDynamicMemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/SoakedDynamicMemberAccessOpPatcher.js
@@ -25,7 +25,7 @@ export default class SoakedDynamicMemberAccessOpPatcher extends DynamicMemberAcc
       }
       this.overwrite(this.expression.outerEnd, this.indexingExpr.outerStart, `, ${varName} => ${prefix}${varName}[`);
       soakContainer.insert(soakContainer.contentStart, '__guard__(');
-      soakContainer.insert(soakContainer.contentEnd, ')');
+      soakContainer.appendDeferredSuffix(')');
     }
 
     this.expression.patch();

--- a/src/stages/main/patchers/SoakedFunctionApplicationPatcher.js
+++ b/src/stages/main/patchers/SoakedFunctionApplicationPatcher.js
@@ -77,7 +77,7 @@ export default class SoakedFunctionApplicationPatcher extends FunctionApplicatio
     this.overwrite(fn.expression.outerEnd, callStartToken.end,
       `, '${memberName}', ${varName} => ${prefix}${varName}.${memberName}(`);
     soakContainer.insert(soakContainer.contentStart, '__guardMethod__(');
-    soakContainer.insert(soakContainer.contentEnd, ')');
+    soakContainer.appendDeferredSuffix(')');
   }
 
   /**
@@ -103,7 +103,7 @@ export default class SoakedFunctionApplicationPatcher extends FunctionApplicatio
     this.overwrite(indexingExpr.outerEnd, callStartToken.end,
       `, (${objVarName}, ${methodVarName}) => ${prefix}${objVarName}[${methodVarName}](`);
     soakContainer.insert(soakContainer.contentStart, '__guardMethod__(');
-    soakContainer.insert(soakContainer.contentEnd, ')');
+    soakContainer.appendDeferredSuffix(')');
   }
 
   patchNonMethodCall() {
@@ -117,7 +117,7 @@ export default class SoakedFunctionApplicationPatcher extends FunctionApplicatio
     }
     this.overwrite(this.fn.outerEnd, callStartToken.end, `, ${varName} => ${prefix}${varName}(`);
     soakContainer.insert(soakContainer.contentStart, '__guardFunc__(');
-    soakContainer.insert(soakContainer.contentEnd, ')');
+    soakContainer.appendDeferredSuffix(')');
   }
 
   getCallStartToken(): SourceToken {

--- a/src/stages/main/patchers/SoakedMemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/SoakedMemberAccessOpPatcher.js
@@ -30,7 +30,7 @@ export default class SoakedMemberAccessOpPatcher extends MemberAccessOpPatcher {
       this.overwrite(this.expression.outerEnd, memberNameToken.start, `, ${varName} => ${prefix}${varName}.`);
 
       soakContainer.insert(soakContainer.contentStart, '__guard__(');
-      soakContainer.insert(soakContainer.contentEnd, ')');
+      soakContainer.appendDeferredSuffix(')');
     }
     this.expression.patch();
   }

--- a/test/soaked_test.js
+++ b/test/soaked_test.js
@@ -641,4 +641,15 @@ describe('soaked expressions', () => {
       }
     `);
   });
+
+  it('handles a soaked dynamic access used with a logical assignment operator with a function RHS', () => {
+    check(`
+      a.b?.c or= (it) -> it
+    `, `
+      __guard__(a.b, x => x.c || (a.b.c = it => it));
+      function __guard__(value, transform) {
+        return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #704

In some cases, a soak operation could place a close-paren at the end of the soak
container before the normal suffix for the soak container node. To avoid this, I
added a way to defer a code snippet to be inserted at the end of a node once it
is finished patching.

It's almost the case that you can just apply the suffix code at the end of the
`patch` method, except that the code for handling repeatable expressions needs
to sometimes include the suffix code in its repeat code. So code handling
repeatable expressions needs to be aware of the deferred suffix mechanism, but
hopefully that will stay fairly small-scoped.