### PR TITLE
feat: allow external constructors in classes

### DIFF
--- a/src/stages/normalize/index.js
+++ b/src/stages/normalize/index.js
@@ -4,6 +4,7 @@ import BlockPatcher from './patchers/BlockPatcher';
 import ClassPatcher from './patchers/ClassPatcher';
 import AssignOpPatcher from './patchers/AssignOpPatcher';
 import ConditionalPatcher from './patchers/ConditionalPatcher';
+import ConstructorPatcher from './patchers/ConstructorPatcher';
 import DoOpPatcher from './patchers/DoOpPatcher';
 import ExpansionPatcher from './patchers/ExpansionPatcher';
 import ForInPatcher from './patchers/ForInPatcher';
@@ -43,10 +44,15 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
 
       case 'BoundFunction':
       case 'Function':
+      case 'BoundGeneratorFunction':
+      case 'GeneratorFunction':
         return FunctionPatcher;
 
       case 'Conditional':
         return ConditionalPatcher;
+
+      case 'Constructor':
+        return ConstructorPatcher;
 
       case 'DoOp':
         return DoOpPatcher;

--- a/src/stages/normalize/patchers/ClassPatcher.js
+++ b/src/stages/normalize/patchers/ClassPatcher.js
@@ -224,7 +224,7 @@ export default class ClassPatcher extends NodePatcher {
             patcher.expression.contentStart, patcher.expression.contentEnd);
           let ctorName;
           if (this.nameAssignee instanceof IdentifierPatcher) {
-            let className = this.claimFreeBinding(this.nameAssignee.node.data);
+            let className = this.nameAssignee.node.data;
             ctorName = this.claimFreeBinding(`create${className}`);
           } else {
             ctorName = this.claimFreeBinding('createInstance');

--- a/src/stages/normalize/patchers/ConstructorPatcher.js
+++ b/src/stages/normalize/patchers/ConstructorPatcher.js
@@ -1,0 +1,14 @@
+import PassthroughPatcher from '../../../patchers/PassthroughPatcher';
+import type NodePatcher from '../../../patchers/NodePatcher';
+import type { PatcherContext } from '../../../patchers/types';
+
+export default class ConstructorPatcher extends PassthroughPatcher {
+  assignee: NodePatcher;
+  expression: NodePatcher;
+
+  constructor(patcherContext: PatcherContext, assignee: NodePatcher, expression: NodePatcher) {
+    super(patcherContext, assignee, expression);
+    this.assignee = assignee;
+    this.expression = expression;
+  }
+}

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1209,4 +1209,47 @@ describe('classes', () => {
       Outer.initClass();
     `);
   });
+
+  it('allows an external constructor for a simple class', () => {
+    check(`
+      f = -> @x = 3
+      class A
+        constructor: f
+    `, `
+      let f = function() { return this.x = 3; };
+      let createA = undefined;
+      class A {
+        static initClass() {
+          createA = f;
+        }
+        constructor() {
+          return createA.apply(this, arguments);
+        }
+      }
+      A.initClass();
+    `);
+  });
+
+  it('allows external constructors with bound methods', () => {
+    check(`
+      fn = ->
+      class A
+        constructor: fn
+        method: =>
+    `, `
+      let fn = function() {};
+      let createA = undefined;
+      class A {
+        static initClass() {
+          createA = fn;
+        }
+        constructor() {
+          this.method = this.method.bind(this);
+          return createA.apply(this, arguments);
+        }
+        method() {}
+      }
+      A.initClass();
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #830

We handle external constructors in the normalize step, since it generates
another line in `initClass` and that way we don't need to worry about handling
bound methods and `super` issues at the same time.

Note that this does not yet handle external constructors in experession-style
classes, but should should start working once #835 is addressed.