### PR TITLE
fix: properly specify parens under unary operators

### DIFF
--- a/src/stages/main/patchers/UnaryOpPatcher.js
+++ b/src/stages/main/patchers/UnaryOpPatcher.js
@@ -16,8 +16,8 @@ export default class UnaryOpPatcher extends NodePatcher {
   /**
    * OP EXPRESSION
    */
-  patchAsExpression({ needsParens=true }={}) {
-    this.expression.patch({ needsParens });
+  patchAsExpression() {
+    this.expression.patch({ needsParens: true });
   }
 
   /**

--- a/test/unary_operator_test.js
+++ b/test/unary_operator_test.js
@@ -102,4 +102,15 @@ describe('unary operators', () => {
       a => a == null;
     `);
   });
+
+  it('properly respects precedence with a unary operator in a conditional', () => {
+    check(`
+      unless typeof a.b?
+        c
+    `, `
+      if (!typeof (a.b != null)) {
+        c;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #872

The previous logic for unary operators was to propagate the `needsParens`
patching flag to the child, but that actually isn't valid. Even if the unary
operator is in a context where it doesn't need additional parens (e.g. a
conditional), its operand might be a binary operator that needs parens, so just
pass true for `needsParens`.