### PR TITLE
fix: traverse into rest nodes when checking if an assignee can become JS

### DIFF
--- a/src/utils/canPatchAssigneeToJavaScript.js
+++ b/src/utils/canPatchAssigneeToJavaScript.js
@@ -30,7 +30,10 @@ export default function canPatchAssigneeToJavaScript(node: Node, isTopLevel: boo
     return node.members.every((member, i) => {
       let isFinalExpansion = (i === node.members.length - 1) &&
           ['Spread', 'Rest', 'Expansion'].indexOf(member.type) > -1;
-      return isFinalExpansion || canPatchAssigneeToJavaScript(member, false);
+      let isValidFinalExpansion = isFinalExpansion && (
+        member.type === 'Expansion' || canPatchAssigneeToJavaScript(member.expression)
+      );
+      return isValidFinalExpansion || canPatchAssigneeToJavaScript(member, false);
     });
   }
   if (node.type === 'ObjectInitialiser') {

--- a/test/expansion_test.js
+++ b/test/expansion_test.js
@@ -363,4 +363,12 @@ describe('expansion', () => {
       o = true
     `, true);
   });
+
+  it('handles an object default within an array rest', () => {
+    check(`
+      [{a = 1}...] = b
+    `, `
+      let obj = b.slice(0, b.length - 0), val = obj.a, a = val != null ? val : 1;
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #914