### PR TITLE
fix: don't unsafely negate operators like `>` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ problems you run into.
 * `--loose-for-expressions`: Do not wrap expression loop targets in `Array.from`.
 * `--loose-for-of`: Do not wrap JS `for...of` loop targets in `Array.from`.
 * `--loose-includes`: Do not wrap in `Array.from` when converting `in` to `includes`.
+* `--loose-comparison-negation`: Allow unsafe simplifications like `!(a > b)` to `a <= b`.
 * `--allow-invalid-constructors`: Don't error when constructors use `this`
   before super or omit the `super` call in a subclass.
 * `--enable-babel-constructor-workaround`: Use a hacky babel-specific workaround

--- a/src/cli.js
+++ b/src/cli.js
@@ -64,6 +64,10 @@ function parseArguments(args: Array<string>): CLIOptions {
         baseOptions.looseIncludes = true;
         break;
 
+      case '--loose-comparison-negation':
+        baseOptions.looseComparisonNegation = true;
+        break;
+
       case '--allow-invalid-constructors':
         baseOptions.allowInvalidConstructors = true;
         break;
@@ -199,6 +203,8 @@ function usage() {
   console.log('  --loose-for-expressions  Do not wrap expression loop targets in Array.from.');
   console.log('  --loose-for-of           Do not wrap JS for...of loop targets in Array.from.');
   console.log('  --loose-includes         Do not wrap in Array.from when converting in to includes.');
+  console.log('  --loose-comparison-negation');
+  console.log('                           Allow unsafe simplifications like `!(a > b)` to `a <= b`.');
   console.log('  --allow-invalid-constructors');
   console.log('                           Don\'t error when constructors use this before super or omit');
   console.log('                           the super call in a subclass.');

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ export type Options = {
   looseForExpressions: ?boolean,
   looseForOf: ?boolean,
   looseIncludes: ?boolean,
+  looseComparisonNegation: ?boolean,
   allowInvalidConstructors: ?boolean,
   enableBabelConstructorWorkaround: ?boolean,
 };
@@ -40,6 +41,7 @@ const DEFAULT_OPTIONS = {
   looseForExpressions: false,
   looseForOf: false,
   looseIncludes: false,
+  looseComparisonNegation: false,
   allowInvalidConstructors: false,
   enableBabelConstructorWorkaround: false,
 };

--- a/src/stages/main/patchers/EqualityPatcher.js
+++ b/src/stages/main/patchers/EqualityPatcher.js
@@ -1,5 +1,6 @@
 import BinaryOpPatcher from './BinaryOpPatcher';
 import getCompareOperator from '../../../utils/getCompareOperator';
+import isCompareOpNegationUnsafe from '../../../utils/isCompareOpNegationUnsafe';
 import type { SourceToken } from './../../../patchers/types';
 import { SourceType } from 'coffee-lex';
 
@@ -48,9 +49,14 @@ export default class EqualityPatcher extends BinaryOpPatcher {
 
   /**
    * Flips negated flag but doesn't edit anything immediately so that we can
-   * use the correct operator in `patch`.
+   * use the correct operator in `patch`. If the negation is unsafe, fall back
+   * to the superclass default behavior of just adding ! to the front.
    */
   negate() {
+    if (isCompareOpNegationUnsafe(this.sourceOfToken(this.getCompareToken())) &&
+        !this.options.looseComparisonNegation) {
+      return super.negate();
+    }
     this.negated = !this.negated;
   }
 }

--- a/src/utils/isCompareOpNegationUnsafe.ts
+++ b/src/utils/isCompareOpNegationUnsafe.ts
@@ -1,0 +1,8 @@
+/**
+ * Determine if this operator is unsafe to convert under the getCompareOperator
+ * algorithm. For example, `a < b` can't be negated to `a >= b` because it would
+ * be incorrect if either variable is `NaN`.
+ */
+export default function isCompareOpNegationUnsafe(operator: string): boolean {
+  return ['<', '>', '<=', '>='].indexOf(operator) > -1;
+}

--- a/test/chained_comparison_test.js
+++ b/test/chained_comparison_test.js
@@ -84,12 +84,23 @@ describe('chained comparison', () => {
     `);
   });
 
-  it('flips the inequalities when used in an `unless`', () => {
+  it('flips the inequalities when used in an `unless` with loose mode specified', () => {
     check(`
       unless a < b <= c
         d
     `, `
       if (a >= b || b > c) {
+        d;
+      }
+    `, { looseComparisonNegation: true });
+  });
+
+  it('does not flip the inequalities when used in an `unless` by default', () => {
+    check(`
+      unless a < b <= c
+        d
+    `, `
+      if (!(a < b && b <= c)) {
         d;
       }
     `);

--- a/test/comparison_test.js
+++ b/test/comparison_test.js
@@ -11,7 +11,7 @@ describe('comparisons', () => {
     check(`a >= b`, `a >= b;`);
   });
 
-  it('flips comparisons when used with an `unless`', () => {
+  it('flips comparisons when used with an `unless` when the loose option is specified', () => {
     check(`
       unless a < b
         c
@@ -19,15 +19,37 @@ describe('comparisons', () => {
       if (a >= b) {
         c;
       }
+    `, { looseComparisonNegation: true });
+  });
+
+  it('does not flip comparisons when used with an `unless` by default', () => {
+    check(`
+      unless a < b
+        c
+    `, `
+      if (!(a < b)) {
+        c;
+      }
     `);
   });
 
-  it('flips nested comparisons when used with an `unless`', () => {
+  it('flips nested comparisons when used with an `unless` when loose is specified', () => {
     check(`
       unless a < b && b > c
         d
     `, `
       if ((a >= b) || (b <= c)) {
+        d;
+      }
+    `, { looseComparisonNegation: true });
+  });
+
+  it('does not flip nested comparisons when used with an `unless` by default', () => {
+    check(`
+      unless a < b && b > c
+        d
+    `, `
+      if (!(a < b) || !(b > c)) {
         d;
       }
     `);

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -231,7 +231,7 @@ describe('switch', () => {
         case score >= 90: 'B'; break;
         default: 'A';
       }
-    `);
+    `, { looseComparisonNegation: true });
   });
 
   it('converts a switch without an expression with function call cases', () => {

--- a/test/while_test.js
+++ b/test/while_test.js
@@ -61,7 +61,7 @@ describe('while', () => {
       until a < b
         a--
     `, `
-      while (a >= b) {
+      while (!(a < b)) {
         a--;
       }
     `);


### PR DESCRIPTION
Fixes #902

For both normal binary operators and chained comparison operators, we need to be
careful about rewriting `!(a < b)` as `a >= b`, since the rewrite isn't correct
for cases like `NaN`. Now, we just do the simpler negation by default and only
do the nicer-looking one with an opt-in flag.