### PR TITLE
fix: implement strictly correct argument and array spreads

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -649,6 +649,22 @@ export default class NodePatcher {
   }
 
   /**
+   * Marks this node as an assignee. Nested assignees, like destructure
+   * operations, should override this method and propagate it to the children.
+   */
+  setAssignee() {
+    this._assignee = true;
+  }
+
+  /**
+   * Checks if this node has been marked as an assignee. This is particularly
+   * useful for distinguishing rest from spread operations.
+   */
+  isAssignee() {
+    return this._assignee;
+  }
+
+  /**
    * Gets whether this patcher's node implicitly returns.
    */
   implicitlyReturns(): boolean {

--- a/src/stages/main/patchers/ArrayInitialiserPatcher.js
+++ b/src/stages/main/patchers/ArrayInitialiserPatcher.js
@@ -15,6 +15,11 @@ export default class ArrayInitialiserPatcher extends NodePatcher {
     this.members.forEach(member => member.setRequiresExpression());
   }
 
+  setAssignee() {
+    this.members.forEach(member => member.setAssignee());
+    super.setAssignee();
+  }
+
   patchAsExpression() {
     this.members.forEach((member, i, members) => {
       let isLast = i === members.length - 1;

--- a/src/stages/main/patchers/AssignOpPatcher.js
+++ b/src/stages/main/patchers/AssignOpPatcher.js
@@ -33,6 +33,7 @@ export default class AssignOpPatcher extends NodePatcher {
   }
 
   initialize() {
+    this.assignee.setAssignee();
     this.assignee.setRequiresExpression();
     this.expression.setRequiresExpression();
   }

--- a/src/stages/main/patchers/ForPatcher.js
+++ b/src/stages/main/patchers/ForPatcher.js
@@ -21,9 +21,11 @@ export default class ForPatcher extends LoopPatcher {
 
   initialize() {
     if (this.keyAssignee) {
+      this.keyAssignee.setAssignee();
       this.keyAssignee.setRequiresExpression();
     }
     if (this.valAssignee) {
+      this.valAssignee.setAssignee();
       this.valAssignee.setRequiresExpression();
     }
     this.target.setRequiresExpression();

--- a/src/stages/main/patchers/FunctionPatcher.js
+++ b/src/stages/main/patchers/FunctionPatcher.js
@@ -19,7 +19,10 @@ export default class FunctionPatcher extends NodePatcher {
     if (this.body && !this.implicitReturnsDisabled()) {
       this.body.setImplicitlyReturns();
     }
-    this.parameters.forEach(param => param.setRequiresExpression());
+    this.parameters.forEach(param => {
+      param.setAssignee();
+      param.setRequiresExpression();
+    });
   }
 
   patchAsStatement(options={}) {

--- a/src/stages/main/patchers/ObjectInitialiserPatcher.js
+++ b/src/stages/main/patchers/ObjectInitialiserPatcher.js
@@ -19,6 +19,11 @@ export default class ObjectInitialiserPatcher extends NodePatcher {
     this.members.forEach(member => member.setRequiresExpression());
   }
 
+  setAssignee() {
+    this.members.forEach(member => member.expression.setAssignee());
+    super.setAssignee();
+  }
+
   setExpression(force) {
     if (this.isImplicitObject()) {
       let { curlyBraceInsertionPosition } = this.getOpenCurlyInfo();

--- a/src/stages/main/patchers/TryPatcher.js
+++ b/src/stages/main/patchers/TryPatcher.js
@@ -22,6 +22,7 @@ export default class TryPatcher extends NodePatcher {
 
   initialize() {
     if (this.catchAssignee) {
+      this.catchAssignee.setAssignee();
       this.catchAssignee.setRequiresExpression();
     }
   }

--- a/test/spread_test.js
+++ b/test/spread_test.js
@@ -1,13 +1,58 @@
 import check from './support/check';
+import validate from './support/validate';
 
 describe('spread', () => {
-  it('moves the ellipsis to before the expression in function calls', () => {
-    check(`a(b...)`, `a(...b);`);
-    check(`a(1, 2, makeArray(arguments...)...)`, `a(1, 2, ...makeArray(...arguments));`);
+  it('handles simple function calls', () => {
+    check(`
+      a(b...)
+    `, `
+      a(...Array.from(b || []));
+    `);
   });
 
-  it('moves the ellipsis to before the expression in array literals', () => {
-    check(`[b...]`, `[...b];`);
-    check(`[1, 2, makeArray(arguments...)...]`, `[1, 2, ...makeArray(...arguments)];`);
+  it('handles advanced function calls', () => {
+    check(`
+      a(1, 2, makeArray(arguments...)...)
+    `, `
+      a(1, 2, ...Array.from(makeArray(...arguments)));
+    `);
+  });
+
+  it('has the correct runtime behavior when spreading null in a function call', () => {
+    validate(`
+      f = -> arguments.length
+      o = f(null...)
+    `, 0);
+  });
+
+  it('has the correct runtime behavior when spreading a fake array in a function call', () => {
+    validate(`
+      f = -> arguments.length
+      obj = {length: 2, 0: 'a', 1: 'b'}
+      o = f(1, 2, obj...)
+    `, 4);
+  });
+
+  it('handles simple array literals', () => {
+    check(`
+      [b...]
+    `, `
+      [...Array.from(b)];
+    `);
+  });
+
+  it('handles advanced array literals', () => {
+    check(`
+      [1, 2, makeArray(arguments...)...]
+    `, `
+      [1, 2, ...Array.from(makeArray(...arguments))];
+    `);
+  });
+
+  it('has the correct runtime behavior when spreading a fake array in an array literal', () => {
+    validate(`
+      obj = {length: 2, 0: 'a', 1: 'b'}
+      o = [1, 2, obj...]
+    `, [1, 2, 'a', 'b']);
   });
 });


### PR DESCRIPTION
Fixes #918

JS requires argument spreads to be iterable and not just array-like (even though
babel allows them to be array-like), so like with a bunch of other cases we wrap
in `Array.from` to be 100% correct. It turns out single-argument function call
spreads get compiled differently (the value doesn't get passed to `slice`), so
we need to add an additional check there to accept null or undefined.

I also needed to set up a system to distinguish assignee expressions from
non-assignee expressions. Technically, decaffeinate-parser could do this, and
attempts to in one simple case, but it seems easier and more useful to implement
it on the decaffeinate side.

Note that this is still technically not quite right for single-argument function
call spreads, since in that case non-null non-undefined non-object values (e.g.
numbers) will crash in CoffeeScript and be accepted with this defensive code.
However, that's really obscure and hopefully never comes up, and crashing less
than CoffeeScript does seems somewhat acceptable.