### PR TITLE
fix: properly set the class name for complex class declarations

### DIFF
--- a/src/utils/isReservedWord.js.flow
+++ b/src/utils/isReservedWord.js.flow
@@ -1,3 +1,5 @@
 declare function isReservedWord(name: string): boolean;
+declare function isForbiddenJsName(name: string): boolean;
 
 export default isReservedWord;
+export { isForbiddenJsName };

--- a/src/utils/isReservedWord.ts
+++ b/src/utils/isReservedWord.ts
@@ -1,24 +1,46 @@
 // Taken from various constants in the CoffeeScript lexer:
 // https://github.com/jashkenas/coffeescript/blob/master/src/lexer.coffee
-const RESERVED_WORDS = new Set([
-  // JS_KEYWORDS
+
+const JS_KEYWORDS = [
   'true', 'false', 'null', 'this',
   'new', 'delete', 'typeof', 'in', 'instanceof',
   'return', 'throw', 'break', 'continue', 'debugger', 'yield',
   'if', 'else', 'switch', 'for', 'while', 'do', 'try', 'catch', 'finally',
   'class', 'extends', 'super',
   'import', 'export', 'default',
-  // COFFEE_KEYWORDS
+];
+
+const COFFEE_KEYWORDS = [
   'undefined', 'Infinity', 'NaN',
   'then', 'unless', 'until', 'loop', 'of', 'by', 'when',
-  // COFFEE_ALIASES
+];
+
+const COFFEE_ALIASES = [
   'and', 'or', 'is', 'isnt', 'not', 'yes', 'no', 'on', 'off',
-  // RESERVED
+];
+
+const RESERVED = [
   'case', 'default', 'function', 'var', 'void', 'with', 'const', 'let', 'enum',
   'export', 'import', 'native', 'implements', 'interface', 'package', 'private',
   'protected', 'public', 'static',
-  // STRICT_PROSCRIBED
+];
+
+const STRICT_PROSCRIBED = [
   'arguments', 'eval',
+];
+
+const JS_FORBIDDEN = new Set([
+  ...JS_KEYWORDS,
+  ...RESERVED,
+  ...STRICT_PROSCRIBED
+]);
+
+const RESERVED_WORDS = new Set([
+  ...JS_KEYWORDS,
+  ...COFFEE_KEYWORDS,
+  ...COFFEE_ALIASES,
+  ...RESERVED,
+  ...STRICT_PROSCRIBED,
   // Mentioned in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Future_reserved_keywords
   'await',
 ]);
@@ -31,4 +53,12 @@ const RESERVED_WORDS = new Set([
  */
 export default function isReservedWord(name: string): boolean {
   return RESERVED_WORDS.has(name);
+}
+
+/**
+ * Determine if the given name should not be used as a JavaScript variable,
+ * conforming to CoffeeScript's equivalent implementation.
+ */
+export function isForbiddenJsName(name: string): boolean {
+  return JS_FORBIDDEN.has(name);
 }

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -751,7 +751,7 @@ describe('classes', () => {
       class A.B
         a: -> 1
     `, `
-      A.B = class {
+      A.B = class B {
         a() { return 1; }
       };
     `);
@@ -881,7 +881,7 @@ describe('classes', () => {
       let C = undefined;
       class A {
         static initClass() {
-          B = class {
+          B = class B {
             static initClass() {
               this.prototype.classField = 2;
             }
@@ -891,7 +891,7 @@ describe('classes', () => {
           };
           B.initClass();
           let CONSTANT = undefined;
-          C = class {
+          C = class C {
             static initClass() {
               CONSTANT = 7;
             }
@@ -1223,7 +1223,7 @@ describe('classes', () => {
     `, `
       class Outer {
         static initClass() {
-          this.Inner = class {};
+          this.Inner = class Inner {};
         }
       }
       Outer.initClass();
@@ -1236,7 +1236,7 @@ describe('classes', () => {
         class @for
     `, `
       (function() {
-        return this.for = class {};
+        return this.for = class _for {};
       });
     `);
   });
@@ -1312,7 +1312,38 @@ describe('classes', () => {
       class A
     `, `
       class A {}
-      A = class {};
+      A = class A {};
     `);
+  });
+
+  it('assigns the right name to a normal class constructor', () => {
+    validate(`
+      class A
+      o = A.name
+    `, 'A');
+  });
+
+  it('assigns the right name to a class constructor for a property access', () => {
+    validate(`
+      A = {}
+      class A.B
+      o = A.B.name
+    `, 'B');
+  });
+
+  it('assigns the right name to a class constructor for a keyword', () => {
+    validate(`
+      A = {}
+      class A.for
+      o = A.for.name
+    `, '_for');
+  });
+
+  it('does not modify the constructor name for a CoffeeScript keyword', () => {
+    validate(`
+      A = {}
+      class A.or
+      o = A.or.name
+    `, 'or');
   });
 });


### PR DESCRIPTION
Fixes #861

This is mostly a revert of #854, although I also added some additional logic to
check if the generated name is a reserved JS word (copying CoffeeScript's set of
names) and add an underscore if so. I also added some tests to ensure that the
behavior matches CoffeeScript for these cases.