### PR TITLE
fix: generate non-crashing code on empty object destructure on undefined

### DIFF
--- a/src/utils/canPatchAssigneeToJavaScript.js
+++ b/src/utils/canPatchAssigneeToJavaScript.js
@@ -34,6 +34,11 @@ export default function canPatchAssigneeToJavaScript(node: Node, isTopLevel: boo
     });
   }
   if (node.type === 'ObjectInitialiser') {
+    // JS empty destructure crashes if the RHS is undefined or null, so more
+    // precisely copy the behavior for empty destructures.
+    if (node.members.length === 0) {
+      return false;
+    }
     return node.members.every(node => canPatchAssigneeToJavaScript(node, false));
   }
   if (node.type === 'ObjectInitialiserMember') {

--- a/test/expansion_test.js
+++ b/test/expansion_test.js
@@ -356,4 +356,11 @@ describe('expansion', () => {
       o = [[]] = a
     `, [1]);
   });
+
+  it('does not generate crashing code when doing a destructure on undefined', () => {
+    validate(`
+      {} = undefined
+      o = true
+    `, true);
+  });
 });


### PR DESCRIPTION
Fixes #908

Just fall back to the more precise algorithm in this case (generating one
assignment per destructured value, like CS does).