### PR TITLE
fix: allow semicolon delimiters for lists

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -853,6 +853,17 @@ export default class NodePatcher {
   }
 
   /**
+   * Gets the token after the end of this node, or null if there is none.
+   */
+  nextToken(): ?SourceToken {
+    let nextTokenIndex = this.contentEndTokenIndex.next();
+    if (!nextTokenIndex) {
+      return null;
+    }
+    return this.sourceTokenAtIndex(nextTokenIndex);
+  }
+
+  /**
    * Gets the original source of this patcher's node.
    */
   getOriginalSource(): string {

--- a/src/stages/normalize/patchers/ArrayInitialiserPatcher.js
+++ b/src/stages/normalize/patchers/ArrayInitialiserPatcher.js
@@ -1,6 +1,6 @@
 import NodePatcher from './../../../patchers/NodePatcher';
 import type { PatcherContext } from './../../../patchers/types';
-import { SourceType } from 'coffee-lex';
+import normalizeListItem from '../../../utils/normalizeListItem';
 
 export default class ArrayInitialiserPatcher extends NodePatcher {
   members: Array<NodePatcher>;
@@ -12,15 +12,8 @@ export default class ArrayInitialiserPatcher extends NodePatcher {
 
   patchAsExpression() {
     for (let member of this.members) {
-      // If the last token of the arg is a comma, then the actual delimiter must
-      // be a newline and the comma is unnecessary and can cause a syntax error
-      // when combined with other normalize stage transformations. So just
-      // remove the redundant comma.
-      let lastToken = member.lastToken();
-      if (lastToken.type === SourceType.COMMA) {
-        this.remove(lastToken.start, lastToken.end);
-      }
       member.patch();
+      normalizeListItem(this, member);
     }
   }
 }

--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.js
@@ -1,6 +1,7 @@
 import { SourceType } from 'coffee-lex';
 
 import NodePatcher from './../../../patchers/NodePatcher';
+import normalizeListItem from '../../../utils/normalizeListItem';
 import type { PatcherContext } from './../../../patchers/types';
 
 export default class FunctionApplicationPatcher extends NodePatcher {
@@ -32,15 +33,8 @@ export default class FunctionApplicationPatcher extends NodePatcher {
     }
 
     for (let arg of args) {
-      // If the last token of the arg is a comma, then the actual delimiter must
-      // be a newline and the comma is unnecessary and can cause a syntax error
-      // when combined with other normalize stage transformations. So just
-      // remove the redundant comma.
-      let lastToken = arg.lastToken();
-      if (lastToken.type === SourceType.COMMA) {
-        this.remove(lastToken.start, lastToken.end);
-      }
       arg.patch();
+      normalizeListItem(this, arg);
     }
 
     if (implicitCall) {

--- a/src/stages/normalize/patchers/FunctionPatcher.js
+++ b/src/stages/normalize/patchers/FunctionPatcher.js
@@ -1,3 +1,4 @@
+import { SourceType } from 'coffee-lex';
 import ArrayInitialiserPatcher from './ArrayInitialiserPatcher';
 import DefaultParamPatcher from './DefaultParamPatcher';
 import ExpansionPatcher from './ExpansionPatcher';
@@ -5,6 +6,7 @@ import IdentifierPatcher from './IdentifierPatcher';
 import RestPatcher from './SpreadPatcher';
 import NodePatcher from './../../../patchers/NodePatcher';
 import canPatchAssigneeToJavaScript from '../../../utils/canPatchAssigneeToJavaScript';
+import normalizeListItem from '../../../utils/normalizeListItem';
 import stripSharedIndent from '../../../utils/stripSharedIndent';
 
 import type { PatcherContext } from './../../../patchers/types';
@@ -34,6 +36,15 @@ export default class FunctionPatcher extends NodePatcher {
         assignments.push(...this.patchParameterAndGetAssignments(parameter));
       } else {
         parameter.patch();
+      }
+      normalizeListItem(this, parameter);
+      if (i === this.parameters.length - 1) {
+        // Parameter lists allow trailing semicolons but not trailing commas, so
+        // just get rid of it as a special case if it's there.
+        let nextToken = parameter.nextToken();
+        if (nextToken && nextToken.type === SourceType.SEMICOLON) {
+          this.remove(nextToken.start, nextToken.end);
+        }
       }
     }
 

--- a/src/stages/normalize/patchers/ObjectInitialiserPatcher.js
+++ b/src/stages/normalize/patchers/ObjectInitialiserPatcher.js
@@ -1,6 +1,6 @@
 import NodePatcher from './../../../patchers/NodePatcher';
+import normalizeListItem from '../../../utils/normalizeListItem';
 import type { PatcherContext } from './../../../patchers/types';
-import { SourceType } from 'coffee-lex';
 
 /**
  * Handles object literals.
@@ -15,15 +15,8 @@ export default class ObjectInitialiserPatcher extends NodePatcher {
 
   patchAsExpression() {
     for (let member of this.members) {
-      // If the last token of the arg is a comma, then the actual delimiter must
-      // be a newline and the comma is unnecessary and can cause a syntax error
-      // when combined with other normalize stage transformations. So just
-      // remove the redundant comma.
-      let lastToken = member.lastToken();
-      if (lastToken.type === SourceType.COMMA) {
-        this.remove(lastToken.start, lastToken.end);
-      }
       member.patch();
+      normalizeListItem(this, member);
     }
   }
 }

--- a/src/utils/normalizeListItem.js
+++ b/src/utils/normalizeListItem.js
@@ -1,0 +1,25 @@
+import { SourceType } from 'coffee-lex';
+
+import type NodePatcher from '../patchers/NodePatcher';
+
+/**
+ * Given a list item (i.e. one element of an array literal, object literal,
+ * function invocation, etc), run some normalize steps to simplify this type of
+ * syntax in the normalize stage.
+ */
+export default function normalizeListItem(patcher: NodePatcher, listItemPatcher: NodePatcher) {
+  // If the last token of the arg is a comma, then the actual delimiter must
+  // be a newline and the comma is unnecessary and can cause a syntax error
+  // when combined with other normalize stage transformations. So just
+  // remove the redundant comma.
+  let lastToken = listItemPatcher.lastToken();
+  if (lastToken.type === SourceType.COMMA) {
+    patcher.remove(lastToken.start, lastToken.end);
+  }
+  // CoffeeScript allows semicolon-separated lists, so just change them to
+  // commas if we see them.
+  let nextToken = listItemPatcher.nextToken();
+  if (nextToken && nextToken.type === SourceType.SEMICOLON && nextToken.end <= patcher.contentEnd) {
+    patcher.overwrite(nextToken.start, nextToken.end, ',');
+  }
+}

--- a/test/array_test.js
+++ b/test/array_test.js
@@ -133,4 +133,12 @@ describe('arrays', () => {
       }];
     `)
   );
+
+  it('allows semicolon delimiters between array values', () =>
+    check(`
+      [a, b; c, d;]
+    `, `
+      [a, b, c, d,];
+    `)
+  );
 });

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -623,4 +623,12 @@ describe('function calls', () => {
       f;
     `);
   });
+
+  it('allows semicolon delimiters between arguments', () => {
+    check(`
+      a(b, c; d, e;)
+    `, `
+      a(b, c, d, e);
+    `);
+  });
 });

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -413,4 +413,12 @@ describe('functions', () => {
       });
     `)
   );
+
+  it('allows semicolon delimiters between parameters', () =>
+    check(`
+      (a, b; c, d;) ->
+    `, `
+      (function(a, b, c, d) {});
+    `)
+  );
 });

--- a/test/object_test.js
+++ b/test/object_test.js
@@ -375,4 +375,12 @@ describe('objects', () => {
       ];
     `);
   });
+
+  it('allows semicolon delimiters between object values', () => {
+    check(`
+      {a: b, c: d; e: f, g: h;}
+    `, `
+      ({a: b, c: d, e: f, g: h,});
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #856

In the normalize step, we just replace the semicolon with a comma, except at the
end of a parameter list when we need to just remove it.