### PR TITLE
fix: don't specify a class name for namespaced classes

### DIFF
--- a/src/stages/main/patchers/ClassPatcher.js
+++ b/src/stages/main/patchers/ClassPatcher.js
@@ -1,6 +1,5 @@
 import ClassBlockPatcher from './ClassBlockPatcher';
 import IdentifierPatcher from './IdentifierPatcher';
-import MemberAccessOpPatcher from './MemberAccessOpPatcher';
 import NodePatcher from './../../../patchers/NodePatcher';
 import type { SourceToken, PatcherContext } from './../../../patchers/types';
 import { SourceType } from 'coffee-lex';
@@ -57,16 +56,9 @@ export default class ClassPatcher extends NodePatcher {
       // `class A.B` → `A.B`
       //  ^^^^^^
       this.remove(classToken.start, this.nameAssignee.outerStart);
-      let name = this.getName();
-      if (name) {
-        // `A.B` → `A.B = class B`
-        //             ^^^^^^^^^^
-        this.insert(this.nameAssignee.outerEnd, ` = class ${this.getName()}`);
-      } else {
-        // `A[0]` → `A[0] = class`
-        //               ^^^^^^^^
-        this.insert(this.nameAssignee.outerEnd, ` = class`);
-      }
+      // `A[0]` → `A[0] = class`
+      //               ^^^^^^^^
+      this.insert(this.nameAssignee.outerEnd, ` = class`);
     }
     if (this.nameAssignee) {
       this.nameAssignee.patch();
@@ -133,8 +125,6 @@ export default class ClassPatcher extends NodePatcher {
     let { nameAssignee } = this;
     if (nameAssignee instanceof IdentifierPatcher) {
       return nameAssignee.node.data;
-    } else if (nameAssignee instanceof MemberAccessOpPatcher) {
-      return nameAssignee.node.member.data;
     } else {
       return null;
     }

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -750,7 +750,7 @@ describe('classes', () => {
       class A.B
         a: -> 1
     `, `
-      A.B = class B {
+      A.B = class {
         a() { return 1; }
       };
     `);
@@ -1203,10 +1203,21 @@ describe('classes', () => {
     `, `
       class Outer {
         static initClass() {
-          this.Inner = class Inner {};
+          this.Inner = class {};
         }
       }
       Outer.initClass();
+    `);
+  });
+
+  it('handles a class this-assigned to a keyword name', () => {
+    check(`
+      ->
+        class @for
+    `, `
+      (function() {
+        return this.for = class {};
+      });
     `);
   });
 


### PR DESCRIPTION
Fixes #853

The code to put a name for the class was actually wrong, since it introduces a
name when it shouldn't. And in this case, it also introduced the use of a
keyword as an identifier, which caused a crash.