### PR TITLE
fix: allow `new` to be used on bound and unbound functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "decaffeinate-coffeescript": "1.10.0-patch19",
     "decaffeinate-parser": "^16.0.7",
     "detect-indent": "^4.0.0",
-    "esnext": "^3.0.12",
+    "esnext": "^3.0.13",
     "lines-and-columns": "^1.1.5",
     "magic-string": "^0.17.0",
     "repeating": "^2.0.0"

--- a/src/stages/main/patchers/BoundFunctionPatcher.js
+++ b/src/stages/main/patchers/BoundFunctionPatcher.js
@@ -37,7 +37,7 @@ export default class BoundFunctionPatcher extends FunctionPatcher {
       }
     });
 
-    if (referencesArguments) {
+    if (referencesArguments || (node.parentNode && node.parentNode.type === 'NewOp')) {
       return ManuallyBoundFunctionPatcher;
     } else {
       return null;

--- a/src/stages/main/patchers/ManuallyBoundFunctionPatcher.js
+++ b/src/stages/main/patchers/ManuallyBoundFunctionPatcher.js
@@ -1,4 +1,5 @@
 import FunctionPatcher from './FunctionPatcher';
+import NewOpPatcher from './NewOpPatcher';
 
 /**
  * Handles bound functions that cannot become arrow functions.
@@ -11,6 +12,12 @@ export default class ManuallyBoundFunctionPatcher extends FunctionPatcher {
   }
 
   patchAsExpression(options={}) {
+    let needsParens = this.parent instanceof NewOpPatcher;
+
+    if (needsParens) {
+      this.insert(this.innerStart, '(');
+    }
+
     super.patchAsExpression(options);
     // If we're instructed to patch as a method, then it won't be legal to add
     // `.bind(this)`, so skip that step. Calling code is expected to bind us
@@ -18,6 +25,10 @@ export default class ManuallyBoundFunctionPatcher extends FunctionPatcher {
     // code will be added to the constructor to bind the method properly.
     if (!options.method) {
       this.insert(this.innerEnd, '.bind(this)');
+    }
+
+    if (needsParens) {
+      this.insert(this.innerEnd, ')');
     }
   }
 

--- a/test/new_op_test.js
+++ b/test/new_op_test.js
@@ -68,4 +68,20 @@ describe('`new` operator', () => {
       });
     `);
   });
+
+  it('allows `new` on regular functions', () => {
+    check(`
+      new -> a
+    `, `
+      (new function() { return a; });
+    `);
+  });
+
+  it('allows `new` on bound functions', () => {
+    check(`
+      new => a
+    `, `
+      (new (function() { return a; }.bind(this)));
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #846

We need to stop the function from becoming an arrow function if it is used with
`new`.