### PR TITLE
fix: make sure complex assignments have the right return value

### DIFF
--- a/test/expansion_test.js
+++ b/test/expansion_test.js
@@ -341,4 +341,19 @@ describe('expansion', () => {
       let array = a();
     `);
   });
+
+  it('returns the RHS for a simple expression-style array destructure', () => {
+    validate(`
+      b = [1, 2, 3]
+      c = [a] = b
+      o = b == c
+    `, true);
+  });
+
+  it('properly returns the RHS for a complex assignment', () => {
+    validate(`
+      a = [1]
+      o = [[]] = a
+    `, [1]);
+  });
 });

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1269,7 +1269,7 @@ describe('for loops', () => {
       x = (a for [a = 1] in b)
     `, `
       let a, val;
-      let x = (Array.from(b).map((value) => (val = value[0], a = val != null ? val : 1, value, a)));
+      let x = (Array.from(b).map((value) => ((val = value[0], a = val != null ? val : 1, value), a)));
     `);
   });
 

--- a/test/slice_test.js
+++ b/test/slice_test.js
@@ -149,7 +149,7 @@ describe('slice', () => {
     `, `
       () => {
         let ref;
-        return ref = d(), a.splice(b, c - b, ...[].concat(ref)), ref;
+        return (ref = d(), a.splice(b, c - b, ...[].concat(ref)), ref);
       };
     `);
   });


### PR DESCRIPTION
Fixes #881

There were a few fixes here:
* For normal expression-style assignments where the RHS is wrapped in
  `Array.from`, we need to return the original unwrapped RHS, so make it
  repeatable and return it via a comma expression.
* For this new case, make sure we wrap expression in parens to avoid precedence
  issues.
* For the normal complex assignment case, always wrap is in parens if it's an
  expression, not just when it starts with a `{`, since we want to avoid
  precedence issues with the comma operator. In some cases, like the return
  case, this is unnecessary, but that seems not worth worrying about, and IMO
  it's better to wrap an assignment expression in parens anyway.