### PR TITLE
fix: generate no assignments for an array destructure

### DIFF
--- a/src/utils/canPatchAssigneeToJavaScript.js
+++ b/src/utils/canPatchAssigneeToJavaScript.js
@@ -22,6 +22,11 @@ export default function canPatchAssigneeToJavaScript(node: Node, isTopLevel: boo
     if (!isTopLevel) {
       return false;
     }
+    // Empty destructure operations need to result in zero assignments, and thus
+    // not call Array.from at all.
+    if (node.members.length === 0) {
+      return false;
+    }
     return node.members.every((member, i) => {
       let isFinalExpansion = (i === node.members.length - 1) &&
           ['Spread', 'Rest', 'Expansion'].indexOf(member.type) > -1;

--- a/test/expansion_test.js
+++ b/test/expansion_test.js
@@ -321,4 +321,24 @@ describe('expansion', () => {
       o = secondWord
     `, 'World');
   });
+
+  it('allows an empty destructure', () => {
+    validate(`
+      o = ([] = 3)
+    `, 3);
+  });
+
+  it('does not call Array.from for an empty destructure', () => {
+    check(`
+      [] = undefined
+    `, '');
+  });
+
+  it('does not call Array.from for an empty destructure of a non-repeatable value', () => {
+    check(`
+      [] = a()
+    `, `
+      let array = a();
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #880

The complex assignment code path generates an assignment for each destructured
value, so we can get the right behavior by using that on an empty destructure.
This means we can skip the `Array.from` and avoid crashing if it would be
invalid.