### PR TITLE
fix: properly format external constructors in single-line classes

### DIFF
--- a/src/stages/normalize/patchers/ClassPatcher.js
+++ b/src/stages/normalize/patchers/ClassPatcher.js
@@ -230,10 +230,13 @@ export default class ClassPatcher extends NodePatcher {
             ctorName = this.claimFreeBinding('createInstance');
           }
 
+          let bodyIndent = this.getBodyIndent();
+          let indentString = this.getProgramIndentString();
+
           this.overwrite(
             patcher.expression.outerStart,
             patcher.expression.outerEnd,
-            `->\n${this.body.getIndent(1)}return ${ctorName}.apply(this, arguments)`
+            `->\n${bodyIndent}${indentString}return ${ctorName}.apply(this, arguments)`
           );
 
           return {
@@ -255,12 +258,7 @@ export default class ClassPatcher extends NodePatcher {
    * class.
    */
   generateInitClassMethod(nonMethodPatchers, customConstructorInfo, insertPoint) {
-    let bodyIndent = this.body.getIndent();
-    // If the body is inline, generate code at one indent level up instead of
-    // at the class indentation level.
-    if (bodyIndent === this.getIndent()) {
-      bodyIndent = this.getIndent(1);
-    }
+    let bodyIndent = this.getBodyIndent();
     let indentString = this.getProgramIndentString();
     this.insert(insertPoint, `\n${bodyIndent}@initClass: ->`);
     let assignmentNames = [];
@@ -285,6 +283,17 @@ export default class ClassPatcher extends NodePatcher {
 
     this.insert(insertPoint, `\n${bodyIndent}${indentString}return`);
     return assignmentNames;
+  }
+
+  getBodyIndent() {
+    let bodyNodeIndent = this.body.getIndent();
+    // If the body is inline, generate code at one indent level up instead of
+    // at the class indentation level.
+    if (bodyNodeIndent === this.getIndent()) {
+      return this.getIndent(1);
+    } else {
+      return bodyNodeIndent;
+    }
   }
 
   /**

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1066,6 +1066,25 @@ describe('classes', () => {
     `);
   });
 
+  it('handles a single-line class with an external constructor', () => {
+    check(`
+      f = ->
+      class A then constructor: f
+    `, `
+      let f = function() {};
+      let createA = undefined;
+      class A {
+        static initClass() {
+          createA = f;
+        }
+        constructor() {
+          return createA.apply(this, arguments);
+        }
+      }
+      A.initClass();
+    `);
+  });
+
   it('allows super calls within nested functions', () => {
     check(`
       class B extends A


### PR DESCRIPTION
Fixes #851

There was already some code to special-case the indent level for single-line
classes, so we just needed to reuse it when generating the constructor.