### PR TITLE
feat: avoid the guard helper in some soaked member accesses

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -348,10 +348,10 @@ export default class NodePatcher {
       let ref = this.claimFreeBinding(repeatableOptions.ref);
       this.insert(this.innerStart, `${ref} = `);
       this.patchAsForcedExpression(patchOptions);
+      this.commitDeferredSuffix();
       if (repeatableOptions.parens) {
         this.insert(this.innerEnd, ')');
       }
-      this.commitDeferredSuffix();
       return ref;
     }
   }

--- a/src/stages/main/patchers/CompoundAssignOpPatcher.js
+++ b/src/stages/main/patchers/CompoundAssignOpPatcher.js
@@ -1,6 +1,6 @@
 import AssignOpPatcher from './AssignOpPatcher';
 import type { SourceToken } from './../../../patchers/types';
-import traverse from '../../../utils/traverse';
+import nodeContainsSoakOperation from '../../../utils/nodeContainsSoakOperation';
 import { SourceType } from 'coffee-lex';
 
 export default class CompoundAssignOpPatcher extends AssignOpPatcher {
@@ -33,18 +33,7 @@ export default class CompoundAssignOpPatcher extends AssignOpPatcher {
    * statement code, so instead run the expression code path.
    */
   lhsHasSoakOperation() {
-    let foundSoak = false;
-    traverse(this.assignee.node, node => {
-      if (foundSoak) {
-        return false;
-      }
-      if (node.type === 'SoakedDynamicMemberAccessOp' ||
-        node.type === 'SoakedFunctionApplication' ||
-        node.type === 'SoakedMemberAccessOp') {
-        foundSoak = true;
-      }
-    });
-    return foundSoak;
+    return nodeContainsSoakOperation(this.assignee.node);
   }
 
 }

--- a/src/stages/main/patchers/ConditionalPatcher.js
+++ b/src/stages/main/patchers/ConditionalPatcher.js
@@ -42,9 +42,6 @@ export default class ConditionalPatcher extends NodePatcher {
     }
   }
 
