### PR TITLE
fix: avoid placing close-parens with too much indentation

### DIFF
--- a/test/member_access_test.js
+++ b/test/member_access_test.js
@@ -137,4 +137,28 @@ describe('member access', () => {
        );
     `);
   });
+
+  it('handles an implicit call wrapping a multiline function call and followed by a dot', () => {
+    check(`
+      a b(
+        c)
+        .d
+    `, `
+      a(b(
+        c)).d;
+    `);
+  });
+
+  it('handles a complex implicit call wrapping a multiline function call and followed by a dot', () => {
+    check(`
+      a
+        .b c(d,
+          e)
+        .f
+    `, `
+      a
+        .b(c(d,
+          e)).f;
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #777

This feels like a bit of a hack, unfortunately, but it's the only thing I could
think of the works in all cases. Rather than placing the close-paren just before
the following dot, we move the dot to be just after where the close-paren would
go, which generally might join the two lines, and might end up destroying an
inline comment, but handles all known cases without crashing.