### PR TITLE
refactor: add a `mayBeUnboundReference` to `NodePatcher`

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -1178,7 +1178,7 @@ export default class NodePatcher {
    * value, to guard against the case where this node is a variable that doesn't
    * exist. IdentifierPatcher overrides this to check the current scope.
    */
-  mayBeInvalidReference() {
+  mayBeUnboundReference() {
     return false;
   }
 }

--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -1172,4 +1172,13 @@ export default class NodePatcher {
     let nextSemanticIdx = this.indexOfSourceTokenBetweenSourceIndicesMatching(from, to, isSemanticToken);
     return nextSemanticIdx && this.sourceTokenAtIndex(nextSemanticIdx);
   }
+
+  /**
+   * Determine if we need to do a `typeof` check in a conditional for this
+   * value, to guard against the case where this node is a variable that doesn't
+   * exist. IdentifierPatcher overrides this to check the current scope.
+   */
+  mayBeInvalidReference() {
+    return false;
+  }
 }

--- a/src/stages/main/patchers/ExistsOpCompoundAssignOpPatcher.js
+++ b/src/stages/main/patchers/ExistsOpCompoundAssignOpPatcher.js
@@ -84,7 +84,7 @@ export default class ExistsOpCompoundAssignOpPatcher extends CompoundAssignOpPat
    * variable might not be declared.
    */
   needsTypeofCheck() {
-    return this.assignee.mayBeInvalidReference();
+    return this.assignee.mayBeUnboundReference();
   }
 
   /**

--- a/src/stages/main/patchers/ExistsOpCompoundAssignOpPatcher.js
+++ b/src/stages/main/patchers/ExistsOpCompoundAssignOpPatcher.js
@@ -1,5 +1,4 @@
 import CompoundAssignOpPatcher from './CompoundAssignOpPatcher';
-import IdentifierPatcher from './IdentifierPatcher';
 
 export default class ExistsOpCompoundAssignOpPatcher extends CompoundAssignOpPatcher {
   patchAsExpression({ needsParens=false }={}) {
@@ -85,8 +84,7 @@ export default class ExistsOpCompoundAssignOpPatcher extends CompoundAssignOpPat
    * variable might not be declared.
    */
   needsTypeofCheck() {
-    return this.assignee instanceof IdentifierPatcher &&
-      !this.node.scope.hasBinding(this.assignee.node.data);
+    return this.assignee.mayBeInvalidReference();
   }
 
   /**

--- a/src/stages/main/patchers/ExistsOpPatcher.js
+++ b/src/stages/main/patchers/ExistsOpPatcher.js
@@ -5,7 +5,7 @@ export default class ExistsOpPatcher extends BinaryOpPatcher {
    * LEFT '?' RIGHT → `LEFT != null ? LEFT : RIGHT`
    */
   patchAsExpression() {
-    let needsTypeofCheck = this.left.mayBeInvalidReference();
+    let needsTypeofCheck = this.left.mayBeUnboundReference();
     if (needsTypeofCheck) {
       // `a ? b` → `typeof a ? b`
       //            ^^^^^^^
@@ -35,7 +35,7 @@ export default class ExistsOpPatcher extends BinaryOpPatcher {
    * LEFT '?' RIGHT → `if (LEFT == null) { RIGHT }`
    */
   patchAsStatement() {
-    let needsTypeofCheck = this.left.mayBeInvalidReference();
+    let needsTypeofCheck = this.left.mayBeUnboundReference();
     // `a ? b` → `if (a ? b`
     //            ^^^
     this.insert(this.contentStart, `if (`);

--- a/src/stages/main/patchers/ExistsOpPatcher.js
+++ b/src/stages/main/patchers/ExistsOpPatcher.js
@@ -1,15 +1,11 @@
 import BinaryOpPatcher from './BinaryOpPatcher';
-import IdentifierPatcher from './IdentifierPatcher';
 
 export default class ExistsOpPatcher extends BinaryOpPatcher {
   /**
    * LEFT '?' RIGHT → `LEFT != null ? LEFT : RIGHT`
    */
   patchAsExpression() {
-    let needsTypeofCheck = (
-      this.left instanceof IdentifierPatcher &&
-      !this.node.scope.hasBinding(this.left.node.data)
-    );
+    let needsTypeofCheck = this.left.mayBeInvalidReference();
     if (needsTypeofCheck) {
       // `a ? b` → `typeof a ? b`
       //            ^^^^^^^
@@ -39,10 +35,7 @@ export default class ExistsOpPatcher extends BinaryOpPatcher {
    * LEFT '?' RIGHT → `if (LEFT == null) { RIGHT }`
    */
   patchAsStatement() {
-    let needsTypeofCheck = (
-      this.left instanceof IdentifierPatcher &&
-      !this.node.scope.hasBinding(this.left.node.data)
-    );
+    let needsTypeofCheck = this.left.mayBeInvalidReference();
     // `a ? b` → `if (a ? b`
     //            ^^^
     this.insert(this.contentStart, `if (`);

--- a/src/stages/main/patchers/IdentifierPatcher.js
+++ b/src/stages/main/patchers/IdentifierPatcher.js
@@ -4,4 +4,13 @@ export default class IdentifierPatcher extends PassthroughPatcher {
   isRepeatable(): boolean {
     return true;
   }
+
+  /**
+   * Determine if this identifier might refer to a non-existent variable. In
+   * that case, some code paths need to emit a `typeof` check to ensure that
+   * we don't crash if this variable hasn't been declared.
+   */
+  mayBeInvalidReference() {
+    return !this.node.scope.hasBinding(this.node.data);
+  }
 }

--- a/src/stages/main/patchers/IdentifierPatcher.js
+++ b/src/stages/main/patchers/IdentifierPatcher.js
@@ -10,7 +10,7 @@ export default class IdentifierPatcher extends PassthroughPatcher {
    * that case, some code paths need to emit a `typeof` check to ensure that
    * we don't crash if this variable hasn't been declared.
    */
-  mayBeInvalidReference() {
+  mayBeUnboundReference() {
     return !this.node.scope.hasBinding(this.node.data);
   }
 }

--- a/src/stages/main/patchers/UnaryExistsOpPatcher.js
+++ b/src/stages/main/patchers/UnaryExistsOpPatcher.js
@@ -108,13 +108,7 @@ export default class UnaryExistsOpPatcher extends UnaryOpPatcher {
    * @private
    */
   needsTypeofCheck(): boolean {
-    let { node } = this;
-    let { expression } = node;
-    return (
-      expression &&
-      expression.type === 'Identifier' &&
-      !node.scope.hasBinding(expression.data)
-    );
+    return this.expression.mayBeInvalidReference();
   }
 
   /**

--- a/src/stages/main/patchers/UnaryExistsOpPatcher.js
+++ b/src/stages/main/patchers/UnaryExistsOpPatcher.js
@@ -108,7 +108,7 @@ export default class UnaryExistsOpPatcher extends UnaryOpPatcher {
    * @private
    */
   needsTypeofCheck(): boolean {
-    return this.expression.mayBeInvalidReference();
+    return this.expression.mayBeUnboundReference();
   }
 
   /**


### PR DESCRIPTION
This makes it easier to determine when we need to do a `typeof` check, and
will be useful for some upcoming changes to soak operations that will need
to do a similar check.