### PR TITLE
fix: add parens around assignments in more cases

### DIFF
--- a/src/stages/main/patchers/DoOpPatcher.js
+++ b/src/stages/main/patchers/DoOpPatcher.js
@@ -1,6 +1,7 @@
 import AssignOpPatcher from './AssignOpPatcher';
 import DefaultParamPatcher from './DefaultParamPatcher';
 import FunctionPatcher from './FunctionPatcher';
+import IdentifierPatcher from './IdentifierPatcher';
 import NodePatcher from '../../../patchers/NodePatcher';
 import type { PatcherContext, SourceTokenListIndex } from '../../../patchers/types';
 import { SourceType } from 'coffee-lex';
@@ -23,7 +24,9 @@ export default class DoOpPatcher extends NodePatcher {
     let nextToken = this.sourceTokenAtIndex(doTokenIndex.next());
     this.remove(doToken.start, nextToken.start);
 
-    let addParens = this.hasDoFunction() && !this.isSurroundedByParentheses();
+    let addParens = !this.isSurroundedByParentheses() && !(
+        this.expression instanceof IdentifierPatcher
+      );
 
     if (addParens) {
       this.insert(this.outerStart, '(');

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -1,4 +1,5 @@
 import check from './support/check';
+import validate from './support/validate';
 
 describe('conditionals', () => {
   it('surrounds `if` conditions in parentheses and bodies in curly braces', () => {
@@ -243,10 +244,10 @@ describe('conditionals', () => {
       (function() {
         let c, d;
         return z(a ?
-          (c = a,
+          ((c = a),
           a + c)
         :
-          (d = a,
+          ((d = a),
           a - d));
       });
     `);
@@ -684,5 +685,16 @@ describe('conditionals', () => {
     `, `
       ({a: (c ? b : undefined), d});
     `);
+  });
+
+  it('handles an assignment within an expression-style conditional', () => {
+    validate(`
+      a =
+        if b = 1
+          2
+        else
+          3
+      o = b
+    `, 1);
   });
 });

--- a/test/declaration_test.js
+++ b/test/declaration_test.js
@@ -138,7 +138,14 @@ describe('declarations', () => {
   });
 
   it('adds pre-declarations and regular declarations together properly', () => {
-    check('a = 1\nb = c = 2', 'let c;\nlet a = 1;\nlet b = c = 2;');
+    check(`
+      a = 1
+      b = c = 2
+    `, `
+      let c;
+      let a = 1;
+      let b = (c = 2);
+    `);
   });
 
   it('uses const rather than let if specified', () => {

--- a/test/do_test.js
+++ b/test/do_test.js
@@ -77,4 +77,21 @@ describe('`do`', () => {
       (a = (b, d) => e)(c, d);
     `);
   });
+
+  it('properly converts do expressions on a normal assignment', () => {
+    check(`
+      do a = b
+    `, `
+      let a;
+      (a = b)();
+    `);
+  });
+
+  it('properly converts negated do expressions', () => {
+    check(`
+      do !a
+    `, `
+      (!a)();
+    `);
+  });
 });

--- a/test/slice_test.js
+++ b/test/slice_test.js
@@ -149,7 +149,7 @@ describe('slice', () => {
     `, `
       () => {
         let ref;
-        return (ref = d(), a.splice(b, c - b, ...[].concat(ref)), ref);
+        return ref = d(), a.splice(b, c - b, ...[].concat(ref)), ref;
       };
     `);
   });


### PR DESCRIPTION
Fixes #912

As with various other cases, it's safer to add parens by default and omit them
in a list of cases where they're known to not be necessary. This ended up
simplifying some other assignment code that needed to detect some cases where
parens were necessary.

It turns out that `do` expressions had some similar issues involving parens, so
I also made them add parens by default.