### PR TITLE
fix: don't patch out of bounds when placing close-parens

### DIFF
--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.js
@@ -64,7 +64,10 @@ export default class FunctionApplicationPatcher extends NodePatcher {
 
     let followingCloseParen = this.getFollowingCloseParenIfExists();
     if (followingCloseParen) {
-      this.insert(followingCloseParen.start, ')');
+      // In some cases, (e.g. within function args) our bounds are extended to
+      // allow us to patch the close-paren all the way up to the start of the
+      // following close-paren, but don't patch past the end of those bounds.
+      this.insert(Math.min(followingCloseParen.start, this.getEditingBounds()[1]), ')');
       return;
     }
 

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -437,4 +437,19 @@ describe('functions', () => {
       x(() => ({a: b}));
     `)
   );
+
+  it('handles nested functions surrounded in parens', () =>
+    check(`
+      (->
+        a ->
+          b ->
+            c
+      )
+    `, `
+      () =>
+        a(() =>
+          b(() => c)
+      );
+    `)
+  );
 });


### PR DESCRIPTION
Fixes #744

In some cases, the computed `innerEnd` (which usually defines the editing
bounds) can be strictly before the following close-paren, so trying to patch at
the start of the following close-paren will give an error. In other cases, we
need to patch after `innerEnd` and the editing bounds are extended. To handle
both cases, we allow patching up to the end of the editing bounds, but not
further.