### PR TITLE
fix: overhaul complex expression-style classes

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -1060,7 +1060,7 @@ export default class NodePatcher {
    * that strings inserted before child nodes appear after the indent, not
    * before.
    */
-  indent(offset: number=1) {
+  indent(offset: number=1, {skipFirstLine=false}: {skipFirstLine: boolean}={}) {
     if (offset === 0) {
       return;
     }
@@ -1075,12 +1075,9 @@ export default class NodePatcher {
     // See if there are already non-whitespace characters before the start. If
     // so, skip the start to the next line, since we don't want to put
     // indentation in the middle of a line.
-    for (let i = start - 1; i >= 0 && source[i] !== '\n'; i--) {
-      if (source[i] !== '\t' && source[i] !== ' ') {
-        while (start < end && source[start] !== '\n') {
-          start++;
-        }
-        break;
+    if (skipFirstLine || !this.isFirstNodeInLine()) {
+      while (start < end && source[start] !== '\n') {
+        start++;
       }
     }
 
@@ -1118,6 +1115,16 @@ export default class NodePatcher {
           break;
       }
     }
+  }
+
+  isFirstNodeInLine() {
+    let { source } = this.context;
+    for (let i = this.outerStart - 1; i >= 0 && source[i] !== '\n'; i--) {
+      if (source[i] !== '\t' && source[i] !== ' ') {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**


### PR DESCRIPTION
Fixes #835

Rather than the previous `__initClass__` wrapper function that called the
`initClass` static method, we now use an IIFE whenever the class is "complex
enough". Complex enough means one of the following:
* The class is used in an expression context (or, we can't prove it's in a
  statement context).
* The class has variables that need to be extracted (since we need to create
  a scope for them).

When we do this IIFE wrapping, we also need to indent the whole class. Due to
magic-string subtleties, we need to indent the whole class body before patching
any children, so a lot of the logic needed to be refactored so we can determine
at the start whether that indentation will be necessary.

Rather than handling anonymous classes (and other similarly-tricky classes) by
passing them into a function, we generate a temporary name for them and call
`initClass` using that name. That means that a complex anonymous class in a
statement context does NOT always need an IIFE.