### PR TITLE
fix: remove the `then` token for single-line classes

### DIFF
--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1041,4 +1041,27 @@ describe('classes', () => {
       }
     `);
   });
+
+  it('handles a single-line class', () => {
+    check(`
+      class A then b: -> c
+    `, `
+      class A {
+        b() { return c; }
+      }
+    `);
+  });
+
+  it('handles a single-line class that needs an initClass method', () => {
+    check(`
+      class A then b: c
+    `, `
+      class A {
+        static initClass() {
+          this.prototype.b = c;
+        }
+      }
+      A.initClass();
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #690

We do this in the normalize stage rather than the main stage, since we'll need
to account for it in case we need to generate the `initClass` method.