### PR TITLE
fix: in the normalize step, wrap some multiline expressions in parens

### DIFF
--- a/src/stages/normalize/patchers/ConditionalPatcher.js
+++ b/src/stages/normalize/patchers/ConditionalPatcher.js
@@ -1,7 +1,9 @@
-import NodePatcher from '../../../patchers/NodePatcher';
-import type { PatcherContext } from './../../../patchers/types';
-import type { SourceTokenListIndex } from 'coffee-lex';
 import { SourceType } from 'coffee-lex';
+import type { SourceTokenListIndex } from 'coffee-lex';
+
+import NodePatcher from '../../../patchers/NodePatcher';
+import postfixExpressionRequiresParens from '../../../utils/postfixExpressionRequiresParens';
+import type { PatcherContext } from './../../../patchers/types';
 
 /**
  * Normalizes conditionals by rewriting post-`if` into standard `if`, e.g.
@@ -44,6 +46,10 @@ export default class ConditionalPatcher extends NodePatcher {
    */
   patchPostIf() {
     this.condition.patch();
+    if (postfixExpressionRequiresParens(this.slice(this.condition.contentStart, this.condition.contentEnd)) &&
+        !this.condition.isSurroundedByParentheses()) {
+      this.condition.surroundInParens();
+    }
     this.consequent.patch();
 
     let ifTokenIndex = this.getIfTokenIndex();

--- a/src/stages/normalize/patchers/ForInPatcher.js
+++ b/src/stages/normalize/patchers/ForInPatcher.js
@@ -1,4 +1,6 @@
 import ForPatcher from './ForPatcher';
+import postfixExpressionRequiresParens from '../../../utils/postfixExpressionRequiresParens';
+
 import type NodePatcher from '../../../patchers/NodePatcher';
 import type { PatcherContext } from './../../../patchers/types';
 
@@ -18,7 +20,7 @@ export default class ForInPatcher extends ForPatcher {
   }
 
   surroundThenUsagesInParens() {
-    if (this.step && this.slice(this.step.contentStart, this.step.contentEnd).includes('then')) {
+    if (this.step && postfixExpressionRequiresParens(this.slice(this.step.contentStart, this.step.contentEnd))) {
       this.step.surroundInParens();
     }
     super.surroundThenUsagesInParens();

--- a/src/stages/normalize/patchers/ForPatcher.js
+++ b/src/stages/normalize/patchers/ForPatcher.js
@@ -2,6 +2,7 @@ import { SourceType } from 'coffee-lex';
 
 import NodePatcher from '../../../patchers/NodePatcher';
 import canPatchAssigneeToJavaScript from '../../../utils/canPatchAssigneeToJavaScript';
+import postfixExpressionRequiresParens from '../../../utils/postfixExpressionRequiresParens';
 import type { PatcherContext, SourceToken } from './../../../patchers/types';
 
 export default class ForPatcher extends NodePatcher {
@@ -83,11 +84,11 @@ export default class ForPatcher extends NodePatcher {
    * This method can be subclassed to account for additional fields.
    */
   surroundThenUsagesInParens() {
-    if (this.slice(this.target.contentStart, this.target.contentEnd).includes('then')) {
+    if (postfixExpressionRequiresParens(this.slice(this.target.contentStart, this.target.contentEnd))) {
       this.target.surroundInParens();
     }
     if (this.filter &&
-      this.slice(this.filter.contentStart, this.filter.contentEnd).includes('then')) {
+      postfixExpressionRequiresParens(this.slice(this.filter.contentStart, this.filter.contentEnd))) {
       this.filter.surroundInParens();
     }
   }

--- a/src/stages/normalize/patchers/WhilePatcher.js
+++ b/src/stages/normalize/patchers/WhilePatcher.js
@@ -1,4 +1,6 @@
 import NodePatcher from '../../../patchers/NodePatcher';
+import postfixExpressionRequiresParens from '../../../utils/postfixExpressionRequiresParens';
+
 import type { PatcherContext } from './../../../patchers/types';
 
 /**
@@ -51,7 +53,7 @@ export default class WhilePatcher extends NodePatcher {
       this.condition.outerStart,
       this.condition.outerEnd
     );
-    if (patchedCondition.includes('then') && !this.condition.isSurroundedByParentheses()) {
+    if (postfixExpressionRequiresParens(patchedCondition) && !this.condition.isSurroundedByParentheses()) {
       patchedCondition = `(${patchedCondition})`;
     }
     let patchedBody = this.slice(
@@ -62,7 +64,7 @@ export default class WhilePatcher extends NodePatcher {
       this.guard.outerStart,
       this.guard.outerEnd
     ) : null;
-    if (patchedGuard !== null && patchedGuard.includes('then') && !this.guard.isSurroundedByParentheses()) {
+    if (patchedGuard !== null && postfixExpressionRequiresParens(patchedGuard) && !this.guard.isSurroundedByParentheses()) {
       patchedGuard = `(${patchedGuard})`;
     }
     let whileToken = this.node.isUntil ? 'until' : 'while';

--- a/src/utils/postfixExpressionRequiresParens.ts
+++ b/src/utils/postfixExpressionRequiresParens.ts
@@ -1,0 +1,8 @@
+/**
+ * Rewriting a postfix if/while/for will fail if any intermediate expressions
+ * use `then` or contain a newline. In both cases, surrounding the expression in
+ * parens is enough to rearrange the code without introducing a parse error.
+ */
+export default function postfixExpressionRequiresParens(exprCode: string) {
+  return exprCode.includes('then') || exprCode.includes('\n');
+}

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -581,4 +581,13 @@ describe('conditionals', () => {
       })();
     `)
   );
+
+  it('handles a multiline condition in a postfix conditional', () => {
+    check(`
+      a if do ->
+        b
+    `, `
+      if ((() => b)()) { a; }
+    `);
+  });
 });

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1272,4 +1272,13 @@ describe('for loops', () => {
       }
     `);
   });
+
+  it('handles a multiline step in a postfix loop', () => {
+    check(`
+      a for b in c by do ->
+        d
+    `, `
+      for (let step = (() => d)(), asc = step > 0, i = asc ? 0 : c.length - 1; asc ? i < c.length : i >= 0; i += step) { let b = c[i]; a; }
+    `);
+  });
 });

--- a/test/while_test.js
+++ b/test/while_test.js
@@ -380,4 +380,13 @@ describe('while', () => {
       while (b) { if (c ? d : undefined) { a; } }
     `);
   });
+
+  it('handles a multiline condition in a postfix while', () => {
+    check(`
+      a while do ->
+        b
+    `, `
+      while ((() => b)()) { a; }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #762

We already had code to wrap intermediate expressions in parens if they have a
`then` inside them, and it turns out that a newline can also cause problems, so
extract the condition inso a simple shared function and use it for all
reordering that we do in the normalize step.