### PR TITLE
feat: handle class expressions for complex classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "decaffeinate-coffeescript": "^1.10.0-patch12",
     "decaffeinate-parser": "^13.1.1",
     "detect-indent": "^4.0.0",
-    "esnext": "^3.0.10",
+    "esnext": "^3.0.12",
     "lines-and-columns": "^1.1.5",
     "magic-string": "^0.17.0",
     "repeating": "^2.0.0"

--- a/src/patchers/SharedProgramPatcher.js
+++ b/src/patchers/SharedProgramPatcher.js
@@ -1,0 +1,55 @@
+import NodePatcher from './NodePatcher';
+import type { PatcherContext } from './types';
+import blank from '../utils/blank';
+import determineIndent from '../utils/determineIndent';
+
+export default class ProgramPatcher extends NodePatcher {
+  body: ?NodePatcher;
+  helpers: { [key: string]: string };
+  _indentString: ?string;
+
+  constructor(patcherContext: PatcherContext, body: ?NodePatcher) {
+    super(patcherContext);
+    this.body = body;
+
+    this.helpers = blank();
+    this._indentString = null;
+  }
+
+  shouldTrimContentRange() {
+    return true;
+  }
+
+  /**
+   * Register a helper to be reused in several places.
+   *
+   * FIXME: Pick a different name than what is in scope.
+   */
+  registerHelper(name: string, code: string): string {
+    code = code.trim();
+    if (name in this.helpers) {
+      if (this.helpers[name] !== code) {
+        throw new Error(`BUG: cannot override helper '${name}'`);
+      }
+    } else {
+      this.helpers[name] = code;
+    }
+    return name;
+  }
+
+  patchHelpers() {
+    for (let helper in this.helpers) {
+      this.editor.append(`\n${this.helpers[helper]}`);
+    }
+  }
+
+  /**
+   * Gets the indent string used for each indent in this program.
+   */
+  getProgramIndentString(): string {
+    if (!this._indentString) {
+      this._indentString = determineIndent(this.context.source);
+    }
+    return this._indentString;
+  }
+}

--- a/src/stages/main/patchers/ProgramPatcher.js
+++ b/src/stages/main/patchers/ProgramPatcher.js
@@ -1,30 +1,11 @@
-import NodePatcher from './../../../patchers/NodePatcher';
-import blank from '../../../utils/blank';
-import determineIndent from '../../../utils/determineIndent';
+import SharedProgramPatcher from '../../../patchers/SharedProgramPatcher';
 import getIndent from '../../../utils/getIndent';
 import { SourceType } from 'coffee-lex';
-import type BlockPatcher from './BlockPatcher';
-import type { PatcherContext, SourceToken } from './../../../patchers/types';
+import type { SourceToken } from './../../../patchers/types';
 
 const BLOCK_COMMENT_DELIMITER = '###';
 
