### PR TITLE
fix: allow super within prototype-assigned methods in more cases

### DIFF
--- a/src/stages/main/patchers/FunctionPatcher.js
+++ b/src/stages/main/patchers/FunctionPatcher.js
@@ -1,8 +1,9 @@
 import NodePatcher from './../../../patchers/NodePatcher';
 import FunctionApplicationPatcher from './FunctionApplicationPatcher';
+import { SourceType } from 'coffee-lex';
+import traverse from '../../../utils/traverse';
 import type BlockPatcher from './BlockPatcher';
 import type { PatcherContext, SourceToken } from './../../../patchers/types';
-import { SourceType } from 'coffee-lex';
 
 export default class FunctionPatcher extends NodePatcher {
   parameters: Array<NodePatcher>;
@@ -142,5 +143,22 @@ export default class FunctionPatcher extends NodePatcher {
    */
   statementNeedsParens(): boolean {
     return true;
+  }
+
+  containsSuperCall(): boolean {
+    let foundSuper = false;
+    traverse(this.node, child => {
+      if (foundSuper) {
+        // Already found it, skip this one.
+        return false;
+      } else if (child.type === 'Super') {
+        // Found it.
+        foundSuper = true;
+      } else if (child.type === 'Class') {
+        // Don't go into other classes.
+        return false;
+      }
+    });
+    return foundSuper;
   }
 }

--- a/src/utils/extractPrototypeAssignPatchers.js
+++ b/src/utils/extractPrototypeAssignPatchers.js
@@ -1,0 +1,32 @@
+import AssignOpPatcher from '../stages/main/patchers/AssignOpPatcher';
+import DynamicMemberAccessOpPatcher from '../stages/main/patchers/DynamicMemberAccessOpPatcher';
+import FunctionPatcher from '../stages/main/patchers/FunctionPatcher';
+import MemberAccessOpPatcher from '../stages/main/patchers/MemberAccessOpPatcher';
+
+import type NodePatcher from '../patchers/NodePatcher';
+
+type PrototypeAssignPatchers = ?{
+  classRefPatcher: NodePatcher;
+  // Either a MemberAccessOpPatcher or a DynamicMemberAccessOpPatcher.
+  methodAccessPatcher: NodePatcher;
+};
+
+/**
+ * Given a main stage patcher, determine if it assigns a function to a class
+ * prototype. This means that a super call within the function needs access to
+ * the enclosing function.
+ */
+export default function extractPrototypeAssignPatchers(patcher: NodePatcher): PrototypeAssignPatchers {
+  if (!(patcher instanceof AssignOpPatcher) ||
+      !(patcher.expression instanceof FunctionPatcher) ||
+      !(patcher.assignee instanceof MemberAccessOpPatcher ||
+      patcher.assignee instanceof DynamicMemberAccessOpPatcher) ||
+      !(patcher.assignee.expression instanceof MemberAccessOpPatcher) ||
+      patcher.assignee.expression.member.node.data !== 'prototype') {
+    return null;
+  }
+  return {
+    classRefPatcher: patcher.assignee.expression.expression,
+    methodAccessPatcher: patcher.assignee,
+  };
+}

--- a/test/super_test.js
+++ b/test/super_test.js
@@ -50,4 +50,42 @@ describe('super', () => {
       };
     `);
   });
+
+  it('allows super within a method assignment with a property access class', () => {
+    check(`
+      a.b.prototype.c = -> super
+    `, `
+      a.b.prototype.c = function() { return a.b.prototype.__proto__.c.call(this, ...arguments); };
+    `);
+  });
+
+  it('allows super within a method assignment with a computed class', () => {
+    check(`
+      a().prototype.b = -> super
+    `, `
+      let cls;
+      (cls = a()).prototype.b = function() { return cls.prototype.__proto__.b.call(this, ...arguments); };
+    `);
+  });
+
+  it('allows super within a dynamic prototype member access', () => {
+    check(`
+      A().prototype[b()] = ->
+        super
+    `, `
+      let cls, method;
+      (cls = A()).prototype[method = b()] = function() {
+        return cls.prototype.__proto__[method].call(this, ...arguments);
+      };
+    `);
+  });
+
+  it('does not mark a proto assign as repeatable if the method does not call super', () => {
+    check(`
+      A().prototype[b()] = ->
+        3
+    `, `
+      A().prototype[b()] = () => 3;
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #844

In the general case, we need to handle both normal prototype member access and
dynamic member access, and both the class expression and the member access
expression need to be made repeatable. Fortunately, the relatively new
repeatable protocol makes this relatively easy to accomplish.