### PR TITLE
fix: update decaffeinate-parser to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babylon": "^6.12.0",
     "coffee-lex": "^7.0.0",
     "decaffeinate-coffeescript": "^1.10.0-patch12",
-    "decaffeinate-parser": "^14.0.0",
+    "decaffeinate-parser": "^15.0.1",
     "detect-indent": "^4.0.0",
     "esnext": "^3.0.12",
     "lines-and-columns": "^1.1.5",

--- a/src/stages/normalize/index.js
+++ b/src/stages/normalize/index.js
@@ -1,4 +1,5 @@
 import ArrayInitialiserPatcher from './patchers/ArrayInitialiserPatcher';
+import BareSuperFunctionApplicationPatcher from './patchers/BareSuperFunctionApplicationPatcher';
 import BlockPatcher from './patchers/BlockPatcher';
 import ClassPatcher from './patchers/ClassPatcher';
 import AssignOpPatcher from './patchers/AssignOpPatcher';
@@ -63,6 +64,9 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
       case 'NewOp':
       case 'SoakedFunctionApplication':
         return FunctionApplicationPatcher;
+
+      case 'BareSuperFunctionApplication':
+        return BareSuperFunctionApplicationPatcher;
 
       case 'Identifier':
         return IdentifierPatcher;

--- a/src/stages/normalize/patchers/BareSuperFunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/BareSuperFunctionApplicationPatcher.js
@@ -1,0 +1,7 @@
+import NodePatcher from './../../../patchers/NodePatcher';
+
+export default class FunctionApplicationPatcher extends NodePatcher {
+  patchAsExpression() {
+    this.insert(this.contentEnd, '(arguments...)');
+  }
+}

--- a/src/stages/normalize/patchers/BareSuperFunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/BareSuperFunctionApplicationPatcher.js
@@ -1,6 +1,6 @@
 import NodePatcher from './../../../patchers/NodePatcher';
 
-export default class FunctionApplicationPatcher extends NodePatcher {
+export default class BareSuperFunctionApplicationPatcher extends NodePatcher {
   patchAsExpression() {
     this.insert(this.contentEnd, '(arguments...)');
   }

--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.js
@@ -19,11 +19,6 @@ export default class FunctionApplicationPatcher extends NodePatcher {
 
     this.fn.patch();
 
-    if (this.isImplicitSuper()) {
-      this.insert(this.fn.contentEnd, '(arguments...)');
-      return;
-    }
-
     if (implicitCall) {
       let firstArg = args[0];
       let hasOneArg = args.length === 1;
@@ -126,12 +121,10 @@ export default class FunctionApplicationPatcher extends NodePatcher {
    *
    * Note that we do not add parentheses for constructor invocations with no
    * arguments and no parentheses; that usage is correct in JavaScript, so we
-   * leave it as-is. Also, bare `super` calls have a virtual argument which
-   * doesn't have a source location, but we know that any parens for that will
-   * be handled in later code.
+   * leave it as-is.
    */
   isImplicitCall(): boolean {
-    if (this.args.length === 0 || this.args[0].node.virtual) {
+    if (this.args.length === 0) {
       return false;
     }
     let searchStart = this.fn.outerEnd;
@@ -153,24 +146,5 @@ export default class FunctionApplicationPatcher extends NodePatcher {
     } else {
       return this.fn.outerEnd;
     }
-  }
-
-  isImplicitSuper(): boolean {
-    if (this.fn.node.type !== 'Super') {
-      return false;
-    }
-
-    if (this.args.length !== 1) {
-      return false;
-    }
-
-    let arg = this.args[0].node;
-
-    return (
-      arg.virtual &&
-      arg.type === 'Spread' &&
-      arg.expression.type === 'Identifier' &&
-      arg.expression.data === 'arguments'
-    );
   }
 }

--- a/src/utils/traverse.js
+++ b/src/utils/traverse.js
@@ -40,6 +40,7 @@ export default function traverse(node: Node, callback: (node: Node, descend: (no
 const ORDER = {
   ArrayInitialiser: ['members'],
   AssignOp: ['assignee', 'expression'],
+  BareSuperFunctionApplication: [],
   BitAndOp: ['left', 'right'],
   BitNotOp: ['expression'],
   BitOrOp: ['left', 'right'],


### PR DESCRIPTION
There's now a `BareSuperFunctionApplication` node type that simplifies the
checks we needed to do. As before, it gets turned into its expanded form in the
normalize stage.

This also pulls in a fix to chained comparisons and unary operators.