### PR TITLE
fix: allow computed keys for the names of bound methods

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -396,7 +396,7 @@ export default class NodePatcher {
       );
     }
     this.log(
-      'INSERT RIGHT',
+      'INSERT',
       index,
       JSON.stringify(content),
       'BEFORE',
@@ -405,6 +405,33 @@ export default class NodePatcher {
 
     this.adjustBoundsToInclude(index);
     this.editor.appendLeft(index, content);
+  }
+
+  /**
+   * Insert content at the specified index, before any content normally
+   * specified with `insert`. Note that this should be used sparingly. In almost
+   * every case, the correct behavior is to do all patching operations in order
+   * and always use `insert`. However, in some cases (like a constructor that
+   * needs the patched contents of the methods below it), we need to do patching
+   * out of order, so it's ok to use `prependLeft` to ensure that the code ends
+   * up before the later values.
+   */
+  prependLeft(index: number, content: string) {
+    if (typeof index !== 'number') {
+      throw new Error(
+        `cannot insert ${JSON.stringify(content)} at non-numeric index ${index}`
+      );
+    }
+    this.log(
+      'PREPEND LEFT',
+      index,
+      JSON.stringify(content),
+      'BEFORE',
+      JSON.stringify(this.context.source.slice(index, index + 8))
+    );
+
+    this.adjustBoundsToInclude(index);
+    this.editor.prependLeft(index, content);
   }
 
   allowPatchingOuterBounds(): boolean {
@@ -1130,6 +1157,15 @@ export default class NodePatcher {
   }
 
   /**
+   * Check if this expression has been marked as repeatable. Generally this
+   * should only be used for advanced cases, like transferring the repeat code
+   * result from one patcher to another.
+   */
+  isSetAsRepeatableExpression(): boolean {
+    return Boolean(this._repeatableOptions);
+  }
+
+  /**
    * Get the code snippet computed from patchAsRepeatableExpression that can be
    * used to refer to the result of this expression without further
    * side-effects.
@@ -1139,6 +1175,15 @@ export default class NodePatcher {
       throw new Error('Must patch as a repeatable expression to access repeat code.');
     }
     return this._repeatCode;
+  }
+
+  /**
+   * Explicitly set the repeatable result. Generally this should only be used
+   * for advanced cases, like transferring the repeat code result from one
+   * patcher to another.
+   */
+  overrideRepeatCode(repeatCode) {
+    this._repeatCode = repeatCode;
   }
 
   /**

--- a/src/patchers/types.js
+++ b/src/patchers/types.js
@@ -17,7 +17,9 @@ export type ParseContext = {
 };
 
 export type Editor = {
+  prependLeft: (index: number, content: string) => Editor;
   appendLeft: (index: number, content: string) => Editor;
+  prependRight: (index: number, content: string) => Editor;
   appendRight: (index: number, content: string) => Editor;
   overwrite: (start: number, end: number, content: string) => Editor;
   remove: (start: number, end: number) => Editor;

--- a/src/stages/main/patchers/ConstructorPatcher.js
+++ b/src/stages/main/patchers/ConstructorPatcher.js
@@ -1,6 +1,7 @@
 import ClassPatcher from './ClassPatcher';
 import ObjectBodyMemberPatcher from './ObjectBodyMemberPatcher';
 import babelConstructorWorkaroundLines from '../../../utils/babelConstructorWorkaroundLines';
+import getBindingCodeForMethod from '../../../utils/getBindingCodeForMethod';
 import getInvalidConstructorErrorMessage from '../../../utils/getInvalidConstructorErrorMessage';
 import traverse from '../../../utils/traverse';
 import { isFunction } from '../../../utils/types';
@@ -102,10 +103,7 @@ export default class ConstructorPatcher extends ObjectBodyMemberPatcher {
   getBindings(): Array<string> {
     if (!this._bindings) {
       let boundMethods = this.parent.boundInstanceMethods();
-      let bindings = boundMethods.map(method => {
-        let key = this.context.source.slice(method.key.contentStart, method.key.contentEnd);
-        return `this.${key} = this.${key}.bind(this)`;
-      });
+      let bindings = boundMethods.map(getBindingCodeForMethod);
       this._bindings = bindings;
     }
     return this._bindings;

--- a/src/utils/getBindingCodeForMethod.js
+++ b/src/utils/getBindingCodeForMethod.js
@@ -1,0 +1,12 @@
+import IdentifierPatcher from '../stages/main/patchers/IdentifierPatcher';
+import type ClassAssignOpPatcher from '../stages/main/patchers/ClassAssignOpPatcher';
+
+export default function getBindingCodeForMethod(method: ClassAssignOpPatcher): string {
+  let accessCode;
+  if (method.key instanceof IdentifierPatcher) {
+    accessCode = `.${method.key.node.data}`;
+  } else {
+    accessCode = `[${method.key.getRepeatCode()}]`;
+  }
+  return `this${accessCode} = this${accessCode}.bind(this)`;
+}

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1346,4 +1346,72 @@ describe('classes', () => {
       o = A.or.name
     `, 'or');
   });
+
+  it('allows bound methods with non-identifier names that can be simplified', () => {
+    check(`
+      class A
+        "#{b}": => c
+    `, `
+      class A {
+        constructor() {
+          this[b] = this[b].bind(this);
+        }
+      
+        [b]() { return c; }
+      }
+    `);
+  });
+
+  it('allows bound methods with complex non-identifier names', () => {
+    check(`
+      class A
+        "#{b}foo": => c
+    `, `
+      class A {
+        constructor() {
+          this[\`\${b}foo\`] = this[\`\${b}foo\`].bind(this);
+        }
+      
+        [\`\${b}foo\`]() { return c; }
+      }
+    `);
+  });
+
+  it('allows bound methods with non-identifier names that can be simplified with an existing constructor', () => {
+    check(`
+      class A
+        constructor: ->
+          console.log 'got here'
+      
+        "#{b}": => c
+    `, `
+      class A {
+        constructor() {
+          this[b] = this[b].bind(this);
+          console.log('got here');
+        }
+      
+        [b]() { return c; }
+      }
+    `);
+  });
+
+  it('allows bound methods with complex non-identifier names with an existing constructor', () => {
+    check(`
+      class A
+        constructor: ->
+          console.log 'got here'
+      
+        "#{b}foo": => c
+    `, `
+      class A {
+        constructor() {
+          this[\`\${b}foo\`] = this[\`\${b}foo\`].bind(this);
+          console.log('got here');
+        }
+      
+        [\`\${b}foo\`]() { return c; }
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #858

The basic idea is that we make sure all bound method keys are repeatable and
that method bindings are patched after the bound method keys are, then use that
information if necessary to generate a method binding line using square bracket
notation.

There were some nuances here:
* We now need to change the patching order so constructors are patched last, so
  that we have the patched values for method names to bind. This means that we
  need to explicitly do so in BlockPatcher, and in the case where we introduce
  the constructor, we want to introduce it at the top of the class but after the
  class contents are patched. Since normally patching needs to be done in order,
  I added a way to use the `prependLeft` method from magic-string for special
  cases where we know that patching needs to be done out of order.
* Since there's a special case that a `"#{a}"` key turns into `[a]`, we need to
  properly handle the case where the string expression is repeatable. This
  requires extending the repeatable protocol a little.