### PR TITLE
fix: ensure that inclusive slice bounds are numbers

### DIFF
--- a/src/stages/main/patchers/SlicePatcher.js
+++ b/src/stages/main/patchers/SlicePatcher.js
@@ -62,9 +62,9 @@ export default class SlicePatcher extends NodePatcher {
             `, ${right.node.data + 1}`
           );
         } else {
-          // `a.slice(0..1]` → `a.slice(0, 1]`
-          //           ^^                ^^
-          this.overwrite(slice.start, slice.end, ', ');
+          // `a.slice(0..1]` → `a.slice(0, +1]`
+          //           ^^                ^^^
+          this.overwrite(slice.start, slice.end, ', +');
           right.patch();
           this.insert(right.outerEnd, ' + 1 || undefined');
         }

--- a/src/stages/main/patchers/SlicePatcher.js
+++ b/src/stages/main/patchers/SlicePatcher.js
@@ -65,6 +65,12 @@ export default class SlicePatcher extends NodePatcher {
           // `a.slice(0..1]` → `a.slice(0, +1]`
           //           ^^                ^^^
           this.overwrite(slice.start, slice.end, ', +');
+          // Don't put two `+` operations immediately next to each other, since
+          // otherwise it will become a `++`. Checking if the CoffeeScript code
+          // starts with `+` should be easy and correct in this case.
+          if (this.slice(right.contentStart, right.contentStart + 1) === '+') {
+            this.insert(slice.end, ' ');
+          }
           right.patch();
           this.insert(right.outerEnd, ' + 1 || undefined');
         }

--- a/test/slice_test.js
+++ b/test/slice_test.js
@@ -25,11 +25,11 @@ describe('slice', () => {
   });
 
   it('changes inclusive slices with a literal float end of range to exclusive by inserting `+ 1`', () => {
-    check(`a[0..2.0]`, `a.slice(0, 2.0 + 1 || undefined);`);
+    check(`a[0..2.0]`, `a.slice(0, +2.0 + 1 || undefined);`);
   });
 
   it('changes inclusive slices with a variable end of range to exclusive by inserting `+ 1`', () => {
-    check(`a[0..b]`, `a.slice(0, b + 1 || undefined);`);
+    check(`a[0..b]`, `a.slice(0, +b + 1 || undefined);`);
   });
 
   it('changes slices with no begin or end of the range to a bare call to `.slice`', () => {
@@ -51,6 +51,15 @@ describe('slice', () => {
     `, `
       let a = (Array.from(d).filter((c) => e).map((c) => b)).slice(0, 2);
     `);
+  });
+
+  it('properly handles string bounds in an inclusive range', () => {
+    validate(`
+      a = [1, 2, 3, 4, 5]
+      start = '1'
+      end = '3'
+      o = a[start..end]
+    `, [2, 3, 4]);
   });
 
   it('handles an exclusive splice with both bounds specified', () => {

--- a/test/slice_test.js
+++ b/test/slice_test.js
@@ -62,6 +62,14 @@ describe('slice', () => {
     `, [2, 3, 4]);
   });
 
+  it('does not generate a preincrement operator when adding `+` to an inclusive end', () => {
+    check(`
+      a[start..+end]
+    `, `
+      a.slice(start, + +end + 1 || undefined);
+    `);
+  });
+
   it('handles an exclusive splice with both bounds specified', () => {
     check(`
       a[b...c] = d


### PR DESCRIPTION
Fixes #882

We need to put a `+` unary op at the front to avoid string concatenation when
adding `1`.