### PR TITLE
fix: properly patch code around for-of loop targets

### DIFF
--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1306,4 +1306,32 @@ describe('for loops', () => {
       ;
     `);
   });
+
+  it('handles an existence op for-of loop target with a non-repeatable LHS', () => {
+    check(`
+      for k, v of a() ? b
+        c
+    `, `
+      let left;
+      let object = (left = a()) != null ? left : b;
+      for (let k in object) {
+        let v = object[k];
+        c;
+      }
+    `);
+  });
+
+  it('handles an existence op for-own loop target with a non-repeatable LHS', () => {
+    check(`
+      for own k, v of a() ? b
+        c
+    `, `
+      let left;
+      let object = (left = a()) != null ? left : b;
+      for (let k of Object.keys(object || {})) {
+        let v = object[k];
+        c;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #884

In some cases, some code could end up left over on the left side after patching
the target, due to using magic-string's `appendLeft`. To avoid this, we can
always do an overwrite operation for the target and its surrounding code when we
know that we're extracting the target into a variable.