### PR TITLE
fix: prefer to remove parens when a statement is surrounded by parens

### DIFF
--- a/src/stages/main/patchers/BlockPatcher.js
+++ b/src/stages/main/patchers/BlockPatcher.js
@@ -78,9 +78,11 @@ export default class BlockPatcher extends SharedBlockPatcher {
   }
 
   patchInnerStatement(statement) {
-    if (statement.isSurroundedByParentheses()) {
-      statement.setRequiresExpression();
+    if (statement.isSurroundedByParentheses() && !statement.statementNeedsParens()) {
+      this.remove(statement.outerStart, statement.innerStart);
+      this.remove(statement.innerEnd, statement.outerEnd);
     }
+
     let hasImplicitReturn = (
       statement.implicitlyReturns() &&
       !statement.explicitlyReturns()

--- a/src/stages/main/patchers/FunctionPatcher.js
+++ b/src/stages/main/patchers/FunctionPatcher.js
@@ -25,12 +25,6 @@ export default class FunctionPatcher extends NodePatcher {
     });
   }
 
-  patchAsStatement(options={}) {
-    this.insert(this.innerStart, '(');
-    this.patchAsExpression(options);
-    this.insert(this.innerEnd, ')');
-  }
-
   patchAsExpression({ method=false }={}) {
     this.patchFunctionStart({ method });
     this.parameters.forEach((parameter, i) => {

--- a/test/binary_operator_test.js
+++ b/test/binary_operator_test.js
@@ -87,9 +87,9 @@ describe('binary operators', () => {
 
   it('handles binary existence operator with a global LHS as an expression', () => {
     check(`
-      (a ? b)
+      x = (a ? b)
     `, `
-      (typeof a !== 'undefined' && a !== null ? a : b);
+      let x = (typeof a !== 'undefined' && a !== null ? a : b);
     `);
   });
 
@@ -119,17 +119,17 @@ describe('binary operators', () => {
 
   it('handles binary existence operator with a safe-to-repeat member expression as an expression', () => {
     check(`
-      (a.b ? a)
+      x = (a.b ? a)
     `, `
-      (a.b != null ? a.b : a);
+      let x = (a.b != null ? a.b : a);
     `);
   });
 
   it('handles binary existence operator with a this-access on the left side', () => {
     check(`
-      (@a.b ? c)
+      x = (@a.b ? c)
     `, `
-      (this.a.b != null ? this.a.b : c);
+      let x = (this.a.b != null ? this.a.b : c);
     `);
   });
 
@@ -144,10 +144,10 @@ describe('binary operators', () => {
 
   it('handles binary existence operator with an unsafe-to-repeat member expression as an expression', () => {
     check(`
-      (a() ? b)
+      x = (a() ? b)
     `, `
       let left;
-      ((left = a()) != null ? left : b);
+      let x = ((left = a()) != null ? left : b);
     `);
   });
 

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -548,7 +548,7 @@ describe('conditionals', () => {
     check(`
       if a then (b)else c
     `, `
-      if (a) { (b);} else { c; }
+      if (a) { b;} else { c; }
     `)
   );
 
@@ -629,12 +629,12 @@ describe('conditionals', () => {
 
   it('handles a parenthesized empty condition with only a block comment for its body', () => {
     check(`
-      (if true
+      x = (if true
         ### a ###
       else
       )
     `, `
-      (true ?
+      let x = (true ?
         undefined/* a */
        : undefined
       );
@@ -701,9 +701,12 @@ describe('conditionals', () => {
   it('properly handles an expression-style conditional in an implicit return context', () => {
     check(`
       ->
-        (if a then b else c)
+        x = (if a then b else c)
     `, `
-      () => a ? b : c;
+      (function() {
+        let x;
+        return x = (a ? b : c);
+      });
     `);
   });
 

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -470,7 +470,7 @@ describe('function calls', () => {
         null
         )
     `, `
-      (a(() => null));
+      a(() => null);
     `);
   });
 

--- a/test/instanceof_test.js
+++ b/test/instanceof_test.js
@@ -16,7 +16,7 @@ describe('instanceof', () => {
   // Ideally we wouldn't have redundant parens here, but it makes the
   // implementation simpler.
   it('handles negated `instanceof` when there are already parens', () => {
-    check(`(a not instanceof b)`, `(!(a instanceof b));`);
+    check(`(a not instanceof b)`, `!(a instanceof b);`);
   });
 
   it('works with double-negated `instanceof`', () => {

--- a/test/return_test.js
+++ b/test/return_test.js
@@ -80,4 +80,30 @@ describe('return', () => {
       return a;
     `)
   );
+
+  it('allows return surrounded by parens', () =>
+    check(`
+      ->
+        (return)
+        a
+    `, `
+      (function() {
+        return;
+        return a;
+      });
+    `)
+  );
+
+  it('allows return surrounded by two sets of parens', () =>
+    check(`
+      ->
+        ((return))
+        a
+    `, `
+      (function() {
+        return;
+        return a;
+      });
+    `)
+  );
 });

--- a/test/semicolon_test.js
+++ b/test/semicolon_test.js
@@ -7,7 +7,7 @@ describe('semicolons', () => {
         result)())
       a
     `, `
-      ((() => result)());
+      (() => result)();
       a;
     `);
   });

--- a/test/sequence_test.js
+++ b/test/sequence_test.js
@@ -24,24 +24,26 @@ describe('sequences', () => {
         c
       )
     `, `
-      if (a) { (
+      if (a) { 
         b,
         c
-      ); }
+      ; }
     `);
   });
 
   it('handles mixed semicolon and newline-separated sequence expressions', () => {
     check(`
+      a
       (
-        a; b
-        c
+        b; c
+        d
       )
     `, `
-      (
-        a, b,
-        c
-      );
+      a;
+      
+        b, c,
+        d
+      ;
     `);
   });
 });

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -492,16 +492,17 @@ describe('switch', () => {
   it('properly handles an expression-style switch in an implicit return context', () => {
     check(`
       ->
-        (switch a
+        x = (switch a
            when b
              c)
     `, `
-      () =>
-        (() => { switch (a) {
+      (function() {
+        let x;
+        return x = ((() => { switch (a) {
            case b:
              return c;
-        } })()
-      ;
+        } })());
+      });
     `);
   });
 });

--- a/test/throw_test.js
+++ b/test/throw_test.js
@@ -65,7 +65,7 @@ describe('throw', () => {
       (throw
         a)
     `, `
-      (() => { throw a; })();
+      throw a;
     `);
   });
 });

--- a/test/try_test.js
+++ b/test/try_test.js
@@ -351,9 +351,12 @@ describe('try', () => {
   it('properly handles an expression-style try/catch in an implicit return context', () => {
     check(`
       ->
-        (try a)
+        x = (try a)
     `, `
-      () => (() => { try { return a; } catch (error) {} })();
+      (function() {
+        let x;
+        return x = ((() => { try { return a; } catch (error) {} })());
+      });
     `);
   });
 });


### PR DESCRIPTION
Fixes #945

In CoffeeScript, regular statements, like `return`, `break`, etc, are allowed to
be surrounded by parens, and CoffeeScript emits code with the parens removed, so
we need to follow that behavior. In general, when a statement is surrounded by
parens, we might as well remove the parens and treat it as statement (if it was
going to be a statement already), since that usually looks better anyway.

This also means we can wrap statements in parens when generating them in the
normalize stage without making the code uglier, which will be nice for a later
fix.