### PR TITLE
fix: better handle comment-only blocks in conditionals

### DIFF
--- a/src/stages/main/patchers/BlockPatcher.js
+++ b/src/stages/main/patchers/BlockPatcher.js
@@ -98,23 +98,27 @@ export default class BlockPatcher extends SharedBlockPatcher {
     if (leftBrace) {
       this.insert(this.innerStart, '(');
     }
-    this.statements.forEach(
-      (statement, i, statements) => {
-        statement.patch();
-        if (i !== statements.length - 1) {
-          let semicolonTokenIndex = this.getSemicolonSourceTokenBetween(
-            statement,
-            statements[i + 1]
-          );
-          if (semicolonTokenIndex) {
-            let semicolonToken = this.sourceTokenAtIndex(semicolonTokenIndex);
-            this.overwrite(semicolonToken.start, semicolonToken.end, ',');
-          } else {
-            this.insert(statement.outerEnd, ',');
+    if (this.statements.length === 0) {
+      this.insert(this.contentStart, 'undefined');
+    } else {
+      this.statements.forEach(
+        (statement, i, statements) => {
+          statement.patch();
+          if (i !== statements.length - 1) {
+            let semicolonTokenIndex = this.getSemicolonSourceTokenBetween(
+              statement,
+              statements[i + 1]
+            );
+            if (semicolonTokenIndex) {
+              let semicolonToken = this.sourceTokenAtIndex(semicolonTokenIndex);
+              this.overwrite(semicolonToken.start, semicolonToken.end, ',');
+            } else {
+              this.insert(statement.outerEnd, ',');
+            }
           }
         }
-      }
-    );
+      );
+    }
     if (rightBrace) {
       this.insert(this.innerEnd, ')');
     }

--- a/src/stages/main/patchers/ConditionalPatcher.js
+++ b/src/stages/main/patchers/ConditionalPatcher.js
@@ -104,7 +104,7 @@ export default class ConditionalPatcher extends NodePatcher {
       consequent.patch();
       // `a ? b` → `a ? b : undefined`
       if (elseToken !== null) {
-        this.overwrite(this.consequent.outerEnd, elseToken.end, ' : undefined');
+        this.overwrite(elseToken.start, elseToken.end, ' : undefined');
       } else {
         this.insert(this.consequent.outerEnd, ' : undefined');
       }

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -537,7 +537,8 @@ describe('conditionals', () => {
     `, `
       let x =
         a ?
-          b : undefined;
+          b
+         : undefined;
           // Do nothing
     `)
   );
@@ -622,6 +623,20 @@ describe('conditionals', () => {
           */
         else {}
       });
+    `);
+  });
+
+  it('handles a parenthesized empty condition with only a block comment for its body', () => {
+    check(`
+      (if true
+        ### a ###
+      else
+      )
+    `, `
+      (true ?
+        undefined/* a */
+       : undefined
+      );
     `);
   });
 });


### PR DESCRIPTION
Fixes #774

We used to remove from the end of the consequent to the start of the else in the
expression case, but that can destroy comments, so be more conservative now.
Also, if we have a block with 0 statements in an expression context, we should
use `undefined` instead of having no contents at all.