### PR TITLE
feat: implement `yield return`

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babylon": "^6.12.0",
     "coffee-lex": "^6.0.0",
     "decaffeinate-coffeescript": "^1.10.0-patch12",
-    "decaffeinate-parser": "^13.0.3",
+    "decaffeinate-parser": "^13.1.1",
     "detect-indent": "^4.0.0",
     "esnext": "^3.0.10",
     "lines-and-columns": "^1.1.5",

--- a/src/stages/main/index.js
+++ b/src/stages/main/index.js
@@ -68,6 +68,7 @@ import WhilePatcher from './patchers/WhilePatcher';
 import GeneratorFunctionPatcher from './patchers/GeneratorFunctionPatcher';
 import YieldPatcher from './patchers/YieldPatcher';
 import YieldFromPatcher from './patchers/YieldFromPatcher';
+import YieldReturnPatcher from './patchers/YieldReturnPatcher';
 import type NodePatcher from './../../patchers/NodePatcher';
 import type { Node } from '../../patchers/types';
 import BreakPatcher from './patchers/BreakPatcher';
@@ -129,13 +130,16 @@ export default class MainStage extends TransformCoffeeScriptStage {
         return ThisPatcher;
 
       case 'Yield':
-       return YieldPatcher;
+        return YieldPatcher;
 
       case 'YieldFrom':
-       return YieldFromPatcher;
+        return YieldFromPatcher;
+
+      case 'YieldReturn':
+        return YieldReturnPatcher;
 
       case 'GeneratorFunction':
-       return GeneratorFunctionPatcher;
+        return GeneratorFunctionPatcher;
 
       case 'Function':
         return FunctionPatcher;

--- a/src/stages/main/patchers/YieldReturnPatcher.js
+++ b/src/stages/main/patchers/YieldReturnPatcher.js
@@ -1,0 +1,22 @@
+import { SourceType } from 'coffee-lex';
+
+import ReturnPatcher from './ReturnPatcher';
+
+export default class YieldReturnPatcher extends ReturnPatcher {
+  initialize() {
+    this.yields();
+    super.initialize();
+  }
+
+  patchAsStatement() {
+    let yieldTokenIndex = this.contentStartTokenIndex;
+    let returnTokenIndex = yieldTokenIndex.next();
+    let yieldToken = this.sourceTokenAtIndex(yieldTokenIndex);
+    let returnToken = this.sourceTokenAtIndex(returnTokenIndex);
+    if (yieldToken.type !== SourceType.YIELD || returnToken.type !== SourceType.RETURN) {
+      throw this.error('Unexpected token types for `yield return`.');
+    }
+    this.remove(yieldToken.start, returnToken.start);
+    super.patchAsStatement();
+  }
+}

--- a/src/utils/traverse.js
+++ b/src/utils/traverse.js
@@ -134,7 +134,8 @@ const ORDER = {
   UnsignedRightShiftOp: ['left', 'right'],
   While: ['condition', 'guard', 'body'],
   Yield: ['expression'],
-  YieldFrom: ['expression']
+  YieldFrom: ['expression'],
+  YieldReturn: ['expression'],
 };
 
 export function childPropertyNames(node: Node): Array<string> {

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -239,6 +239,28 @@ describe('functions', () => {
     `);
   });
 
+  it('correctly handles `yield return` with an expression', () => {
+    check(`
+      ->
+        yield return 3
+    `, `
+      (function*() {
+        return 3;
+      });
+    `);
+  });
+
+  it('correctly handles `yield return` without an expression', () => {
+    check(`
+      ->
+        yield return
+    `, `
+      (function*() {
+        
+      });
+    `);
+  });
+
   it('keeps function with a spread in braces', () => {
     check(`(args...) =>`, `(...args) => {};`);
   });


### PR DESCRIPTION
Fixes #688

It behaves almost the same as `return`, except we need to remove the `yield`
token and mark the function as yielding.