### PR TITLE
refactor: remove `virtual` checks on AST nodes

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -61,10 +61,6 @@ export default class NodePatcher {
   setupLocationInformation() {
     let { node, context } = this;
 
-    if (node.virtual) {
-      return;
-    }
-
     /**
      * `contentStart` and `contentEnd` is the exclusive range within the original source that
      * composes this patcher's node. For example, here's the contentStart and contentEnd of
@@ -840,7 +836,7 @@ export default class NodePatcher {
    * Determines whether this patcher's node spanned multiple lines.
    */
   isMultiline(): boolean {
-    return !this.node.virtual && /\n/.test(this.getOriginalSource());
+    return /\n/.test(this.getOriginalSource());
   }
 
   /**

--- a/src/stages/main/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/main/patchers/FunctionApplicationPatcher.js
@@ -30,7 +30,7 @@ export default class FunctionApplicationPatcher extends NodePatcher {
     args.forEach((arg, i) => {
       arg.patch();
       let isLast = i === args.length - 1;
-      let commaTokenIndex = arg.node.virtual ? null : this.indexOfSourceTokenAfterSourceTokenIndex(
+      let commaTokenIndex = this.indexOfSourceTokenAfterSourceTokenIndex(
         arg.outerEndTokenIndex,
         SourceType.COMMA,
         isSemanticToken

--- a/src/stages/main/patchers/SpreadPatcher.js
+++ b/src/stages/main/patchers/SpreadPatcher.js
@@ -20,11 +20,6 @@ export default class SpreadPatcher extends NodePatcher {
    * All we have to do is move the `...` from the right to the left.
    */
   patchAsExpression() {
-    if (this.node.virtual) {
-      // i.e. the virtual spread in a bare `super` call.
-      return;
-    }
-
     // `a...` → `...a...`
     //           ^^^
     this.insert(this.expression.outerStart, '...');

--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.js
@@ -21,11 +21,10 @@ export default class FunctionApplicationPatcher extends NodePatcher {
 
     if (implicitCall) {
       let firstArg = args[0];
-      let hasOneArg = args.length === 1;
       let firstArgIsOnNextLine = !firstArg ? false :
         /\n/.test(this.context.source.slice(this.fn.outerEnd, firstArg.outerStart));
       let funcEnd = this.getFuncEnd();
-      if ((hasOneArg && firstArg.node.virtual) || firstArgIsOnNextLine) {
+      if (firstArgIsOnNextLine) {
         this.insert(funcEnd, '(');
       } else {
         this.overwrite(funcEnd, firstArg.outerStart, '(');

--- a/src/utils/formatDecaffeinateParserAst.js
+++ b/src/utils/formatDecaffeinateParserAst.js
@@ -10,7 +10,7 @@ function formatAstNodeLines(node, context) {
   let propLines = [];
   let childPropNames = childPropertyNames(node);
   let blacklistedProps = childPropNames.concat(
-    ['raw', 'line', 'column', 'type', 'range', 'virtual', 'scope', 'parentNode', 'context', 'start', 'end']
+    ['raw', 'line', 'column', 'type', 'range', 'scope', 'parentNode', 'context', 'start', 'end']
   );
   for (let key of Object.keys(node)) {
     if (blacklistedProps.indexOf(key) !== -1) {
@@ -43,12 +43,7 @@ function formatAstNodeLines(node, context) {
       propLines.push(...childLines);
     }
   }
-  let rangeStr;
-  if (node.virtual) {
-    rangeStr = '(virtual)';
-  } else {
-    rangeStr = formatRange(node.range[0], node.range[1], context);
-  }
+  let rangeStr = formatRange(node.range[0], node.range[1], context);
   return [
     `${node.type} ${rangeStr} {`,
     ...propLines.map(s => '  ' + s),


### PR DESCRIPTION
The AST now never has any virtual nodes, so we can get rid of some special cases
in a few places.