### PR TITLE
fix: wrap default param assignments in parens

### DIFF
--- a/src/stages/normalize/patchers/FunctionPatcher.js
+++ b/src/stages/normalize/patchers/FunctionPatcher.js
@@ -109,14 +109,16 @@ export default class FunctionPatcher extends NodePatcher {
     };
     this.addDefaultParamAssignmentAtScopeHeader = (assigneeCode: string, initCode: string, assigneeIsValidExpression: boolean) => {
       if (assigneeIsValidExpression) {
-        defaultParamAssignments.push(`${assigneeCode} ?= ${initCode}`);
+        // Wrap in parens to avoid precedence issues for inline statements. The
+        // parens will be removed later in normal situations.
+        defaultParamAssignments.push(`(${assigneeCode} ?= ${initCode})`);
         return assigneeCode;
       } else {
         // Handle cases like `({a}={}) ->`, where we need to check for default
         // with the param as a normal variable, then include the destructure.
         assigneeCode = this.fixGeneratedAssigneeWhitespace(assigneeCode);
         let paramName = this.claimFreeBinding('param');
-        defaultParamAssignments.push(`${paramName} ?= ${initCode}`);
+        defaultParamAssignments.push(`(${paramName} ?= ${initCode})`);
         defaultParamAssignments.push(`${assigneeCode} = ${paramName}`);
         return paramName;
       }

--- a/test/default_param_test.js
+++ b/test/default_param_test.js
@@ -103,4 +103,12 @@ describe('default params', () => {
       };
     `);
   });
+
+  it('handles a function as a default value (#729)', () => {
+    check(`
+      filter = (items, predicate = (-> true)) -> items.filter(predicate)
+    `, `
+      let filter = function(items, predicate) { if (predicate == null) { predicate = () => true; } return items.filter(predicate); };
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #729

This avoids some precedence issues that can come up if the default value has an
arrow function in it.