### PR TITLE
fix: properly implicitly return for expression-style `if`, `switch`, and `try`

### DIFF
--- a/src/stages/main/patchers/ConditionalPatcher.js
+++ b/src/stages/main/patchers/ConditionalPatcher.js
@@ -237,7 +237,17 @@ export default class ConditionalPatcher extends NodePatcher {
     }
   }
 
+  /**
+   * If we ended up as a statement, then we know our children are set as
+   * implicit return nodes, so no need to turn the conditional into an
+   * expression for implicit return purposes.
+   */
+  implicitlyReturns() {
+    return super.implicitlyReturns() && this.willPatchAsExpression();
+  }
+
   setImplicitlyReturns() {
+    super.setImplicitlyReturns();
     if (this.consequent) {
       this.consequent.setImplicitlyReturns();
     }

--- a/src/stages/main/patchers/SwitchPatcher.js
+++ b/src/stages/main/patchers/SwitchPatcher.js
@@ -58,7 +58,16 @@ export default class SwitchPatcher extends NodePatcher {
     this.appendLineAfter('}');
   }
 
+  /**
+   * If we're a statement, our children can handle implicit return, so no need
+   * to convert to an expression.
+   */
+  implicitlyReturns() {
+    return super.implicitlyReturns() && this.willPatchAsExpression();
+  }
+
   setImplicitlyReturns() {
+    super.setImplicitlyReturns();
     this.cases.forEach(casePatcher => casePatcher.setImplicitlyReturns());
     if (this.alternate) {
       this.alternate.setImplicitlyReturns();

--- a/src/stages/main/patchers/TryPatcher.js
+++ b/src/stages/main/patchers/TryPatcher.js
@@ -130,7 +130,16 @@ export default class TryPatcher extends NodePatcher {
     });
   }
 
+  /**
+   * If we're a statement, our children can handle implicit return, so no need
+   * to convert to an expression.
+   */
+  implicitlyReturns() {
+    return super.implicitlyReturns() && this.willPatchAsExpression();
+  }
+
   setImplicitlyReturns() {
+    super.setImplicitlyReturns();
     if (this.body) {
       this.body.setImplicitlyReturns();
     }

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -697,4 +697,13 @@ describe('conditionals', () => {
       o = b
     `, 1);
   });
+
+  it('properly handles an expression-style conditional in an implicit return context', () => {
+    check(`
+      ->
+        (if a then b else c)
+    `, `
+      () => a ? b : c;
+    `);
+  });
 });

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -488,4 +488,20 @@ describe('switch', () => {
       });
     `);
   });
+
+  it('properly handles an expression-style switch in an implicit return context', () => {
+    check(`
+      ->
+        (switch a
+           when b
+             c)
+    `, `
+      () =>
+        (() => { switch (a) {
+           case b:
+             return c;
+        } })()
+      ;
+    `);
+  });
 });

--- a/test/try_test.js
+++ b/test/try_test.js
@@ -347,4 +347,13 @@ describe('try', () => {
       console.log(error);
     `);
   });
+
+  it('properly handles an expression-style try/catch in an implicit return context', () => {
+    check(`
+      ->
+        (try a)
+    `, `
+      () => (() => { try { return a; } catch (error) {} })();
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #925

In all three of these cases, we would mark our children but not ourselves as
implicitly returning. This makes sense in most cases because implicitly
returning means we get turned into an expression, which often isn't ideal. The
problem is that if we end up as an expression for any other reason (e.g. the
node is surrounded by parens), the implicit return will be skipped and the code
will be incorrect. So now we always record ourselves as implicitly returning
(which happens before we know whether we are going to be an expression), and
skip the implicit return if we end up as a statement, since we know that in that
case it's safe.