### PR TITLE
fix: don't generate an assignment for this-assigned inner classes

### DIFF
--- a/src/stages/normalize/patchers/ClassPatcher.js
+++ b/src/stages/normalize/patchers/ClassPatcher.js
@@ -3,6 +3,7 @@ import { SourceType } from 'coffee-lex';
 import NodePatcher from './../../../patchers/NodePatcher';
 import AssignOpPatcher from './AssignOpPatcher';
 import BlockPatcher from './BlockPatcher';
+import IdentifierPatcher from './IdentifierPatcher';
 import ProgramPatcher from './ProgramPatcher';
 
 import type { PatcherContext } from './../../../patchers/types';
@@ -246,10 +247,11 @@ export default class ClassPatcher extends NodePatcher {
    */
   getAssignmentName(statementPatcher) {
     if (statementPatcher.node.type === 'AssignOp' &&
-      statementPatcher.node.assignee.type === 'Identifier') {
+        statementPatcher.assignee instanceof IdentifierPatcher) {
       return statementPatcher.node.assignee.data;
     }
-    if (statementPatcher instanceof ClassPatcher) {
+    if (statementPatcher instanceof ClassPatcher &&
+        statementPatcher.nameAssignee instanceof IdentifierPatcher) {
       return statementPatcher.nameAssignee.node.data;
     }
     return null;
@@ -277,7 +279,7 @@ export default class ClassPatcher extends NodePatcher {
         return `${prefixCode}${keyCode}${suffixCode}`;
       }
     } else if (statementPatcher instanceof ClassPatcher &&
-        statementPatcher.nameAssignee) {
+        statementPatcher.nameAssignee instanceof IdentifierPatcher) {
       // Nested classes need a special case: they need to be converted to an
       // assignment statement so that the name can be declared outside the outer
       // class body and the initialized within initClass.

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1195,4 +1195,18 @@ describe('classes', () => {
       }
     `);
   });
+
+  it('handles an inner class with a this-assignment', () => {
+    check(`
+      class Outer
+        class @Inner
+    `, `
+      class Outer {
+        static initClass() {
+          this.Inner = class Inner {};
+        }
+      }
+      Outer.initClass();
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #828

Inner classes had a special case that they usually need to be turned into an
assignment, but for this-assigned inner classes, it's correct to leave them
alone.