### PR TITLE
fix: allow super within methods with non-identifier names

### DIFF
--- a/src/stages/main/patchers/SuperPatcher.js
+++ b/src/stages/main/patchers/SuperPatcher.js
@@ -6,6 +6,7 @@ import ClassAssignOpPatcher from './ClassAssignOpPatcher';
 import ConstructorPatcher from './ConstructorPatcher';
 import DynamicMemberAccessOpPatcher from './DynamicMemberAccessOpPatcher';
 import FunctionPatcher from './FunctionPatcher';
+import IdentifierPatcher from './IdentifierPatcher';
 import MemberAccessOpPatcher from './MemberAccessOpPatcher';
 import extractPrototypeAssignPatchers from '../../../utils/extractPrototypeAssignPatchers';
 
@@ -55,15 +56,19 @@ export default class SuperPatcher extends NodePatcher {
   getEnclosingMethodInfo(): MethodInfo {
     let methodAssignment = this.getEnclosingMethodAssignment();
     if (methodAssignment instanceof ClassAssignOpPatcher) {
-      let methodName;
+      let accessCode;
       if (methodAssignment.isStaticMethod()) {
-        methodName = methodAssignment.key.node.member.data;
+        accessCode = `.${methodAssignment.key.node.member.data}`;
       } else {
-        methodName = methodAssignment.key.node.data;
+        if (methodAssignment.key instanceof IdentifierPatcher) {
+          accessCode = `.${methodAssignment.key.node.data}`;
+        } else {
+          accessCode = `[${methodAssignment.key.getRepeatCode()}]`;
+        }
       }
       return {
         classCode: this.getEnclosingClassName(methodAssignment),
-        accessCode: `.${methodName}`,
+        accessCode,
       };
     } else if (methodAssignment instanceof ConstructorPatcher) {
       return {

--- a/test/super_test.js
+++ b/test/super_test.js
@@ -88,4 +88,27 @@ describe('super', () => {
       A().prototype[b()] = () => 3;
     `);
   });
+
+  it('allows super on a method with a non-identifier name', () => {
+    check(`
+      class A
+        0: -> super
+    `, `
+      class A {
+        [0]() { return super[0](...arguments); }
+      }
+    `);
+  });
+
+  it('allows super on a method with a non-repeatable computed name', () => {
+    check(`
+      class A
+        "#{b()}": -> super
+    `, `
+      let ref;
+      class A {
+        [ref = b()]() { return super[ref](...arguments); }
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #869

When we have a method containing `super`, we mark the name as repeatable, then
in the super call, we get that repeat code if necessary.

Note that this doesn't yet address static methods. Those will need to be handled
in the fix for #860.