### PR TITLE
fix: allow computed keys for class methods

### DIFF
--- a/src/stages/main/patchers/ClassAssignOpPatcher.js
+++ b/src/stages/main/patchers/ClassAssignOpPatcher.js
@@ -37,7 +37,11 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
    * @protected
    */
   patchKey() {
-    // Don't bother, we handle it at this level.
+    if (this.key instanceof MemberAccessOpPatcher) {
+      // Do nothing; this case is handled elsewhere.
+    } else {
+      super.patchKey();
+    }
   }
 
   /**
@@ -57,18 +61,6 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
     let colonToken = this.sourceTokenAtIndex(colonIndex);
     this.overwrite(colonToken.start, colonToken.end, ' =');
     this.patchExpression();
-  }
-
-  /**
-   * Determines whether this class assignment has a computed key.
-   *
-   * @protected
-   */
-  isMethodNameComputed(): boolean {
-    if (!super.isMethodNameComputed()) {
-      return false;
-    }
-    return !this.isStaticMethod();
   }
 
   /**

--- a/src/stages/main/patchers/ObjectBodyMemberPatcher.js
+++ b/src/stages/main/patchers/ObjectBodyMemberPatcher.js
@@ -41,18 +41,7 @@ export default class ObjectBodyMemberPatcher extends NodePatcher {
     if (this.isGeneratorMethod()) {
       this.insert(this.key.outerStart, '*');
     }
-    let isComputed = this.isMethodNameComputed();
-    if (isComputed) {
-      // `{ 'hi there': ->` → `{ ['hi there': ->`
-      //                         ^
-      this.insert(this.key.outerStart, '[');
-    }
     this.patchKey();
-    if (isComputed) {
-      // `{ ['hi there': ->` → `{ ['hi there']: ->`
-      //                                     ^
-      this.insert(this.key.outerEnd, ']');
-    }
     // `{ ['hi there']: ->` → `{ ['hi there']->`
     //                ^^
     this.remove(this.key.outerEnd, this.expression.outerStart);
@@ -106,13 +95,6 @@ export default class ObjectBodyMemberPatcher extends NodePatcher {
 
   patchExpression() {
     this.expression.patch({ method: this.isMethod() });
-  }
-
-  /**
-   * @protected
-   */
-  isMethodNameComputed(): boolean {
-    return !(this.key instanceof IdentifierPatcher);
   }
 
   /**

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -55,6 +55,7 @@ describe('classes', () => {
       ;
     `);
   });
+
   it('preserves class body generator functions as generator method definitions', () => {
     check(`
       class A
@@ -62,7 +63,7 @@ describe('classes', () => {
           yield 1
     `, `
       class A {
-        *['a a']() {
+        *'a a'() {
           return yield 1;
         }
       }
@@ -1250,6 +1251,28 @@ describe('classes', () => {
         method() {}
       }
       A.initClass();
+    `);
+  });
+
+  it('allows simple computed keys for class methods', () => {
+    check(`
+      class A
+        "#{f()}": -> 'Hello'
+    `, `
+      class A {
+        [f()]() { return 'Hello'; }
+      }
+    `);
+  });
+
+  it('allows string interpolation keys for class methods', () => {
+    check(`
+      class A
+        "#{f()}, World": -> 'Hello'
+    `, `
+      class A {
+        [\`\${f()}, World\`]() { return 'Hello'; }
+      }
     `);
   });
 });

--- a/test/object_test.js
+++ b/test/object_test.js
@@ -114,14 +114,14 @@ describe('objects', () => {
     `);
   });
 
-  it('uses computed methods for string keys', () => {
+  it('does not use computed properties for method keys', () => {
     check(`
       ({
         'a': -> b
       })
     `, `
       ({
-        ['a']() { return b; }
+        'a'() { return b; }
       });
     `);
   });


### PR DESCRIPTION
Fixes #847

This simplifies the computed key logic to only happen in one place, and ensures
that at least for the normal key case, we actually end up calling patch on the
key. I think some additional work will be necessary to do the equivalent for
static methods, but this should handle the common case.

This also changes the behavior so method name strings aren't surrounded by
brackets, but it turns out that wasn't necessary.