### PR TITLE
fix: update tests, stop comment patching from overwriting other code

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babylon": "^6.12.0",
     "coffee-lex": "^7.0.0",
     "decaffeinate-coffeescript": "1.10.0-patch19",
-    "decaffeinate-parser": "^16.0.5",
+    "decaffeinate-parser": "^16.0.7",
     "detect-indent": "^4.0.0",
     "esnext": "^3.0.12",
     "lines-and-columns": "^1.1.5",

--- a/src/stages/main/patchers/ProgramPatcher.js
+++ b/src/stages/main/patchers/ProgramPatcher.js
@@ -11,11 +11,11 @@ export default class ProgramPatcher extends SharedProgramPatcher {
   }
 
   patchAsStatement() {
+    this.patchComments();
     if (this.body) {
       this.body.patch({ leftBrace: false, rightBrace: false });
     }
     this.patchContinuations();
-    this.patchComments();
     this.patchHelpers();
   }
 

--- a/test/comment_test.js
+++ b/test/comment_test.js
@@ -72,4 +72,30 @@ describe('comments', () => {
       console.log("Hello World!");
     `);
   });
+
+  it('preserves trailing comments in function bodies', () => {
+    check(`
+      a ->
+        if b
+          c
+        ### d ###
+    `, `
+      a(function() {
+        if (b) {
+          return c;
+        }
+        /* d */
+      });
+    `);
+  });
+
+  it.skip('preserves trailing comments in arrow function bodies', () => {
+    check(`
+      a ->
+        b
+        ### c ###
+    `, `
+      a(() => b /* c */);
+    `);
+  });
 });

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -617,10 +617,10 @@ describe('conditionals', () => {
         if (false) {
           // comment
         } else if (true) {
-        }
           /*
           block comment
           */
+        }
         else {}
       });
     `);


### PR DESCRIPTION
Fixes #838

A decaffeinate-parser change made some AST node bounds different (generally for
the better), which broke a test. This also exposed a regression where
decaffeinate could `insertLeft` at the end of a block comment, and then later
when the comment was transformed, it would overwrite that new code. Instead, we
now transform comments first.

Also add a skipped test for a case I discovered where we destroy a comment.