### PR TITLE
fix: normalize commas to semicolons between class statements

### DIFF
--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1539,4 +1539,21 @@ describe('classes', () => {
       })());
     `);
   });
+
+  it('handles an inline class with comma-separated fields (#544)', () => {
+    check(`
+      rethinkdb.monday = new (class extends RDBConstant then tt: protoTermType.MONDAY, st: 'monday')()
+    `, `
+      rethinkdb.monday = new (function() {
+        let Cls = (class extends RDBConstant {
+          static initClass() {
+            this.prototype.tt = protoTermType.MONDAY; this.prototype.st = 'monday';
+            
+          }
+        });
+        Cls.initClass();
+        return Cls();
+      })();
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #544

It looks like CoffeeScript allows commas between class items and they behave the
same as semicolons, so just change them to semicolons. We do this between all
adjacent statements in all blocks since it's easy, but I think it will only do
anything within classes.