### PR TITLE
fix: remove unnecessary `then` tokens after assign operators

### DIFF
--- a/src/stages/normalize/index.js
+++ b/src/stages/normalize/index.js
@@ -82,6 +82,7 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
 
       case 'AssignOp':
       case 'ClassProtoAssignOp':
+      case 'CompoundAssignOp':
         return AssignOpPatcher;
 
       case 'Program':

--- a/src/stages/normalize/patchers/AssignOpPatcher.js
+++ b/src/stages/normalize/patchers/AssignOpPatcher.js
@@ -1,12 +1,39 @@
-import PassthroughPatcher from '../../../patchers/PassthroughPatcher';
+import { SourceType } from 'coffee-lex';
+import NodePatcher from '../../../patchers/NodePatcher';
 
-export default class AssignOpPatcher extends PassthroughPatcher {
-  key: NodePatcher;
+export default class AssignOpPatcher extends NodePatcher {
+  assignee: NodePatcher;
   expression: NodePatcher;
 
-  constructor(patcherContext: PatcherContext, key: NodePatcher, expression: NodePatcher) {
-    super(patcherContext, key, expression);
-    this.key = key;
+  constructor(patcherContext: PatcherContext, assignee: NodePatcher, expression: NodePatcher) {
+    super(patcherContext, assignee, expression);
+    this.assignee = assignee;
     this.expression = expression;
+  }
+
+  patchAsExpression() {
+    this.assignee.patch();
+    this.removeUnnecessaryThenToken();
+    this.expression.patch();
+  }
+
+  /**
+   * Assignment operators are allowed to have a `then` token after them for some
+   * reason, and it doesn't do anything, so just get rid of it.
+   */
+  removeUnnecessaryThenToken() {
+    let thenIndex = this.indexOfSourceTokenBetweenPatchersMatching(
+      this.assignee,
+      this.expression,
+      token => token.type === SourceType.THEN
+    );
+    if (thenIndex) {
+      let thenToken = this.sourceTokenAtIndex(thenIndex);
+      if (this.slice(thenToken.start - 1, thenToken.start) === ' ') {
+        this.remove(thenToken.start - 1, thenToken.end);
+      } else {
+        this.remove(thenToken.start, thenToken.end);
+      }
+    }
   }
 }

--- a/src/stages/normalize/patchers/ClassPatcher.js
+++ b/src/stages/normalize/patchers/ClassPatcher.js
@@ -258,10 +258,10 @@ export default class ClassPatcher extends NodePatcher {
   getNonMethodStatementCode(statementPatcher, deleteStart) {
     if (statementPatcher instanceof AssignOpPatcher &&
         this.isClassAssignment(statementPatcher.node)) {
-      let {key, expression} = statementPatcher;
-      let prefixCode = this.slice(deleteStart, key.outerStart);
-      let keyCode = this.slice(key.outerStart, key.outerEnd);
-      let suffixCode = this.slice(key.outerEnd, expression.outerEnd);
+      let {assignee, expression} = statementPatcher;
+      let prefixCode = this.slice(deleteStart, assignee.outerStart);
+      let keyCode = this.slice(assignee.outerStart, assignee.outerEnd);
+      let suffixCode = this.slice(assignee.outerEnd, expression.outerEnd);
 
       let equalIndex = suffixCode.indexOf('=');
       let colonIndex = suffixCode.indexOf(':');

--- a/test/binary_operator_test.js
+++ b/test/binary_operator_test.js
@@ -273,4 +273,28 @@ describe('binary operators', () => {
       a && (b || (b = c));
     `);
   });
+
+  it('removes the unnecessary `then` token after an assignment operator', () => {
+    check(`
+      a = then b
+    `, `
+      let a = b;
+    `);
+  });
+
+  it('removes the unnecessary `then` token after a compound assignment operator', () => {
+    check(`
+      a += then b
+    `, `
+      a += b;
+    `);
+  });
+
+  it('removes the unnecessary `then` token after an assignment with no space', () => {
+    check(`
+      a =then b
+    `, `
+      let a = b;
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #790

Apparently CoffeeScript allows `then` after any type of assignment, and it
doesn't do anything in particular, so we can just remove it in the normalize
stage.

Also, the assign op patcher in the normalize stage had a `key` field when it
should have been `assignee`, so fix that.