-  /**
-   * @private
-   */
   willPatchAsTernary(): boolean {
     return (
       this.prefersToPatchAsExpression() || (

--- a/src/stages/main/patchers/SoakedMemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/SoakedMemberAccessOpPatcher.js
@@ -1,5 +1,7 @@
 import MemberAccessOpPatcher from './MemberAccessOpPatcher';
 import findSoakContainer from '../../../utils/findSoakContainer';
+import nodeContainsSoakOperation from '../../../utils/nodeContainsSoakOperation';
+import ternaryNeedsParens from '../../../utils/ternaryNeedsParens';
 
 const GUARD_HELPER =
   `function __guard__(value, transform) {
@@ -16,22 +18,67 @@ export default class SoakedMemberAccessOpPatcher extends MemberAccessOpPatcher {
 
   patchAsExpression() {
     if (!this._shouldSkipSoakPatch) {
-      this.registerHelper('__guard__', GUARD_HELPER);
-
-      let soakContainer = findSoakContainer(this);
-      let varName = soakContainer.claimFreeBinding('x');
-      let prefix = this.slice(soakContainer.contentStart, this.contentStart);
-
-      if (prefix.length > 0) {
-        this.remove(soakContainer.contentStart, this.contentStart);
+      if (this.shouldPatchAsConditional()) {
+        this.patchAsConditional();
+      } else {
+        this.patchAsGuardCall();
       }
-
-      let memberNameToken = this.getMemberNameSourceToken();
-      this.overwrite(this.expression.outerEnd, memberNameToken.start, `, ${varName} => ${prefix}${varName}.`);
-
-      soakContainer.insert(soakContainer.contentStart, '__guard__(');
-      soakContainer.appendDeferredSuffix(')');
+    } else {
+      this.expression.patch();
     }
+  }
+
+  shouldPatchAsConditional() {
+    return this.expression.isRepeatable() && !nodeContainsSoakOperation(this.expression.node);
+  }
+
+  patchAsConditional() {
+    let soakContainer = findSoakContainer(this);
+    let memberNameToken = this.getMemberNameSourceToken();
+    let expressionCode = this.expression.patchRepeatable();
+
+    let conditionCode;
+    if (this.expression.mayBeUnboundReference()) {
+      conditionCode = `typeof ${expressionCode} !== 'undefined' && ${expressionCode} !== null`;
+    } else {
+      conditionCode = `${expressionCode} != null`;
+    }
+
+    this.overwrite(this.expression.outerEnd, memberNameToken.start, '.');
+    if (soakContainer.willPatchAsExpression()) {
+      let containerNeedsParens = ternaryNeedsParens(soakContainer);
+      if (containerNeedsParens) {
+        soakContainer.insert(soakContainer.contentStart, '(');
+      }
+      soakContainer.insert(soakContainer.contentStart, `${conditionCode} ? `);
+      soakContainer.appendDeferredSuffix(' : undefined');
+      if (containerNeedsParens) {
+        soakContainer.appendDeferredSuffix(')');
+      }
+    } else {
+      soakContainer.insert(
+        soakContainer.contentStart,  `if (${conditionCode}) {\n${soakContainer.getIndent(1)}`);
+      soakContainer.appendDeferredSuffix(`\n${soakContainer.getIndent()}}`);
+    }
+  }
+
+  patchAsGuardCall() {
+    this.registerHelper('__guard__', GUARD_HELPER);
+
+    let soakContainer = findSoakContainer(this);
+    let varName = soakContainer.claimFreeBinding('x');
+    let prefix = this.slice(soakContainer.contentStart, this.contentStart);
+
+    if (prefix.length > 0) {
+      this.remove(soakContainer.contentStart, this.contentStart);
+    }
+
+    let memberNameToken = this.getMemberNameSourceToken();
+    this.overwrite(this.expression.outerEnd, memberNameToken.start, `, ${varName} => ${prefix}${varName}.`);
+
+    soakContainer.insert(soakContainer.contentStart, '__guard__(');
+    soakContainer.appendDeferredSuffix(')');
+
     this.expression.patch();
   }
 

--- a/src/utils/nodeContainsSoakOperation.js
+++ b/src/utils/nodeContainsSoakOperation.js
@@ -1,0 +1,22 @@
+/* @flow */
+
+import traverse from './traverse';
+import type { Node } from '../patchers/types';
+
+/**
+ * Determine if there are any soak operations within this subtree of the AST.
+ */
+export default function nodeContainsSoakOperation(searchNode: Node): boolean {
+  let foundSoak = false;
+  traverse(searchNode, node => {
+    if (foundSoak) {
+      return false;
+    }
+    if (node.type === 'SoakedDynamicMemberAccessOp' ||
+        node.type === 'SoakedFunctionApplication' ||
+        node.type === 'SoakedMemberAccessOp') {
+      foundSoak = true;
+    }
+  });
+  return foundSoak;
+}

--- a/src/utils/ternaryNeedsParens.js
+++ b/src/utils/ternaryNeedsParens.js
@@ -1,0 +1,39 @@
+/* @flow */
+
+import AssignOpPatcher from '../stages/main/patchers/AssignOpPatcher';
+import ConditionalPatcher from '../stages/main/patchers/ConditionalPatcher';
+import DynamicMemberAccessOpPatcher from '../stages/main/patchers/DynamicMemberAccessOpPatcher';
+import InOpPatcher from '../stages/main/patchers/InOpPatcher';
+import FunctionApplicationPatcher from '../stages/main/patchers/FunctionApplicationPatcher';
+import SoakedDynamicMemberAccessOpPatcher from '../stages/main/patchers/SoakedDynamicMemberAccessOpPatcher';
+import SoakedFunctionApplicationPatcher from '../stages/main/patchers/SoakedFunctionApplicationPatcher';
+import SoakedMemberAccessOpPatcher from '../stages/main/patchers/SoakedMemberAccessOpPatcher';
+import WhilePatcher from '../stages/main/patchers/WhilePatcher';
+import type NodePatcher from '../patchers/NodePatcher';
+
+/**
+ * Given a main stage patcher, determine from the AST if it needs to be wrapped
+ * in parens when transformed into a JS ternary.
+ *
+ * Be defensive by listing all known common cases where this is correct, and
+ * requiring parens in all other cases. That way, any missed cases result in
+ * slightly ugly code rather than incorrect code.
+ */
+export default function ternaryNeedsParens(patcher: NodePatcher): boolean {
+  let { parent } = patcher;
+  return !(
+    patcher.isSurroundedByParentheses() ||
+    (parent instanceof FunctionApplicationPatcher && patcher !== parent.fn) ||
+    (parent instanceof DynamicMemberAccessOpPatcher && patcher === parent.indexingExpr) ||
+    (parent instanceof ConditionalPatcher && patcher === parent.condition &&
+      !parent.willPatchAsTernary()) ||
+    (parent instanceof WhilePatcher && patcher === parent.condition) ||
+    parent instanceof InOpPatcher ||
+    (parent instanceof AssignOpPatcher && patcher === parent.expression) ||
+    // This function is called for soak operations, so outer soak operations
+    // will insert a __guard__ helper and thus won't need additional parens.
+    (parent instanceof SoakedMemberAccessOpPatcher && patcher === parent.expression) ||
+    (parent instanceof SoakedDynamicMemberAccessOpPatcher && patcher === parent.expression) ||
+    (parent instanceof SoakedFunctionApplicationPatcher && patcher === parent.fn)
+  );
+}

--- a/test/compound_assignment_test.js
+++ b/test/compound_assignment_test.js
@@ -496,9 +496,8 @@ describe('compound assignment', () => {
       check(`
         a.b?.c ?= d
       `, `
-        __guard__(a.b, x => x.c != null ? a.b.c : (a.b.c = d));
-        function __guard__(value, transform) {
-          return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+        if (a.b != null) {
+          a.b.c != null ? a.b.c : (a.b.c = d);
         }
       `);
     });

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1163,12 +1163,9 @@ describe('for loops', () => {
       for a, b of c?.d
         console.log a
     `, `
-      for (let a in __guard__(c, x => x.d)) {
-        let b = __guard__(c, x => x.d)[a];
+      for (let a in (typeof c !== 'undefined' && c !== null ? c.d : undefined)) {
+        let b = (typeof c !== 'undefined' && c !== null ? c.d : undefined)[a];
         console.log(a);
-      }
-      function __guard__(value, transform) {
-        return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
     `);
   });


### PR DESCRIPTION
Progress toward #801
Progress toward #336

Now, with a simple soak expression like `a?.b`, it will be expanded into a
ternary rather than using the `__guard__` function. This allows us to handle the
case where the variable is unbound (in which case the code should return
`undefined` rather than throwing an exception). More specifically, we use the
conditional form of soak operations

As described in #336, I separate the expression and statement cases and prefer
to wrap in an `if` if possible.

This only handles the case for normal soaked member access; a later commit will
expand it to soaked dynamic member access and soaked function application.

Also fix a subtle bug in repeatable expression patching where a paren could be
misplaced.