### PR TITLE
fix: be more careful when removing whitespace to fix indentation

### DIFF
--- a/src/stages/normalize/patchers/BlockPatcher.js
+++ b/src/stages/normalize/patchers/BlockPatcher.js
@@ -42,11 +42,31 @@ export default class BlockPatcher extends SharedBlockPatcher {
               'earlier statement in the block.');
           }
           if (charsToRemove > 0) {
-            this.remove(statement.outerStart - charsToRemove, statement.outerStart);
+            this.removePrecedingSpaceChars(statement.outerStart, charsToRemove);
           }
         }
       }
       statement.patch();
+    }
+  }
+
+  /**
+   * Get rid of some number of spaces of indentation before this point in the
+   * code. We need to be careful to only remove ranges that have not had any
+   * inserts yet, since otherwise we might remove other code in addition to the
+   * whitespace, or we might remove too much whitespace.
+   */
+  removePrecedingSpaceChars(index, numToRemove) {
+    let numRemaining = numToRemove;
+    for (let i = index; numRemaining > 0 && i > 0; i--) {
+      let contents = this.slice(i - 1, i);
+      if (contents.includes('\n')) {
+        throw this.error('Found start of line before removing enough indentation.');
+      }
+      if (contents === ' ' || contents === '\t') {
+        this.remove(i - 1, i);
+        numRemaining -= 1;
+      }
     }
   }
 

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1511,4 +1511,32 @@ describe('classes', () => {
       Cls.initClass();
     `);
   });
+
+  it('handles inconsistent indentation in an expression-style complex class', () => {
+    check(`
+      x = class A
+        constructor: ->
+          b
+         c: ->
+           d
+        e: f
+    `, `
+      let A;
+      let x = (A = (function() {
+        A = class A {
+          static initClass() {
+            this.prototype.e = f;
+          }
+          constructor() {
+            b;
+          }
+          c() {
+             return d;
+           }
+        };
+        A.initClass();
+        return A;
+      })());
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #935

In some cases, a line gets indented in the normalize stage, and then we try to
fix indentation by removing some indentation. This can cause too much whitespace
to be removed overall. Instead, we now check every character before removing it
to make sure it's the original single whitespace character, and skip it if not.

There are some more clever strategies that we could use if there's ever a case
where we need to remove more whitespace than we can with this algorithm, but we
crash if we can't find enough whitespace, so that should be easy to detect and
seems unlikely anyway.