### PR TITLE
fix: allow duplicate class declarations

### DIFF
--- a/src/stages/main/patchers/ClassPatcher.js
+++ b/src/stages/main/patchers/ClassPatcher.js
@@ -56,8 +56,8 @@ export default class ClassPatcher extends NodePatcher {
       // `class A.B` → `A.B`
       //  ^^^^^^
       this.remove(classToken.start, this.nameAssignee.outerStart);
-      // `A[0]` → `A[0] = class`
-      //               ^^^^^^^^
+      // `A.B` → `A.B = class`
+      //             ^^^^^^^^
       this.insert(this.nameAssignee.outerEnd, ` = class`);
     }
     if (this.nameAssignee) {

--- a/src/stages/main/patchers/ClassPatcher.js
+++ b/src/stages/main/patchers/ClassPatcher.js
@@ -51,7 +51,7 @@ export default class ClassPatcher extends NodePatcher {
   }
 
   patchAsExpression() {
-    if (this.isNamespaced()) {
+    if (this.isNamespaced() || this.isNameAlreadyDeclared()) {
       let classToken = this.getClassToken();
       // `class A.B` → `A.B`
       //  ^^^^^^
@@ -116,6 +116,16 @@ export default class ClassPatcher extends NodePatcher {
    */
   isNamespaced(): boolean {
     return !this.isAnonymous() && !(this.nameAssignee instanceof IdentifierPatcher);
+  }
+
+  /**
+   * Determine if the name of this class already has a declaration earlier. If
+   * so, we want to emit an assignment-style class instead of a class
+   * declaration.
+   */
+  isNameAlreadyDeclared(): boolean {
+    let name = this.getName();
+    return name && this.node.scope.getBinding(name) !== this.nameAssignee.node;
   }
 
   /**

--- a/src/stages/normalize/patchers/ClassPatcher.js
+++ b/src/stages/normalize/patchers/ClassPatcher.js
@@ -335,15 +335,6 @@ export default class ClassPatcher extends NodePatcher {
         // @a: b -> @a = b
         return `${prefixCode}${keyCode}${suffixCode}`;
       }
-    } else if (statementPatcher instanceof ClassPatcher &&
-        statementPatcher.nameAssignee instanceof IdentifierPatcher) {
-      // Nested classes need a special case: they need to be converted to an
-      // assignment statement so that the name can be declared outside the outer
-      // class body and the initialized within initClass.
-      let className = statementPatcher.nameAssignee.node.data;
-      let prefix = this.slice(deleteStart, statementPatcher.outerStart);
-      let suffix = this.slice(statementPatcher.outerStart, statementPatcher.outerEnd);
-      return `${prefix}${className} = ${suffix}`;
     } else {
       return this.slice(deleteStart, statementPatcher.outerEnd);
     }

--- a/src/utils/Scope.js
+++ b/src/utils/Scope.js
@@ -99,6 +99,7 @@ export default class Scope {
       case 'Function':
       case 'BoundFunction':
       case 'GeneratorFunction':
+      case 'BoundGeneratorFunction':
         getBindingsForNode(node).forEach(identifier => this.declares(identifier.data, identifier));
         break;
 
@@ -111,6 +112,12 @@ export default class Scope {
             );
           }
         });
+        break;
+
+      case 'Class':
+        if (node.nameAssignee && node.nameAssignee.type === 'Identifier') {
+          this.assigns(node.nameAssignee.data, node.nameAssignee);
+        }
         break;
     }
   }
@@ -136,6 +143,7 @@ function getBindingsForNode(node: Node): Array<Node> {
     case 'Function':
     case 'GeneratorFunction':
     case 'BoundFunction':
+    case 'BoundGeneratorFunction':
       return flatMap(node.parameters, getBindingsForNode);
 
     case 'Identifier':

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -881,7 +881,7 @@ describe('classes', () => {
       let C = undefined;
       class A {
         static initClass() {
-          B = class B {
+          B = class {
             static initClass() {
               this.prototype.classField = 2;
             }
@@ -891,7 +891,7 @@ describe('classes', () => {
           };
           B.initClass();
           let CONSTANT = undefined;
-          C = class C {
+          C = class {
             static initClass() {
               CONSTANT = 7;
             }
@@ -1303,6 +1303,16 @@ describe('classes', () => {
       class A {
         [\`\${f()}, World\`]() { return 'Hello'; }
       }
+    `);
+  });
+
+  it('allows two class declarations with the same name', () => {
+    check(`
+      class A
+      class A
+    `, `
+      class A {}
+      A = class {};
     `);
   });
 });


### PR DESCRIPTION
Fixes #855

We now track class declarations in our scope, and only use the normal class
syntax if the class being patched is also the declaration site (the first
assignment seen by the scope).

This also lets us remove a special case in the `initClass` patching in the
normalize step. We don't need to explicitly create an assignment anymore,
because one is created automatically due to a variable with the same name being
declared above the class declaration.