### PR TITLE
fix: surround postfix if/while/for in parens when necessary

### DIFF
--- a/src/stages/normalize/patchers/ConditionalPatcher.js
+++ b/src/stages/normalize/patchers/ConditionalPatcher.js
@@ -3,6 +3,7 @@ import type { SourceTokenListIndex } from 'coffee-lex';
 
 import NodePatcher from '../../../patchers/NodePatcher';
 import postfixExpressionRequiresParens from '../../../utils/postfixExpressionRequiresParens';
+import postfixNodeNeedsOuterParens from '../../../utils/postfixNodeNeedsOuterParens';
 import type { PatcherContext } from './../../../patchers/types';
 
 /**
@@ -58,7 +59,15 @@ export default class ConditionalPatcher extends NodePatcher {
     if (ifToken) {
       let consequentCode = this.slice(this.consequent.outerStart, this.consequent.outerEnd);
       this.remove(this.consequent.outerStart, ifToken.start);
+
+      let needsParens = postfixNodeNeedsOuterParens(this);
+      if (needsParens) {
+        this.insert(ifToken.start, '(');
+      }
       this.insert(this.condition.outerEnd, ` then ${consequentCode}`);
+      if (needsParens) {
+        this.insert(this.condition.outerEnd, ')');
+      }
     }
   }
 

--- a/src/stages/normalize/patchers/ForPatcher.js
+++ b/src/stages/normalize/patchers/ForPatcher.js
@@ -3,6 +3,7 @@ import { SourceType } from 'coffee-lex';
 import NodePatcher from '../../../patchers/NodePatcher';
 import canPatchAssigneeToJavaScript from '../../../utils/canPatchAssigneeToJavaScript';
 import postfixExpressionRequiresParens from '../../../utils/postfixExpressionRequiresParens';
+import postfixNodeNeedsOuterParens from '../../../utils/postfixNodeNeedsOuterParens';
 import type { PatcherContext, SourceToken } from './../../../patchers/types';
 
 export default class ForPatcher extends NodePatcher {
@@ -40,8 +41,16 @@ export default class ForPatcher extends NodePatcher {
       this.surroundThenUsagesInParens();
       let forToken = this.getForToken();
       let forThroughEnd = this.slice(forToken.start, this.contentEnd);
+
+      let needsParens = postfixNodeNeedsOuterParens(this);
       this.remove(this.body.outerEnd, this.contentEnd);
+      if (needsParens) {
+        this.insert(this.body.outerStart, '(');
+      }
       this.insert(this.body.outerStart, `${forThroughEnd} then `);
+      if (needsParens) {
+        this.insert(this.contentEnd, ')');
+      }
     }
 
     if (bodyPrefixLine !== null) {

--- a/src/stages/normalize/patchers/WhilePatcher.js
+++ b/src/stages/normalize/patchers/WhilePatcher.js
@@ -1,5 +1,6 @@
 import NodePatcher from '../../../patchers/NodePatcher';
 import postfixExpressionRequiresParens from '../../../utils/postfixExpressionRequiresParens';
+import postfixNodeNeedsOuterParens from '../../../utils/postfixNodeNeedsOuterParens';
 
 import type { PatcherContext } from './../../../patchers/types';
 
@@ -68,10 +69,14 @@ export default class WhilePatcher extends NodePatcher {
       patchedGuard = `(${patchedGuard})`;
     }
     let whileToken = this.node.isUntil ? 'until' : 'while';
+    let newContent = `${whileToken} ${patchedCondition} ${patchedGuard ? `when ${patchedGuard} ` : ''}then ${patchedBody}`;
+    if (postfixNodeNeedsOuterParens(this)) {
+      newContent = `(${newContent})`;
+    }
     this.overwrite(
       this.contentStart,
       this.contentEnd,
-      `${whileToken} ${patchedCondition} ${patchedGuard ? `when ${patchedGuard} ` : ''}then ${patchedBody}`
+      newContent
     );
   }
 

--- a/src/utils/postfixNodeNeedsOuterParens.js
+++ b/src/utils/postfixNodeNeedsOuterParens.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+import { SourceType } from 'coffee-lex';
+import type NodePatcher from '../patchers/NodePatcher';
+
+/**
+ * Determine if the given postfix if/while/for needs to have parens wrapped
+ * around it while it is reordered. This happens when the expression has a comma
+ * after it as part of a list (function args, array initializer, or object
+ * initializer).
+ */
+export default function postfixNodeNeedsOuterParens(patcher: NodePatcher): boolean {
+  let nextToken = patcher.nextToken();
+  if (nextToken) {
+    return nextToken.type === SourceType.COMMA;
+  }
+  return false;
+}

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -661,4 +661,28 @@ describe('conditionals', () => {
       });
     `);
   });
+
+  it('handles a post-while as a function argument', () => {
+    check(`
+      a(b if c, d)
+    `, `
+      a((c ? b : undefined), d);
+    `);
+  });
+
+  it('handles a post-while as an array element', () => {
+    check(`
+      [a if b, c]
+    `, `
+      [(b ? a : undefined), c];
+    `);
+  });
+
+  it('handles a post-while as an object element', () => {
+    check(`
+      {a: b if c, d}
+    `, `
+      ({a: (c ? b : undefined), d});
+    `);
+  });
 });

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1350,4 +1350,28 @@ describe('for loops', () => {
       }
     `);
   });
+
+  it('handles a post-for as a function argument', () => {
+    check(`
+      a(b for b in c, d)
+    `, `
+      a((Array.from(c).map((b) => b)), d);
+    `);
+  });
+
+  it('handles a post-for as an array element', () => {
+    check(`
+      [a for a in b, c]
+    `, `
+      [(Array.from(b).map((a) => a)), c];
+    `);
+  });
+
+  it('handles a post-for as an object element', () => {
+    check(`
+      {a: b for b in c, d}
+    `, `
+      ({a: (Array.from(c).map((b) => b)), d});
+    `);
+  });
 });

--- a/test/while_test.js
+++ b/test/while_test.js
@@ -389,4 +389,46 @@ describe('while', () => {
       while ((() => b)()) { a; }
     `);
   });
+
+  it('handles a post-while as a function argument', () => {
+    check(`
+      a(b while c, d)
+    `, `
+      a(((() => {
+        let result = [];
+        while (c) {
+          result.push(b);
+        }
+        return result;
+      })()), d);
+    `);
+  });
+
+  it('handles a post-while as an array element', () => {
+    check(`
+      [a while b, c]
+    `, `
+      [((() => {
+        let result = [];
+        while (b) {
+          result.push(a);
+        }
+        return result;
+      })()), c];
+    `);
+  });
+
+  it('handles a post-while as an object element', () => {
+    check(`
+      {a: b while c, d}
+    `, `
+      ({a: ((() => {
+        let result = [];
+        while (c) {
+          result.push(b);
+        }
+        return result;
+      })()), d});
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #896

Whenever an if/while/for is in a non-final position in a comma-separated list
and is followed by a comma token, rearranging it will confuse the parser because
the comma will be seen as part of the body. In these cases (which we can detect
by seeing if the node has a comma after it), we can wrap the node in parens to
avoid the ambiguity.