### PR TITLE
fix: remove the Unicode BOM if necessary at the start of the code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import formatCoffeeScriptLexerTokens from './utils/formatCoffeeScriptLexerTokens
 import formatDecaffeinateParserAst from './utils/formatDecaffeinateParserAst';
 import parse from './utils/parse';
 import PatchError from './utils/PatchError';
+import removeUnicodeBOMIfNecessary from './utils/removeUnicodeBOMIfNecessary';
 import resolveToPatchError from './utils/resolveToPatchError';
 
 export { default as run } from './cli';
@@ -58,6 +59,7 @@ type Stage = {
  * and formatting.
  */
 export function convert(source: string, options: ?Options={}): ConversionResult {
+  source = removeUnicodeBOMIfNecessary(source);
   options = Object.assign({}, DEFAULT_OPTIONS, options);
   let originalNewlineStr = detectNewlineStr(source);
   source = convertNewlines(source, '\n');

--- a/src/utils/removeUnicodeBOMIfNecessary.ts
+++ b/src/utils/removeUnicodeBOMIfNecessary.ts
@@ -1,0 +1,12 @@
+/**
+ * If the source code starts with a Unicode BOM, CoffeeScript will just ignore
+ * it and provide source code locations that assume that it was removed, so we
+ * should do the same.
+ */
+export default function removeUnicodeBOMIfNecessary(source: string): string {
+    if (source[0] === '\uFEFF') {
+        return source.slice(1);
+    } else {
+        return source;
+    }
+}

--- a/test/decaffeinate_test.js
+++ b/test/decaffeinate_test.js
@@ -12,6 +12,10 @@ describe('decaffeinate', () => {
   it('handles empty programs', () => {
     check(``, ``);
   });
+
+  it('handles code starting with a unicode BOM', () => {
+    check(`\uFEFFa`, `a;`);
+  });
 });
 
 describe('automatic conversions', () => {


### PR DESCRIPTION
Fixes #891

Unicode byte order mark characters normally aren't a problem for us, except that
CoffeeScript has a special case to remove them at the start, so it gives all
source indexes as if the BOM was removed. To avoid running into issues there, we
can just do the same. As with newline formats, this is just handled at the
decaffeinate layer and coffee-lex and decaffeinate-parser can assume the simpler
format (although they could also be made more robust later if it's useful).