### PR TITLE
docs: add blog post link, update docs for babel workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Project        | Lines of CoffeeScript | Conversion status                 | Tes
 To contribute to this list, send a pull request to the [decaffeinate-examples]
 project.
 
+In addition, decaffeinate has been used on private codebases within various
+companies, such as Square, Benchling, and Bugsnag. See this
+[blog post from Bugsnag][bugsnag-blog-post] to read about their experiences
+using decaffeinate.
+
 Check the [issues] page for more specific details on outstanding bugs and
 incomplete features. And, of course, you're welcome to file issues for any
 problems you run into.
@@ -70,6 +75,8 @@ problems you run into.
 [codecombat-conversion-status]: https://decaffeinate-examples.github.io/codecombat/conversion-status.svg
 [codecombat-test-status]: https://decaffeinate-examples.github.io/codecombat/test-status.svg
 
+[bugsnag-blog-post]: https://blog.bugsnag.com/converting-a-large-react-codebase-from-coffeescript-to-es6/
+
 ## Goals
 
 * Fully automated conversion of the CoffeeScript language to modern JavaScript.
@@ -92,8 +99,9 @@ problems you run into.
 * `--loose-comparison-negation`: Allow unsafe simplifications like `!(a > b)` to `a <= b`.
 * `--allow-invalid-constructors`: Don't error when constructors use `this`
   before super or omit the `super` call in a subclass.
-* `--enable-babel-constructor-workaround`: Use a hacky babel-specific workaround
-  to allow `this` before `super` in constructors.
+* `--enable-babel-constructor-workaround`: Use a hacky Babel-specific workaround
+  to allow `this` before `super` in constructors. Also works when using
+  TypeScript.
 
 For more usage details, see the output of `decaffeinate --help`.
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -209,8 +209,8 @@ function usage() {
   console.log('                           Don\'t error when constructors use this before super or omit');
   console.log('                           the super call in a subclass.');
   console.log('  --enable-babel-constructor-workaround');
-  console.log('                           Use a hacky babel-specific workaround to allow this before');
-  console.log('                           super in constructors.');
+  console.log('                           Use a hacky Babel-specific workaround to allow this before');
+  console.log('                           super in constructors. Also works when using TypeScript.');
   console.log();
   console.log('EXAMPLES');
   console.log();

--- a/src/utils/getInvalidConstructorErrorMessage.ts
+++ b/src/utils/getInvalidConstructorErrorMessage.ts
@@ -17,9 +17,9 @@ export default function getInvalidConstructorErrorMessage(firstSentence: string)
     CoffeeScript code to avoid the above cases, so that decaffeinate can run without
     this error message.
     
-    If you are using babel, you can run decaffeinate with
-    --enable-babel-constructor-workaround to generate babel-specific code to allow
+    If you are using Babel or TypeScript, you can run decaffeinate with
+    --enable-babel-constructor-workaround to generate Babel-specific code to allow
     constructors that don't call \`super\`. Note that this approach is fragile and
-    may break in future versions of babel.
+    may break in future versions of Babel/TypeScript.
   `);
 }


### PR DESCRIPTION
There was a blog post about decaffeinate relatively recently, so add it to the
README as further proof that it actually works.

The Babel constructor workaround also happens to work on TypeScript code (and
babel 5), so seems worth calling out.