### PR TITLE
feat: avoid the guard helper in some additional soak cases

### DIFF
--- a/src/stages/main/patchers/SoakedDynamicMemberAccessOpPatcher.js
+++ b/src/stages/main/patchers/SoakedDynamicMemberAccessOpPatcher.js
@@ -1,5 +1,7 @@
 import DynamicMemberAccessOpPatcher from './DynamicMemberAccessOpPatcher';
 import findSoakContainer from '../../../utils/findSoakContainer';
+import nodeContainsSoakOperation from '../../../utils/nodeContainsSoakOperation';
+import ternaryNeedsParens from '../../../utils/ternaryNeedsParens';
 
 const GUARD_HELPER =
   `function __guard__(value, transform) {
@@ -16,17 +18,61 @@ export default class SoakedDynamicMemberAccessOpPatcher extends DynamicMemberAcc
 
   patchAsExpression() {
     if (!this._shouldSkipSoakPatch) {
-      this.registerHelper('__guard__', GUARD_HELPER);
-      let soakContainer = findSoakContainer(this);
-      let varName = soakContainer.claimFreeBinding('x');
-      let prefix = this.slice(soakContainer.contentStart, this.contentStart);
-      if (prefix.length > 0) {
-        this.remove(soakContainer.contentStart, this.contentStart);
+      if (this.shouldPatchAsConditional()) {
+        this.patchAsConditional();
+      } else {
+        this.patchAsGuardCall();
       }
-      this.overwrite(this.expression.outerEnd, this.indexingExpr.outerStart, `, ${varName} => ${prefix}${varName}[`);
-      soakContainer.insert(soakContainer.contentStart, '__guard__(');
-      soakContainer.appendDeferredSuffix(')');
+    } else {
+      this.expression.patch();
+      this.indexingExpr.patch();
     }
+  }
+
+  shouldPatchAsConditional() {
+    return this.expression.isRepeatable() && !nodeContainsSoakOperation(this.expression.node);
+  }
+
+  patchAsConditional() {
+    let soakContainer = findSoakContainer(this);
+    let expressionCode = this.expression.patchRepeatable();
+
+    let conditionCode;
+    if (this.expression.mayBeUnboundReference()) {
+      conditionCode = `typeof ${expressionCode} !== 'undefined' && ${expressionCode} !== null`;
+    } else {
+      conditionCode = `${expressionCode} != null`;
+    }
+
+    this.overwrite(this.expression.outerEnd, this.indexingExpr.outerStart, '[');
+    if (soakContainer.willPatchAsExpression()) {
+      let containerNeedsParens = ternaryNeedsParens(soakContainer);
+      if (containerNeedsParens) {
+        soakContainer.insert(soakContainer.contentStart, '(');
+      }
+      soakContainer.insert(soakContainer.contentStart, `${conditionCode} ? `);
+      soakContainer.appendDeferredSuffix(' : undefined');
+      if (containerNeedsParens) {
+        soakContainer.appendDeferredSuffix(')');
+      }
+    } else {
+      soakContainer.insert(
+        soakContainer.contentStart,  `if (${conditionCode}) {\n${soakContainer.getIndent(1)}`);
+      soakContainer.appendDeferredSuffix(`\n${soakContainer.getIndent()}}`);
+    }
+  }
+
+  patchAsGuardCall() {
+    this.registerHelper('__guard__', GUARD_HELPER);
+    let soakContainer = findSoakContainer(this);
+    let varName = soakContainer.claimFreeBinding('x');
+    let prefix = this.slice(soakContainer.contentStart, this.contentStart);
+    if (prefix.length > 0) {
+      this.remove(soakContainer.contentStart, this.contentStart);
+    }
+    this.overwrite(this.expression.outerEnd, this.indexingExpr.outerStart, `, ${varName} => ${prefix}${varName}[`);
+    soakContainer.insert(soakContainer.contentStart, '__guard__(');
+    soakContainer.appendDeferredSuffix(')');
 
     this.expression.patch();
     this.indexingExpr.patch();

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -372,9 +372,8 @@ describe('function calls', () => {
     check(`
       a? b
     `, `
-      __guardFunc__(a, f => f(b));
-      function __guardFunc__(func, transform) {
-        return typeof func === 'function' ? transform(func) : undefined;
+      if (typeof a === 'function') {
+        a(b);
       }
     `);
   });


### PR DESCRIPTION
Fixes #801
Progress toward #336

We now use a conditional for soaked dynamic member access and soaked function
calls as long as the expression is repeatable and does not contain any soak
operations.

This is pretty much the same strategy as for soaked member accesses. For
function calls, the code naturally becomes method call syntax when necessary, so
we don't need a special case for methods like with the `__guardMethod__` stuff.

There's some duplicated code, but a lot of helper methods have been shared and
there are enough differences that it seems reasonable to have the duplication
for now and try to consolidate later if it becomes a bigger issue.