-export default class ProgramPatcher extends NodePatcher {
-  body: ?BlockPatcher;
-  helpers: { [key: string]: string };
-  _indentString: ?string;
-
-  constructor(patcherContext: PatcherContext, body: ?BlockPatcher) {
-    super(patcherContext);
-    this.body = body;
-
-    this.helpers = blank();
-    this._indentString = null;
-  }
-
-  shouldTrimContentRange() {
-    return true;
-  }
-
+export default class ProgramPatcher extends SharedProgramPatcher {
   canPatchAsExpression(): boolean {
     return false;
   }
@@ -35,10 +16,7 @@ export default class ProgramPatcher extends NodePatcher {
     }
     this.patchContinuations();
     this.patchComments();
-
-    for (let helper in this.helpers) {
-      this.editor.append(`\n${this.helpers[helper]}`);
-    }
+    this.patchHelpers();
   }
 
   /**
@@ -156,33 +134,6 @@ export default class ProgramPatcher extends NodePatcher {
         'node'
       );
     }
-  }
-
-  /**
-   * Register a helper to be reused in several places.
-   *
-   * FIXME: Pick a different name than what is in scope.
-   */
-  registerHelper(name: string, code: string): string {
-    code = code.trim();
-    if (name in this.helpers) {
-      if (this.helpers[name] !== code) {
-        throw new Error(`BUG: cannot override helper '${name}'`);
-      }
-    } else {
-      this.helpers[name] = code;
-    }
-    return name;
-  }
-
-  /**
-   * Gets the indent string used for each indent in this program.
-   */
-  getProgramIndentString(): string {
-    if (!this._indentString) {
-      this._indentString = determineIndent(this.context.source);
-    }
-    return this._indentString;
   }
 
   /**

--- a/src/stages/normalize/patchers/ClassPatcher.js
+++ b/src/stages/normalize/patchers/ClassPatcher.js
@@ -8,9 +8,10 @@ import ProgramPatcher from './ProgramPatcher';
 import type { PatcherContext } from './../../../patchers/types';
 
 const INIT_CLASS_HELPER = `\
-__initClass__ = (c) ->
-  c.initClass()
-  return c
+\`function __initClass__(c) {
+  c.initClass();
+  return c;
+}\`
 `;
 
 export default class ClassPatcher extends NodePatcher {

--- a/src/stages/normalize/patchers/ClassPatcher.js
+++ b/src/stages/normalize/patchers/ClassPatcher.js
@@ -2,8 +2,16 @@ import { SourceType } from 'coffee-lex';
 
 import NodePatcher from './../../../patchers/NodePatcher';
 import AssignOpPatcher from './AssignOpPatcher';
+import BlockPatcher from './BlockPatcher';
+import ProgramPatcher from './ProgramPatcher';
 
 import type { PatcherContext } from './../../../patchers/types';
+
+const INIT_CLASS_HELPER = `\
+__initClass__ = (c) ->
+  c.initClass()
+  return c
+`;
 
 export default class ClassPatcher extends NodePatcher {
   nameAssignee: ?NodePatcher;
@@ -22,8 +30,6 @@ export default class ClassPatcher extends NodePatcher {
    * method instead.
    *
    * Current limitations:
-   * - Doesn't handle anonymous classes.
-   * - Doesn't handle classes used in an expression context.
    * - Doesn't deconflict the "initClass" name of the static method.
    * - Doesn't deconflict the variable assignments that are moved outside the
    *   class body.
@@ -55,13 +61,28 @@ export default class ClassPatcher extends NodePatcher {
     let insertPoint = this.getInitClassInsertPoint();
     let nonMethodPatchers = this.getNonMethodPatchers(insertPoint);
 
-    if (nonMethodPatchers.length > 0) {
-      let assignmentNames = this.generateInitClassMethod(nonMethodPatchers, insertPoint);
-      let indent = this.getIndent();
+    if (nonMethodPatchers.length === 0) {
+      return;
+    }
+
+    // We have at least one non-method, so this needs to be a "complex" class
+    // with an initClass static method.
+    let needsInitClassWrapper = this.needsInitClassWrapper();
+
+    if (needsInitClassWrapper) {
+      let helper = this.registerHelper('__initClass__', INIT_CLASS_HELPER);
+      this.insert(this.outerStart, `${helper}(`);
+    }
+
+    let assignmentNames = this.generateInitClassMethod(nonMethodPatchers, insertPoint);
+    let indent = this.getIndent();
+    if (needsInitClassWrapper) {
+      this.insert(this.outerEnd, `)`);
+    } else {
       this.insert(this.outerEnd, `\n${indent}${this.nameAssignee.node.data}.initClass()`);
-      for (let assignmentName of assignmentNames) {
-        this.insert(this.outerStart, `${assignmentName} = undefined\n${indent}`);
-      }
+    }
+    for (let assignmentName of assignmentNames) {
+      this.insert(this.outerStart, `${assignmentName} = undefined\n${indent}`);
     }
   }
 
@@ -97,6 +118,26 @@ export default class ClassPatcher extends NodePatcher {
     }
   }
 
+  needsInitClassWrapper() {
+    // Anonymous classes can't be referenced by name, so we need to pass them
+    // to a function to call initClass on them.
+    if (!this.nameAssignee) {
+      return true;
+    }
+    // It's safe to use the more straightforward class init approach as long as
+    // we know that a statement can be added after us and we're not in an
+    // implicit return position.
+    if (this.parent instanceof BlockPatcher) {
+      let { statements } = this.parent;
+      if (!(this.parent.parent instanceof ProgramPatcher) &&
+          this === statements[statements.length - 1]) {
+        return true;
+      }
+      return false;
+    }
+    return true;
+  }
+
   getInitClassInsertPoint() {
     if (this.superclass) {
       return this.superclass.outerEnd;
@@ -104,10 +145,7 @@ export default class ClassPatcher extends NodePatcher {
     if (this.nameAssignee) {
       return this.nameAssignee.outerEnd;
     }
-    if (this.body) {
-      return this.body.outerStart;
-    }
-    return this.outerStart;
+    return this.firstToken().end;
   }
 
   /**

--- a/src/stages/normalize/patchers/ProgramPatcher.js
+++ b/src/stages/normalize/patchers/ProgramPatcher.js
@@ -1,18 +1,10 @@
-import PassthroughPatcher from '../../../patchers/PassthroughPatcher';
-import determineIndent from '../../../utils/determineIndent';
+import SharedProgramPatcher from '../../../patchers/SharedProgramPatcher';
 
-export default class ProgramPatcher extends PassthroughPatcher {
-  shouldTrimContentRange() {
-    return true;
-  }
-
-  /**
-   * Gets the indent string used for each indent in this program.
-   */
-  getProgramIndentString(): string {
-    if (!this._indentString) {
-      this._indentString = determineIndent(this.context.source);
+export default class ProgramPatcher extends SharedProgramPatcher {
+  patchAsStatement() {
+    if (this.body) {
+      this.body.patch();
     }
-    return this._indentString;
+    this.patchHelpers();
   }
 }

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1131,4 +1131,65 @@ describe('classes', () => {
       o = b.c(1)
     `, 9);
   });
+
+  it('handles a complex anonymous class in an expression context', () => {
+    check(`
+      A = class
+        b: c
+    `, `
+      const A = __initClass__(class {
+        static initClass() {
+          this.prototype.b = c;
+        }
+      });
+      var __initClass__ = function(c) {
+        c.initClass();
+        return c;
+      };
+    `);
+  });
+
+  it('handles a class expression in an implicit return context', () => {
+    check(`
+      f = ->
+        class A
+          b: c
+    `, `
+      let f = () =>
+        __initClass__(class A {
+          static initClass() {
+            this.prototype.b = c;
+          }
+        })
+      ;
+      var __initClass__ = function(c) {
+        c.initClass();
+        return c;
+      };
+    `);
+  });
+
+  it('handles a define call ending in a class (#625)', () => {
+    check(`
+      define (require) ->
+        'use strict'
+        
+        class MainLayout extends BaseView
+          container: 'body'
+    `, `
+      define(function(require) {
+        'use strict';
+        
+        return __initClass__(class MainLayout extends BaseView {
+          static initClass() {
+            this.prototype.container = 'body';
+          }
+        });
+      });
+      var __initClass__ = function(c) {
+        c.initClass();
+        return c;
+      };
+    `);
+  });
 });

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1142,10 +1142,10 @@ describe('classes', () => {
           this.prototype.b = c;
         }
       });
-      var __initClass__ = function(c) {
+      function __initClass__(c) {
         c.initClass();
         return c;
-      };
+      }
     `);
   });
 
@@ -1162,10 +1162,10 @@ describe('classes', () => {
           }
         })
       ;
-      var __initClass__ = function(c) {
+      function __initClass__(c) {
         c.initClass();
         return c;
-      };
+      }
     `);
   });
 
@@ -1186,10 +1186,10 @@ describe('classes', () => {
           }
         });
       });
-      var __initClass__ = function(c) {
+      function __initClass__(c) {
         c.initClass();
         return c;
-      };
+      }
     `);
   });
 });


### PR DESCRIPTION
Fixes #625

The general strategy here is to define an `__initClass__` helper in the
normalize stage which calls the `initClass` static method. This is uglier than
the previous approach of adding an `initClass` statement after the class
definition, so we dynamically decide which of the two to use, preferring the
statement approach. Since the normalize stage does not properly communicate
whether patching is done as an expression, we just look at the AST and only
allow the `initClass` statement if we're a child of a block and not in an
implicit return position.

Also, the existing code for handling helpers was all for the main stage, so I
factored it into a `SharedProgramPatcher` that also works in the normalize
stage.

This almost fixes #544, but there's a remaining issue in that example because
commas can split class properties but not statements in CoffeeScript.

There's still a little more to do to make complex classes 100% correct, but I
think this should handle most cases.