### PR TITLE
fix: don't crash on some edge cases involving empty conditionals

### DIFF
--- a/src/stages/main/patchers/BlockPatcher.js
+++ b/src/stages/main/patchers/BlockPatcher.js
@@ -20,7 +20,10 @@ export default class BlockPatcher extends SharedBlockPatcher {
   }
 
   setImplicitlyReturns() {
-    this.statements[this.statements.length - 1].setImplicitlyReturns();
+    // A block can have no statements if it only had a block comment.
+    if (this.statements.length > 0) {
+      this.statements[this.statements.length - 1].setImplicitlyReturns();
+    }
   }
 
   /**

--- a/src/stages/main/patchers/ConditionalPatcher.js
+++ b/src/stages/main/patchers/ConditionalPatcher.js
@@ -209,6 +209,8 @@ export default class ConditionalPatcher extends NodePatcher {
     } else {
       if (this.consequent !== null) {
         this.consequent.patch({ leftBrace: false });
+      } else {
+        this.insert(this.condition.outerEnd, '} ');
       }
     }
   }

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -590,4 +590,38 @@ describe('conditionals', () => {
       if ((() => b)()) { a; }
     `);
   });
+
+  it('handles a conditional with no consequent or alternate', () => {
+    check(`
+      if a
+      else
+    `, `
+      if (a) {} 
+      else {}
+    `);
+  });
+
+  it('handles a conditional with only a comment for the consequent and alternate', () => {
+    check(`
+      ->
+        if false
+          # comment
+        else if true
+          ###
+          block comment
+          ###
+        else
+    `, `
+      (function() {
+        if (false) {
+          // comment
+        } else if (true) {
+        }
+          /*
+          block comment
+          */
+        else {}
+      });
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #763

* In one case, we just weren't placing the `}`.
* BlockPatcher would sometimes have `setImplicitlyReturns` called when empty
  (due to only having a block comment that gets removed from the AST). Just
  ignore it in this case.