### PR TITLE
fix: handle heregexes with a double-backslash followed by a space

### DIFF
--- a/src/stages/main/patchers/InterpolatedPatcher.js
+++ b/src/stages/main/patchers/InterpolatedPatcher.js
@@ -77,16 +77,13 @@ export default class InterpolatedPatcher extends NodePatcher {
 
   escapeQuasis(skipPattern, escapeStrings) {
     for (let quasi of this.quasis) {
-      escape(
-        this.editor,
-        skipPattern,
-        escapeStrings,
-        // For now, clamp the quasi bounds to be strictly between the quotes.
-        // Ideally, decaffeinate-parser would provide better location data
-        // that would make this unnecessary.
-        Math.max(quasi.contentStart, this.firstToken().end),
-        Math.min(quasi.contentEnd, this.lastToken().start),
-      );
+      let tokens = this.getProgramSourceTokens().slice(
+        quasi.contentStartTokenIndex, quasi.contentEndTokenIndex.next()).toArray();
+      for (let token of tokens) {
+        if (token.type === SourceType.STRING_CONTENT) {
+          escape(this.editor, skipPattern, escapeStrings, token.start, token.end);
+        }
+      }
     }
   }
 

--- a/src/utils/escape.js
+++ b/src/utils/escape.js
@@ -14,7 +14,7 @@ import type MagicString from 'magic-string';
 export default function escape(patcher: MagicString, skipPattern: RegExp, escapeStrings: Array<string>, start: number, end: number) {
   let source = patcher.original;
   for (let i = start; i < end; i++) {
-    if (skipPattern.test(source.slice(i))) {
+    if (skipPattern.test(source.slice(i, end))) {
       i++;
     } else if (escapeStrings.some(str => source.slice(i, i + str.length) === str)) {
       patcher.appendRight(i, '\\');

--- a/test/regular_expression_test.js
+++ b/test/regular_expression_test.js
@@ -128,4 +128,12 @@ describe('regular expressions', () => {
       new RegExp(\`\\u2029\`);
     `);
   });
+
+  it('handles a double backslash followed by a space', () => {
+    check(`
+      ///\\\\[\\\\ ]///
+      `, `
+      new RegExp(\`\\\\\\\\[\\\\\\\\]\`);
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #923

The lexer already breaks up the heregex into tokens of actual string content, so
we should just do escape operations over those tokens, ignoring padding
characters. Also, the escape function was looking past the end of the string,
but if `\` is at the end of a content token then we don't want to match
characters past it, so limit the skip matching to the end of the token being
considered.