### PR TITLE
fix: properly handle negation of conditionals

### DIFF
--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -714,4 +714,30 @@ describe('conditionals', () => {
       if (b) { for (let a of Array.from(b)) { a; } }
     `);
   });
+
+  it('handles negated parenthesized conditionals', () => {
+    check(`
+      a unless (b if c)
+    `, `
+      if (!(c ? b : undefined)) { a; }
+    `);
+  });
+
+  it('handles negated IIFE-style conditionals', () => {
+    check(`
+      a unless (
+        if b
+          if c
+            d)
+    `, `
+      if (!(() => {
+        
+        if (b) {
+          if (c) {
+            return d;
+          }
+        }
+      })()) { a; }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #934

Conditional negation was using the default behavior of just adding a `!` to the
front. When a negated conditional gets patched to a ternary, we need to wrap it
in parens to avoid precedence problems.