### PR TITLE
fix: always generate an assignment for expression-style classes

### DIFF
--- a/src/stages/main/patchers/ClassPatcher.js
+++ b/src/stages/main/patchers/ClassPatcher.js
@@ -53,7 +53,8 @@ export default class ClassPatcher extends NodePatcher {
   }
 
   patchAsExpression() {
-    if (this.isNamespaced() || this.isNameAlreadyDeclared()) {
+    if (this.nameAssignee &&
+        (this.isNamespaced() || this.isNameAlreadyDeclared() || this.willPatchAsExpression())) {
       let classToken = this.getClassToken();
       // `class A.B` → `A.B`
       //  ^^^^^^


### PR DESCRIPTION
Fixes #867

Unlike in JavaScript, CoffeeScript named classes assign to their outer scope, so
we need an explicit assignment unless we know the class will be a JS class
declaration statement.