### PR TITLE
fix: properly handle assignments within `do` expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babylon": "^6.12.0",
     "coffee-lex": "^7.0.0",
     "decaffeinate-coffeescript": "1.10.0-patch19",
-    "decaffeinate-parser": "^16.0.3",
+    "decaffeinate-parser": "^16.0.5",
     "detect-indent": "^4.0.0",
     "esnext": "^3.0.12",
     "lines-and-columns": "^1.1.5",

--- a/src/stages/normalize/patchers/DefaultParamPatcher.js
+++ b/src/stages/normalize/patchers/DefaultParamPatcher.js
@@ -1,3 +1,4 @@
+import AssignOpPatcher from './AssignOpPatcher';
 import DoOpPatcher from './DoOpPatcher';
 import FunctionPatcher from './FunctionPatcher';
 import IdentifierPatcher from './IdentifierPatcher';
@@ -66,7 +67,13 @@ export default class DefaultParamPatcher extends PassthroughPatcher {
     if (this.options.looseDefaultParams) {
       return false;
     }
-    if (this.parent instanceof FunctionPatcher && this.parent.parent instanceof DoOpPatcher) {
+    if (this.parent instanceof FunctionPatcher &&
+        this.parent.parent instanceof DoOpPatcher) {
+      return false;
+    }
+    if (this.parent instanceof FunctionPatcher &&
+        this.parent.parent instanceof AssignOpPatcher &&
+        this.parent.parent.parent instanceof DoOpPatcher) {
       return false;
     }
     return true;

--- a/test/do_test.js
+++ b/test/do_test.js
@@ -55,4 +55,26 @@ describe('`do`', () => {
       }()) + 1;
     `);
   });
+
+  it('allows an assignment within a do operation on a fat arrow function (#784)', () => {
+    check(`
+      do a = =>
+        b
+    `, `
+      let a;
+      (a = () => {
+        return b;
+      })();
+    `);
+  });
+
+  it('allows an assignment within a do operation with defaults (#637)', () => {
+    check(`
+      do a = (b = c, d) ->
+        e
+    `, `
+      let a;
+      (a = (b, d) => e)(c, d);
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #784
Fixes #637

We already had a special case for handling `do` expressions with a function
expression, but we need to exercise the same logic in the case when there is an
assignment with a function RHS.