### PR TITLE
fix: wrap yield expressions in parens when necessary

### DIFF
--- a/src/stages/main/patchers/YieldFromPatcher.js
+++ b/src/stages/main/patchers/YieldFromPatcher.js
@@ -1,26 +1,12 @@
-import NodePatcher from './../../../patchers/NodePatcher';
-import type { PatcherContext } from './../../../patchers/types';
+import YieldPatcher from './YieldPatcher';
 
-export default class YieldFromPatcher extends NodePatcher {
-  expression: NodePatcher;
-  
-  constructor(patcherContext: PatcherContext, expression: NodePatcher) {
-    super(patcherContext);
-    this.expression = expression;
-  }
-  
-  initialize() {
-    this.yields();
-    this.expression.setRequiresExpression();
-  }
-
+export default class YieldFromPatcher extends YieldPatcher {
   /**
    * 'yield' 'from' EXPRESSION
    */
   patchAsExpression({ needsParens=true }={}) {
     let src = this.sourceTokenAtIndex(this.contentStartTokenIndex);
     this.overwrite(src.start, src.end, 'yield*');
-    
-    this.expression.patch({ needsParens });
+    super.patchAsExpression({ needsParens });
   }
 }

--- a/src/stages/main/patchers/YieldPatcher.js
+++ b/src/stages/main/patchers/YieldPatcher.js
@@ -1,3 +1,6 @@
+import AssignOpPatcher from './AssignOpPatcher';
+import BlockPatcher from './BlockPatcher';
+import ReturnPatcher from './ReturnPatcher';
 import NodePatcher from './../../../patchers/NodePatcher';
 import type { PatcherContext } from './../../../patchers/types';
 
@@ -18,6 +21,20 @@ export default class YieldPatcher extends NodePatcher {
    * 'yield' EXPRESSION
    */
   patchAsExpression({ needsParens=true }={}) {
+    let surroundInParens = this.needsParens() && !this.isSurroundedByParentheses();
+    if (surroundInParens) {
+      this.insert(this.contentStart, '(');
+    }
     this.expression.patch({ needsParens });
+    if (surroundInParens) {
+      this.insert(this.contentEnd, ')');
+    }
+  }
+
+  needsParens() {
+    return !(
+      this.parent instanceof BlockPatcher ||
+      this.parent instanceof ReturnPatcher ||
+      (this.parent instanceof AssignOpPatcher && this.parent.expression === this));
   }
 }

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -198,6 +198,70 @@ describe('functions', () => {
     `);
   });
 
+  it('wraps parens around yield in a normal expression context', () => {
+    check(`
+      -> 1 + yield 2
+    `, `
+      (function*() { return 1 + (yield 2); });
+    `);
+  });
+
+  it('wraps parens around yield* in a normal expression context', () => {
+    check(`
+      -> 1 + yield from 2
+    `, `
+      (function*() { return 1 + (yield* 2); });
+    `);
+  });
+
+  it('does not wrap parens around yield in an assignment', () => {
+    check(`
+      ->
+        x = yield 2
+        return x
+    `, `
+      (function*() {
+        let x = yield 2;
+        return x;
+      });
+    `);
+  });
+
+  it('does not wrap parens around yield* in an assignment', () => {
+    check(`
+      ->
+        x = yield from 2
+        return x
+    `, `
+      (function*() {
+        let x = yield* 2;
+        return x;
+      });
+    `);
+  });
+
+  it('does not wrap parens around yield in an explicit return', () => {
+    check(`
+      ->
+        return yield 2
+    `, `
+      (function*() {
+        return yield 2;
+      });
+    `);
+  });
+
+  it('does not wrap parens around yield* in an explicit return', () => {
+    check(`
+      ->
+        return yield from 2
+    `, `
+      (function*() {
+        return yield* 2;
+      });
+    `);
+  });
+
   it('turns fat arrow function containing a `yield` statement into a generator function with bind', () => {
     check(`
       => yield fn()


### PR DESCRIPTION
Fixes #776

For many expression cases, JavaScript requires parens around yield expressions,
so we need to add them unless we know it's safe not to. yield in a statement
context, yield in a return, and yield on the RHS of an assignment all do not
require parens, so we skip the parens in those cases.