### PR TITLE
fix: properly use generators for IIFEs when necessary

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -4,8 +4,9 @@ import repeat from 'repeating';
 import type { SourceToken, SourceTokenListIndex, RepeatableOptions, PatcherContext, ParseContext, Editor, SourceTokenList } from './types';
 import type { Options } from '../index';
 import { SourceType } from 'coffee-lex';
-import { isSemanticToken } from '../utils/types';
+import { isFunction, isSemanticToken } from '../utils/types';
 import { logger } from '../utils/debug';
+import traverse from '../utils/traverse';
 
 export default class NodePatcher {
   node: Node;
@@ -29,6 +30,7 @@ export default class NodePatcher {
   outerEndTokenIndex: SourceTokenListIndex;
 
   adjustedIndentLevel: number = 0;
+  yielding: boolean = false;
 
   constructor({node, context, editor, options}: PatcherContext) {
     this.log = logger(this.constructor.name);
@@ -1200,16 +1202,6 @@ export default class NodePatcher {
     return true;
   }
 
-  yields() {
-    let receiver = this.parent;
-    while (receiver) {
-      if (receiver.yieldController) {
-        return receiver.yieldController();
-      }
-      receiver = receiver.parent;
-    }
-  }
-
   /**
    * Gets the first "interesting token" in the indexed range (default range is `this` + parent)
    */
@@ -1225,5 +1217,49 @@ export default class NodePatcher {
    */
   mayBeUnboundReference() {
     return false;
+  }
+
+  patchInIIFE(innerPatchFn: () => void) {
+    if (this.yielding) {
+      this.insert(this.innerStart, 'yield* (function*() {');
+    } else {
+      this.insert(this.innerStart, '(() => {');
+    }
+    innerPatchFn();
+    if (this.yielding) {
+      if (this.referencesArguments()) {
+        this.insert(this.innerEnd, '}).apply(this, arguments)');
+      } else {
+        this.insert(this.innerEnd, '}).call(this)');
+      }
+    } else {
+      this.insert(this.innerEnd, '})()');
+    }
+  }
+
+  yields() {
+    this.yielding = true;
+    if (this.parent && !isFunction(this.parent.node)) {
+      this.parent.yields();
+    }
+  }
+
+  /**
+   * @private
+   */
+  referencesArguments() {
+    let result = false;
+
+    traverse(this.node, node => {
+      if (result || isFunction(node)) {
+        return false;
+      }
+
+      if (node.type === 'Identifier' && node.data === 'arguments') {
+        result = true;
+      }
+    });
+
+    return result;
   }
 }

--- a/src/stages/main/patchers/ConditionalPatcher.js
+++ b/src/stages/main/patchers/ConditionalPatcher.js
@@ -140,9 +140,11 @@ export default class ConditionalPatcher extends NodePatcher {
       this.alternate.setShouldPatchInline(false);
       this.alternate.setImplicitlyReturns();
     }
-    this.insert(this.innerStart, `(() => {\n${conditionIndent}`);
-    this.patchAsStatement();
-    this.insert(this.innerEnd, `\n${baseIndent}})()`);
+    this.patchInIIFE(() => {
+      this.insert(this.innerStart, `\n${conditionIndent}`);
+      this.patchAsStatement();
+      this.insert(this.innerEnd, `\n${baseIndent}`);
+    });
   }
 
   canHandleImplicitReturn(): boolean {

--- a/src/stages/main/patchers/SwitchPatcher.js
+++ b/src/stages/main/patchers/SwitchPatcher.js
@@ -68,14 +68,11 @@ export default class SwitchPatcher extends NodePatcher {
   patchAsExpression() {
     this.setImplicitlyReturns();
 
-    // `` → `(() => { `
-    //       ^^^^^^^^^
-    this.insert(this.contentStart, '(() => { ');
-    this.patchAsStatement();
-
-    // `` → ` })()`
-    //       ^^^^^
-    this.appendToEndOfLine(' })()');
+    this.patchInIIFE(() => {
+      this.insert(this.innerStart, ' ');
+      this.patchAsStatement();
+      this.insert(this.innerEnd, ' ');
+    });
   }
 
   canHandleImplicitReturn(): boolean {

--- a/src/stages/main/patchers/TryPatcher.js
+++ b/src/stages/main/patchers/TryPatcher.js
@@ -122,13 +122,11 @@ export default class TryPatcher extends NodePatcher {
     // Make our children return since we're wrapping in a function.
     this.setImplicitlyReturns();
 
-    // `a = try b()` → `a = (() => { try b()`
-    //                      ^^^^^^^^^
-    this.insert(this.contentStart, '(() => { ');
-    this.patchAsStatement();
-    // `a = (() => { try { b(); } catch (error) {}` → `a = (() => { try { b(); } catch (error) {} })()`
-    //                                                                                           ^^^^^
-    this.insert(this.contentEnd, ' })()');
+    this.patchInIIFE(() => {
+      this.insert(this.innerStart, ' ');
+      this.patchAsStatement();
+      this.insert(this.innerEnd, ' ');
+    });
   }
 
   setImplicitlyReturns() {

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -639,4 +639,26 @@ describe('conditionals', () => {
       );
     `);
   });
+
+  it('handles an IIFE-style conditional containing a yield', () => {
+    check(`
+      ->
+        x = if a
+          if b
+            c
+          yield d
+    `, `
+      (function*() {
+        let x;
+        return x = yield* (function*() {
+          if (a) {
+          if (b) {
+            c;
+          }
+          return yield d;
+        }
+        }).call(this);
+      });
+    `);
+  });
 });

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1278,4 +1278,32 @@ describe('for loops', () => {
       for (let step = (() => d)(), asc = step > 0, i = asc ? 0 : c.length - 1; asc ? i < c.length : i >= 0; i += step) { let b = c[i]; a; }
     `);
   });
+
+  it('handles a deeply nested yield in an IIFE loop', () => {
+    check(`
+      ->
+        for a in b by 1
+            ->
+              c
+              ->
+                yield d
+
+    `, `
+      () =>
+        (() => {
+          let result = [];
+          for (let i = 0; i < b.length; i++) {
+            let a = b[i];
+            result.push(function() {
+              c;
+              return function*() {
+                return yield d;
+              };
+            });
+          }
+          return result;
+        })()
+      ;
+    `);
+  });
 });

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -471,4 +471,21 @@ describe('switch', () => {
       }
     `);
   });
+
+  it('allows an IIFE-style switch inside a generator', () => {
+    check(`
+      ->
+        x = switch yield 1
+          when 2
+            3
+    `, `
+      (function*() {
+        let x;
+        return x = yield* (function*() { switch ((yield 1)) {
+          case 2:
+            return 3;
+        } }).call(this);
+      });
+    `);
+  });
 });

--- a/test/try_test.js
+++ b/test/try_test.js
@@ -262,4 +262,24 @@ describe('try', () => {
       if (!(() => { try { return a; } catch (b) { return c; } })()) { d; }
     `);
   });
+
+  it('handles an IIFE-style try statement with a yield', () => {
+    check(`
+      () ->
+        x = try
+          yield 1
+        catch
+          yield 2
+    `, `
+      (function*() {
+        let x;
+        return x = yield* (function*() { try {
+          return yield 1;
+        } catch (error) {
+          return yield 2;
+        } }).call(this);
+      });
+    `);
+  });
+
 });


### PR DESCRIPTION
Fixes #857

The loop case already handled this, so getting it working in all cases just
meant moving that code up to `NodePatcher` and using it in all of the IIFE
cases.