### PR TITLE
fix: don't crash on a simple super call within an anonymous class

### DIFF
--- a/src/stages/main/patchers/SuperPatcher.js
+++ b/src/stages/main/patchers/SuperPatcher.js
@@ -39,6 +39,10 @@ export default class SuperPatcher extends NodePatcher {
           'construct or file a bug to discuss ways that decaffeinate could ' +
           'handle this case.');
       }
+      if (!className) {
+        throw this.error(
+          'Complex super calls within anonymous classes are not yet supported.');
+      }
       let openParenToken = this.getFollowingOpenParenToken();
       this.overwrite(this.contentStart, openParenToken.end,
         `${className}.prototype.__proto__.${methodName}.call(this, `);
@@ -84,13 +88,10 @@ export default class SuperPatcher extends NodePatcher {
     let { parent } = patcher;
     while (parent) {
       if (parent instanceof ClassPatcher) {
-        let name = parent.getName();
-        if (!name) {
-          throw this.error(
-            'Expected super call to exist in a class with an identifiable name.'
-          );
-        }
-        return name;
+        // Note that this may be null if this is an anonymous class. In that
+        // case, it's still possible, but harder, to generate code that lets us
+        // reference the current class.
+        return parent.getName();
       }
       parent = parent.parent;
     }

--- a/test/super_test.js
+++ b/test/super_test.js
@@ -36,4 +36,18 @@ describe('super', () => {
       }
     `);
   });
+
+  it('allows super within a class assigned to a variable', () => {
+    check(`
+      A = class extends B
+        f: ->
+          super
+    `, `
+      const A = class extends B {
+        f() {
+          return super.f(...arguments);
+        }
+      };
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #843

For most super calls, we can convert them to JS super without needing a
reference to the enclosing class. However, in more advanced cases, we'll need a
reference to effectivelly call super ourselves. CoffeeScript generates code
where even anonymous classes can be referenced, so we may need to do that at
some point in the future. For now, though, we should just convert to JS super
rather than failing if we can't find a name for the enclosing class and it's a
simple case that can become JS super.