### PR TITLE
fix: change negated patching to patch in order

### DIFF
--- a/test/soaked_test.js
+++ b/test/soaked_test.js
@@ -813,4 +813,16 @@ describe('soaked expressions', () => {
       }
     `);
   });
+
+  it('properly handles a soaked condition in an `unless` statement with an assignment', () => {
+    check(`
+      unless a = b?.c
+        d
+    `, `
+      let a;
+      if (!(a = typeof b !== 'undefined' && b !== null ? b.c : undefined)) {
+        d;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #840

Rather than immediately surrounding an expression in parens, we should set a
flag on the expression so it gets an open-paren at the start of patching and a
close-paren at the end. There still could potentially be some conflicts between
deferred patching and patching at the end of an expression, but it seems to not
come up at least for this issue.