### PR TITLE
fix: avoid bounds error when patching an implicit object literal

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -485,8 +485,6 @@ export default class NodePatcher {
    * When editing outside a node's bounds we expand the bounds to fit, if
    * possible. Note that if a node or a node's parent is wrapped in parentheses
    * we cannot adjust the bounds beyond the inside of the parentheses.
-   *
-   * @private
    */
   adjustBoundsToInclude(index: number) {
     this.assertEditableIndex(index);

--- a/src/stages/main/patchers/BinaryOpPatcher.js
+++ b/src/stages/main/patchers/BinaryOpPatcher.js
@@ -17,7 +17,16 @@ export default class BinaryOpPatcher extends NodePatcher {
 
   initialize() {
     this.left.setRequiresExpression();
-    this.right.setRequiresExpression();
+    if (!this.rhsMayBeStatement()) {
+      this.right.setRequiresExpression();
+    }
+  }
+
+  /**
+   * Subclasses can override to avoid setting the RHS as an expression by default.
+   */
+  rhsMayBeStatement() {
+    return false;
   }
 
   negate() {

--- a/src/stages/main/patchers/ExistsOpPatcher.js
+++ b/src/stages/main/patchers/ExistsOpPatcher.js
@@ -2,6 +2,18 @@ import BinaryOpPatcher from './BinaryOpPatcher';
 
 export default class ExistsOpPatcher extends BinaryOpPatcher {
   /**
+   * If we are a statement, the RHS should be patched as a statement.
+   */
+  rhsMayBeStatement() {
+    return true;
+  }
+
+  setExpression(force) {
+    this.right.setRequiresExpression();
+    super.setExpression(force);
+  }
+
+  /**
    * LEFT '?' RIGHT → `LEFT != null ? LEFT : RIGHT`
    */
   patchAsExpression() {

--- a/test/object_test.js
+++ b/test/object_test.js
@@ -383,4 +383,30 @@ describe('objects', () => {
       ({a: b, c: d, e: f, g: h,});
     `);
   });
+
+  it('handles implicit objects after an existence operator in an expression context', () => {
+    check(`
+      a = b ?
+        c: d
+        e: f
+    `, `
+      let a = typeof b !== 'undefined' && b !== null ? b : {
+        c: d,
+        e: f
+      };
+    `);
+  });
+
+  it('handles implicit objects after an existence operator in a statement context', () => {
+    check(`
+      a ?
+        b: c
+        d: e
+    `, `
+      if (typeof a === 'undefined' || a === null) { ({
+          b: c,
+          d: e
+        }); }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #689

There's a lot of logic to find a nice-looking place for the open-brace, but
generally it might be in a safe place that's before our bounds. But that means
that other patchers, like the exists op patcher, might have already written
there. To avoid this, we now call `adjustBoundsToInclude` to effectively
"reserve" that area. This required a little bit of extra care so that we only
actually adjust the bounds when we're being patched as an expression, and
ExistsOpPatcher needs to patch its child as a statement when necessary.