### PR TITLE
fix: add more cases to fix delimiters between list items

### DIFF
--- a/src/stages/normalize/patchers/ArrayInitialiserPatcher.js
+++ b/src/stages/normalize/patchers/ArrayInitialiserPatcher.js
@@ -11,9 +11,9 @@ export default class ArrayInitialiserPatcher extends NodePatcher {
   }
 
   patchAsExpression() {
-    for (let member of this.members) {
+    for (let [i, member] of this.members.entries()) {
       member.patch();
-      normalizeListItem(this, member);
+      normalizeListItem(this, member, this.members[i + 1]);
     }
   }
 }

--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.js
@@ -32,9 +32,9 @@ export default class FunctionApplicationPatcher extends NodePatcher {
       }
     }
 
-    for (let arg of args) {
+    for (let [i, arg] of args.entries()) {
       arg.patch();
-      normalizeListItem(this, arg);
+      normalizeListItem(this, arg, args[i + 1]);
     }
 
     if (implicitCall) {

--- a/src/stages/normalize/patchers/FunctionPatcher.js
+++ b/src/stages/normalize/patchers/FunctionPatcher.js
@@ -37,7 +37,7 @@ export default class FunctionPatcher extends NodePatcher {
       } else {
         parameter.patch();
       }
-      normalizeListItem(this, parameter);
+      normalizeListItem(this, parameter, this.parameters[i + 1]);
       if (i === this.parameters.length - 1) {
         // Parameter lists allow trailing semicolons but not trailing commas, so
         // just get rid of it as a special case if it's there.

--- a/src/stages/normalize/patchers/ObjectInitialiserPatcher.js
+++ b/src/stages/normalize/patchers/ObjectInitialiserPatcher.js
@@ -14,9 +14,9 @@ export default class ObjectInitialiserPatcher extends NodePatcher {
   }
 
   patchAsExpression() {
-    for (let member of this.members) {
+    for (let [i, member] of this.members.entries()) {
       member.patch();
-      normalizeListItem(this, member);
+      normalizeListItem(this, member, this.members[i + 1]);
     }
   }
 }

--- a/src/utils/normalizeListItem.js
+++ b/src/utils/normalizeListItem.js
@@ -7,7 +7,7 @@ import type NodePatcher from '../patchers/NodePatcher';
  * function invocation, etc), run some normalize steps to simplify this type of
  * syntax in the normalize stage.
  */
-export default function normalizeListItem(patcher: NodePatcher, listItemPatcher: NodePatcher) {
+export default function normalizeListItem(patcher: NodePatcher, listItemPatcher: NodePatcher, nextListItemPatcher: ?NodePatcher) {
   // If the last token of the arg is a comma, then the actual delimiter must
   // be a newline and the comma is unnecessary and can cause a syntax error
   // when combined with other normalize stage transformations. So just
@@ -22,4 +22,49 @@ export default function normalizeListItem(patcher: NodePatcher, listItemPatcher:
   if (nextToken && nextToken.type === SourceType.SEMICOLON && nextToken.end <= patcher.contentEnd) {
     patcher.overwrite(nextToken.start, nextToken.end, ',');
   }
+
+  if (nextListItemPatcher) {
+    // We have two adjacent items, so do some cleanups based on the tokens
+    // between them (comma tokens, or technically semicolons are treated as
+    // commas as well).
+    let commaTokens = patcher.getProgramSourceTokens()
+      .slice(listItemPatcher.outerEndTokenIndex.next(), nextListItemPatcher.outerStartTokenIndex)
+      .filter(token => token.type === SourceType.COMMA || token.type === SourceType.SEMICOLON)
+      .toArray();
+
+    // Sometimes other normalize steps can cause two adjacent list items to be
+    // reinterpreted as a function call, so put a comma in between them to stop
+    // that, but avoid other cases where adding a comma would cause a crash.
+    if (nextListItemPatcher.node.type === 'ObjectInitialiser' &&
+        !isNestedListItem(listItemPatcher) &&
+        commaTokens.length === 0) {
+      patcher.insert(listItemPatcher.outerEnd, ',');
+    }
+
+    // In some rare cases (when the LHS is an implicit object initializer), the
+    // parser allows two commas, so get rid of the second.
+    for (let extraneousComma of commaTokens.slice(1)) {
+      patcher.remove(extraneousComma.start, extraneousComma.end);
+    }
+  }
+}
+
+/**
+ * Determine if this node might end in an "unclosed" block. If so, then in some
+ * cases, it's not allowed to put a comma at the end of this node, since doing
+ * so could cause a parser crash.
+ */
+function isNestedListItem(patcher: NodePatcher) {
+  return [
+    'BoundFunction',
+    'BoundGeneratorFunction',
+    'Conditional',
+    'ForIn',
+    'ForOf',
+    'Function',
+    'GeneratorFunction',
+    'Switch',
+    'Try',
+    'While',
+  ].indexOf(patcher.node.type) > -1;
 }

--- a/test/array_test.js
+++ b/test/array_test.js
@@ -141,4 +141,34 @@ describe('arrays', () => {
       [a, b, c, d,];
     `)
   );
+
+  it('allows a function call over an object followed by an object array element', () =>
+    check(`
+      [
+        a {}
+          b: {}
+      ]
+    `, `
+      [
+        a({}),
+          {b: {}}
+      ];
+    `)
+  );
+
+  it('allows a block ending in an implicit call followed by an implicit object', () =>
+    check(`
+      [
+        if a
+          b c
+         d: {}
+      ]
+    `, `
+      [
+        a ?
+          b(c) : undefined,
+         {d: {}}
+      ];
+    `)
+  );
 });

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -631,4 +631,16 @@ describe('function calls', () => {
       a(b, c, d, e);
     `);
   });
+
+  it('allows a trailing comma for an object in a function arg', () => {
+    check(`
+      a
+        b: c,
+      , d
+    `, `
+      a(
+        {b: c},
+       d);
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #886
Fixes #887

This feels a little like a hack, but seems to work in all cases that I know of,
and hopefully is at least enough flexibility to get through the long tail of
crazy parser cases for the normalize stage. As part of patching any list
(function args, function parameters, array values, object values), we now
analyze the tokens between all adjacent list items and fix them up if necessary:
* If there are two commas (which can happen when one is immediately after an
  object initializer), we get rid of the second one.
* If the RHS is an object initializer, then in some cases it could be
  reinterpreted as a function call, so add an explicit comma. However, in other
  cases (when the LHS is something like a conditional with a block body), skip
  the comma. As far as I can tell, these two cases never overlap, so skipping
  the comma is always ok.