### PR TITLE
fix: properly handle reordering when patching postfix conditionals

### DIFF
--- a/src/stages/normalize/patchers/ConditionalPatcher.js
+++ b/src/stages/normalize/patchers/ConditionalPatcher.js
@@ -51,24 +51,24 @@ export default class ConditionalPatcher extends NodePatcher {
         !this.condition.isSurroundedByParentheses()) {
       this.condition.surroundInParens();
     }
-    this.consequent.patch();
 
     let ifTokenIndex = this.getIfTokenIndex();
     let ifToken = this.sourceTokenAtIndex(ifTokenIndex);
-
-    if (ifToken) {
-      let consequentCode = this.slice(this.consequent.outerStart, this.consequent.outerEnd);
-      this.remove(this.consequent.outerStart, ifToken.start);
-
-      let needsParens = postfixNodeNeedsOuterParens(this);
-      if (needsParens) {
-        this.insert(ifToken.start, '(');
-      }
-      this.insert(this.condition.outerEnd, ` then ${consequentCode}`);
-      if (needsParens) {
-        this.insert(this.condition.outerEnd, ')');
-      }
+    if (!ifToken) {
+      throw this.error('Unable to find `if` token.');
     }
+
+    let needsParens = postfixNodeNeedsOuterParens(this);
+    let ifAndConditionCode = this.slice(ifToken.start, this.condition.outerEnd);
+    if (needsParens) {
+      this.insert(this.consequent.outerStart, '(');
+    }
+    this.insert(this.consequent.outerStart, `${ifAndConditionCode} then `);
+    this.consequent.patch();
+    if (needsParens) {
+      this.insert(this.consequent.outerEnd, ')');
+    }
+    this.remove(this.consequent.outerEnd, this.contentEnd);
   }
 
   isPostIf(): boolean {

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -706,4 +706,12 @@ describe('conditionals', () => {
       () => a ? b : c;
     `);
   });
+
+  it('handles a postfix loop within a postfix conditional', () => {
+    check(`
+      a for a in b if b
+    `, `
+      if (b) { for (let a of Array.from(b)) { a; } }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #933

Similar to #620, the robust way to switch the order of two code snippets is to
move the right to the left, to avoid issues where an `appendLeft` at the start
of an expression doesn't get picked up by a `slice`. Rewriting postfix
conditional code to use this strategy avoids a case where we reordered a postfix
conditional around a postfix loop in a way that resulted in incorrect code.