### PR TITLE
fix: wrap postfix statements in parens when followed by a semicolon

### DIFF
--- a/src/utils/postfixNodeNeedsOuterParens.js
+++ b/src/utils/postfixNodeNeedsOuterParens.js
@@ -7,12 +7,14 @@ import type NodePatcher from '../patchers/NodePatcher';
  * Determine if the given postfix if/while/for needs to have parens wrapped
  * around it while it is reordered. This happens when the expression has a comma
  * after it as part of a list (function args, array initializer, or object
- * initializer).
+ * initializer). It also happens when there is a semicolong immediately
+ * afterward, since without the parens the next statement would be pulled into
+ * the block.
  */
 export default function postfixNodeNeedsOuterParens(patcher: NodePatcher): boolean {
   let nextToken = patcher.nextToken();
   if (nextToken) {
-    return nextToken.type === SourceType.COMMA;
+    return nextToken.type === SourceType.COMMA || nextToken.type === SourceType.SEMICOLON;
   }
   return false;
 }

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -740,4 +740,12 @@ describe('conditionals', () => {
       })()) { a; }
     `);
   });
+
+  it('handles a postfix conditional followed by a semicolon', () => {
+    check(`
+      a if b; c
+    `, `
+      (b ? a : undefined); c;
+    `);
+  });
 });

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1374,4 +1374,12 @@ describe('for loops', () => {
       ({a: (Array.from(c).map((b) => b)), d});
     `);
   });
+
+  it('properly converts a postfix for followed by a semicolon', () => {
+    check(`
+      foo = () -> null for i in []; t
+    `, `
+      let foo = function() { ([].map((i) => null)); return t; };
+    `);
+  });
 });

--- a/test/while_test.js
+++ b/test/while_test.js
@@ -431,4 +431,18 @@ describe('while', () => {
       })()), d});
     `);
   });
+
+  it('handles a postfix while followed by a semicolon', () => {
+    check(`
+      a while b; c
+    `, `
+      ((() => {
+        let result = [];
+        while (b) {
+          result.push(a);
+        }
+        return result;
+      })()); c;
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #748

`a if b; c` is a conditional followed by a statement, but `if b then a; c` has
`a; c` as the conditional body. To avoid this, we can always wrap these types of
statements in parens if there's a semicolon after them.