### PR TITLE
fix: properly handle `unless` and `until` with a soak condition

### DIFF
--- a/src/utils/ternaryNeedsParens.js
+++ b/src/utils/ternaryNeedsParens.js
@@ -25,9 +25,10 @@ export default function ternaryNeedsParens(patcher: NodePatcher): boolean {
     patcher.isSurroundedByParentheses() ||
     (parent instanceof FunctionApplicationPatcher && patcher !== parent.fn) ||
     (parent instanceof DynamicMemberAccessOpPatcher && patcher === parent.indexingExpr) ||
-    (parent instanceof ConditionalPatcher && patcher === parent.condition &&
-      !parent.willPatchAsTernary()) ||
-    (parent instanceof WhilePatcher && patcher === parent.condition) ||
+    (parent instanceof ConditionalPatcher && !parent.node.isUnless &&
+      patcher === parent.condition && !parent.willPatchAsTernary()) ||
+    (parent instanceof WhilePatcher && !parent.node.isUntil &&
+      patcher === parent.condition) ||
     parent instanceof InOpPatcher ||
     (parent instanceof AssignOpPatcher && patcher === parent.expression) ||
     // This function is called for soak operations, so outer soak operations

--- a/test/soaked_test.js
+++ b/test/soaked_test.js
@@ -791,4 +791,26 @@ describe('soaked expressions', () => {
       let d = a[b != null ? b.c : undefined];
     `);
   });
+
+  it('properly handles a soaked condition in an `unless` statement', () => {
+    check(`
+      unless a?.b
+        c
+    `, `
+      if (!(typeof a !== 'undefined' && a !== null ? a.b : undefined)) {
+        c;
+      }
+    `);
+  });
+
+  it('properly handles a soaked condition in an `until` statement', () => {
+    check(`
+      until a?.b
+        c
+    `, `
+      while (!(typeof a !== 'undefined' && a !== null ? a.b : undefined)) {
+        c;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #836

We need to wrap a soak ternary in parens when it is negated.

This fixes the last test failure in coffeelint!