### PR TITLE
fix: extract catch assignees to assignments when necessary

### DIFF
--- a/src/stages/normalize/index.js
+++ b/src/stages/normalize/index.js
@@ -19,6 +19,7 @@ import PassthroughPatcher from '../../patchers/PassthroughPatcher';
 import ProgramPatcher from './patchers/ProgramPatcher';
 import ProtoMemberAccessOpPatcher from './patchers/ProtoMemberAccessOpPatcher';
 import SpreadPatcher from './patchers/SpreadPatcher';
+import TryPatcher from './patchers/TryPatcher';
 import TransformCoffeeScriptStage from '../TransformCoffeeScriptStage';
 import WhilePatcher from './patchers/WhilePatcher';
 import MemberAccessOpPatcher from './patchers/MemberAccessOpPatcher';
@@ -110,6 +111,9 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
       case 'ProtoMemberAccessOp':
       case 'SoakedProtoMemberAccessOp':
         return ProtoMemberAccessOpPatcher;
+
+      case 'Try':
+        return TryPatcher;
 
       default:
         return PassthroughPatcher;

--- a/src/stages/normalize/patchers/TryPatcher.js
+++ b/src/stages/normalize/patchers/TryPatcher.js
@@ -1,0 +1,79 @@
+import NodePatcher from '../../../patchers/NodePatcher';
+import type BlockPatcher from './BlockPatcher';
+import type { PatcherContext } from '../../../patchers/types';
+import IdentifierPatcher from './IdentifierPatcher';
+import countVariableUsages from '../../../utils/countVariableUsages';
+
+export default class TryPatcher extends NodePatcher {
+  body: ?BlockPatcher;
+  catchAssignee: ?NodePatcher;
+  catchBody: ?BlockPatcher;
+  finallyBody: ?BlockPatcher;
+
+  constructor(patcherContext: PatcherContext, body: ?BlockPatcher, catchAssignee: ?NodePatcher, catchBody: ?BlockPatcher, finallyBody: ?BlockPatcher) {
+    super(patcherContext);
+    this.body = body;
+    this.catchAssignee = catchAssignee;
+    this.catchBody = catchBody;
+    this.finallyBody = finallyBody;
+  }
+
+  patchAsExpression() {
+    if (this.body) {
+      this.body.patch();
+    }
+    let bodyPrefixLine = this.patchCatchAssignee();
+    if (bodyPrefixLine !== null) {
+      if (this.catchBody) {
+        this.catchBody.insertLineBefore(bodyPrefixLine);
+      } else {
+        this.insert(this.catchAssignee.outerEnd, ` then ${bodyPrefixLine}`);
+      }
+    }
+    if (this.catchBody) {
+      this.catchBody.patch();
+    }
+    if (this.finallyBody) {
+      this.finallyBody.patch();
+    }
+  }
+
+  patchCatchAssignee() {
+    if (!this.catchAssignee) {
+      return null;
+    }
+    if (this.needsExpressionExtracted()) {
+      let assigneeName = this.claimFreeBinding('error');
+      let assigneeCode = this.catchAssignee.patchAndGetCode();
+      this.overwrite(this.catchAssignee.contentStart, this.catchAssignee.contentEnd, assigneeName);
+      return `${assigneeCode} = ${assigneeName}`;
+    } else {
+      this.catchAssignee.patch();
+      return null;
+    }
+  }
+
+  /**
+   * Catch assignees in CoffeeScript can have (mostly) arbitrary assignees,
+   * while JS is more limited. Generally JS only supports assignees that can
+   * create variables.
+   *
+   * Also, JavaScript exception assignees are scoped to the catch block while
+   * CoffeeScript exception assignees follow function scoping, so pull the
+   * variable out into an assignment if the variable is used externally.
+   */
+  needsExpressionExtracted(): boolean {
+    if (!this.catchAssignee) {
+      return false;
+    }
+    if (!(this.catchAssignee instanceof IdentifierPatcher)) {
+      return true;
+    }
+    let varName = this.catchAssignee.node.data;
+    let exceptionVarUsages = this.catchBody
+      ? countVariableUsages(this.catchBody.node, varName) + 1
+      : 1;
+    let totalVarUsages = countVariableUsages(this.node.scope.containerNode, varName);
+    return totalVarUsages > exceptionVarUsages;
+  }
+}

--- a/src/utils/PatchError.js
+++ b/src/utils/PatchError.js
@@ -40,6 +40,8 @@ export default class PatchError extends Error {
 
   static prettyPrint(error: PatchError): string {
     let { source, start, end, message } = error;
+    start = Math.min(Math.max(start, 0), source.length);
+    end = Math.min(Math.max(end, start), source.length);
     let lineMap = new LinesAndColumns(source);
     let startLoc = lineMap.locationForIndex(start);
     let endLoc = lineMap.locationForIndex(end);

--- a/src/utils/Scope.js
+++ b/src/utils/Scope.js
@@ -114,6 +114,14 @@ export default class Scope {
         });
         break;
 
+      case 'Try':
+        if (node.catchAssignee) {
+          leftHandIdentifiers(node.catchAssignee).forEach(identifier =>
+            this.assigns(identifier.data, identifier)
+          );
+        }
+        break;
+
       case 'Class':
         if (node.nameAssignee && node.nameAssignee.type === 'Identifier') {
           this.assigns(node.nameAssignee.data, node.nameAssignee);

--- a/test/try_test.js
+++ b/test/try_test.js
@@ -282,4 +282,69 @@ describe('try', () => {
     `);
   });
 
+  it('treats the exception assignee as a normal variable in its outer scope if necessary', () => {
+    check(`
+      try
+        a
+      catch e
+        b
+      console.log e
+    `, `
+      let e;
+      try {
+        a;
+      } catch (error) {
+        e = error;
+        b;
+      }
+      console.log(e);
+    `);
+  });
+
+  it('handles complex destructuring within a catch', () => {
+    check(`
+      try
+        a
+      catch {b: [c, ..., d]}
+        e
+    `, `
+      try {
+        a;
+      } catch (error) {
+        let array = error.b, c = array[0], d = array[array.length - 1];
+        e;
+      }
+    `);
+  });
+
+  it('properly picks a distinct variable name when choosing a catch assignee', () => {
+    check(`
+      try
+        a
+      catch {error}
+        b
+    `, `
+      try {
+        a;
+      } catch (error1) {
+        let {error} = error1;
+        b;
+      }
+    `);
+  });
+
+  it('handles a complex catch assignee with no catch body', () => {
+    check(`
+      try
+        a
+      catch error
+      console.log error
+    `, `
+      let error;
+      try {
+        a;
+      } catch (error1) { error = error1; }
+      console.log(error);
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #585

Catch assignees have different scoping rules in CoffeeScript and JavaScript, so
the simple way to solve that is to generate an assignment at the start of the
catch block so the variable is function-scoped. This is always correct, but
usually ugly, so we only do it in the rare cases where it's necessary:
* when the variable is actally used outside of the catch block.
* when the variable is a complex assignment instead of just an identifier, e.g.
  a destructure with an expansion node. Even though JS does support some forms
  of exception destructuring, for simplicity, we always extract non-identifiers.

From a code standpoint, this is similar to how normalize ForPatcher moves the
assignee to the start of the body when necessary.

Also fix scope assignment traversal to account for catch assignees.

Also fix an error formatting crash that I ran into in an intermediate test
failure.