### PR TITLE
fix: don't put code in comments when removing trailing empty returns

### DIFF
--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1140,6 +1140,7 @@ describe('classes', () => {
       const A = __initClass__(class {
         static initClass() {
           this.prototype.b = c;
+          
         }
       });
       function __initClass__(c) {
@@ -1159,6 +1160,7 @@ describe('classes', () => {
         __initClass__(class A {
           static initClass() {
             this.prototype.b = c;
+            
           }
         })
       ;
@@ -1183,6 +1185,7 @@ describe('classes', () => {
         return __initClass__(class MainLayout extends BaseView {
           static initClass() {
             this.prototype.container = 'body';
+            
           }
         });
       });

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -320,7 +320,6 @@ describe('functions', () => {
         yield return
     `, `
       (function*() {
-        
       });
     `);
   });

--- a/test/indentation_test.js
+++ b/test/indentation_test.js
@@ -28,7 +28,6 @@ describe('indentation', () => {
        b
     `, `
       a(function() {
-        
       });
       b;
     `);
@@ -45,7 +44,6 @@ describe('indentation', () => {
       (function() {
         a
           .b(() => {
-            
           }
         );
         return 3;

--- a/test/return_test.js
+++ b/test/return_test.js
@@ -56,6 +56,23 @@ describe('return', () => {
     `)
   );
 
+  it('does not pull code into comments when followed by a trailing empty return', () => {
+    check(`
+      a () ->
+        b  # comment
+        return
+      .c =>
+        d
+    `, `
+      a(function() {
+        b;  // comment
+        }).c(() => {
+        return d;
+      }
+      );
+    `);
+  });
+
   it('allows a top-level return', () =>
     check(`
       return a


### PR DESCRIPTION
Fixes #816

The previous logic was to remove trailing empty returns by deleting from the
start of the previous newline to the end of the return, but if there was code
after the `return` on the same line and the previous line had a comment, it
could cause that code to be pulled into the comment.

To fix, I rewrote the logic so it only removes the line if the `return` is on a
line by itself. If not, it does the safe thing of just removing the `return`.

This makes some generated code cleaner, but ends up with an unnecessary blank
line in the `initClass` method for complex class expressions. I couldn't find a
clean solution to avoid this, so it's a style regression in this commit,
favoring correctness in other cases. I think probably the right solution there
is to rethink that code transform so that a line with only `)` doesn't produce
a blank line.