### PR TITLE
fix: correctly place close-paren in an expression assignment containing a soak

### DIFF
--- a/src/stages/main/patchers/AssignOpPatcher.js
+++ b/src/stages/main/patchers/AssignOpPatcher.js
@@ -83,7 +83,7 @@ export default class AssignOpPatcher extends NodePatcher {
     }
 
     if (shouldAddParens) {
-      this.insert(this.innerEnd, ')');
+      this.appendDeferredSuffix(')');
     }
   }
 

--- a/test/soaked_test.js
+++ b/test/soaked_test.js
@@ -835,4 +835,12 @@ describe('soaked expressions', () => {
       }
     `);
   });
+
+  it('properly places parens for expression-style soaked assignment', () => {
+    check(`
+      a = b?.c = 1
+    `, `
+      let a = (typeof b !== 'undefined' && b !== null ? b.c = 1 : undefined);
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #916

This feels a little hacky at the moment since there isn't a clear answer to when
we should insert code at the end of an expression normally vs using
`appendDeferredSuffix`. But generally I think it's reasonable to say that
`appendDeferredSuffix` should be used in cases like close-parens where we want
it to wrap the whole resulting expression (after any other deferred code).