### PR TITLE
fix: properly handle nested implicit object initializers

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -960,6 +960,8 @@ export default class NodePatcher {
         return this;
       } else if (this.parent.node.type === 'ArrayInitialiser') {
         return this;
+      } else if (this.parent.node.type === 'ObjectInitialiser') {
+        return this;
       }
       return this.parent.getBoundingPatcher();
     } else {

--- a/src/stages/main/patchers/ObjectInitialiserPatcher.js
+++ b/src/stages/main/patchers/ObjectInitialiserPatcher.js
@@ -138,7 +138,7 @@ export default class ObjectInitialiserPatcher extends NodePatcher {
   shouldExpandCurlyBraces(): boolean {
     return (
       this.isMultiline() ||
-      this.parent instanceof ObjectInitialiserMemberPatcher
+      (this.parent instanceof ObjectInitialiserMemberPatcher && this.parent.parent.isMultiline())
     );
   }
 

--- a/test/object_test.js
+++ b/test/object_test.js
@@ -409,4 +409,20 @@ describe('objects', () => {
         }); }
     `);
   });
+
+  it('handles nested implicit objects in a conditional expression', () => {
+    check(`
+      x = if count then {a: b: c} else {d: e: f}
+    `, `
+      let x = count ? {a: {b: c}} : {d: {e: f}};
+    `);
+  });
+
+  it('handles nested implicit objects in a conditional statement', () => {
+    check(`
+      if count then {a: b: c} else {d: e: f}
+    `, `
+      if (count) { ({a: {b: c}}); } else { ({d: {e: f}}); }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #898

One issue was that the patching bounds were not properly accounting for object
parents, so add that case. That fixed the correctness issues, but resulted in
ugly code. To avoid inserting a newline unnecessarily, we only add a newline
before the close-curly if we are multiline or if our enclosing object
initializer is multiline.