### PR TITLE
fix: allow sequence operations to be patched as statements

### DIFF
--- a/src/stages/main/patchers/SeqOpPatcher.js
+++ b/src/stages/main/patchers/SeqOpPatcher.js
@@ -1,15 +1,36 @@
-import BinaryOpPatcher from './BinaryOpPatcher';
 import { SourceType } from 'coffee-lex';
+import NodePatcher from './../../../patchers/NodePatcher';
 import type { SourceToken } from './../../../patchers/types';
 
 /**
- * Handles sequence expressions, e.g `a; b`.
+ * Handles sequence expressions/statements, e.g `a; b`.
  */
-export default class SeqOpPatcher extends BinaryOpPatcher {
+export default class SeqOpPatcher extends NodePatcher {
+  left: NodePatcher;
+  right: NodePatcher;
+
+  negated: boolean = false;
+
+  constructor(patcherContext: PatcherContext, left: NodePatcher, right: NodePatcher) {
+    super(patcherContext);
+    this.left = left;
+    this.right = right;
+  }
+
+  negate() {
+    this.negated = !this.negated;
+  }
+
   /**
    * LEFT ';' RIGHT
    */
   patchAsExpression() {
+    this.left.setRequiresExpression();
+    this.right.setRequiresExpression();
+
+    if (this.negated) {
+      this.insert(this.innerStart, '!(');
+    }
     this.left.patch();
 
     let token = this.getOperatorToken();
@@ -23,9 +44,32 @@ export default class SeqOpPatcher extends BinaryOpPatcher {
     }
 
     this.right.patch();
+    if (this.negated) {
+      this.insert(this.innerEnd, ')');
+    }
   }
 
-  operatorTokenPredicate(): (token: SourceToken) => boolean {
-    return (token: SourceToken): boolean => token.type === SourceType.SEMICOLON || token.type === SourceType.NEWLINE;
+  /**
+   * If we're patching as a statement, we can just keep the semicolon or newline.
+   */
+  patchAsStatement() {
+    this.left.patch();
+    this.right.patch();
+  }
+
+  getOperatorToken(): SourceToken {
+    let operatorTokenIndex = this.indexOfSourceTokenBetweenPatchersMatching(
+      this.left,
+      this.right,
+      token => token.type === SourceType.SEMICOLON || token.type === SourceType.NEWLINE
+    );
+    if (!operatorTokenIndex) {
+      throw this.error('expected operator between binary operands');
+    }
+    return this.sourceTokenAtIndex(operatorTokenIndex);
+  }
+
+  statementNeedsParens(): boolean {
+    return this.left.statementShouldAddParens();
   }
 }

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1382,4 +1382,12 @@ describe('for loops', () => {
       let foo = function() { for (let i of []) { null; } return t; };
     `);
   });
+
+  it('handles break in a postfix for', () => {
+    check(`
+      (a; break) for b in c
+    `, `
+      for (let b of Array.from(c)) { a; break; }
+    `);
+  });
 });

--- a/test/sequence_test.js
+++ b/test/sequence_test.js
@@ -25,7 +25,7 @@ describe('sequences', () => {
       )
     `, `
       if (a) { 
-        b,
+        b;
         c
       ; }
     `);
@@ -41,9 +41,20 @@ describe('sequences', () => {
     `, `
       a;
       
-        b, c,
+        b; c;
         d
       ;
+    `);
+  });
+
+  it('handles a negated sequence operation', () => {
+    check(`
+      unless (a; b)
+        c
+    `, `
+      if (!(a, b)) {
+        c;
+      }
     `);
   });
 });


### PR DESCRIPTION
Fixes #941

Previously, SeqOp was a binary operator, so it forced both of its operands to be
expressions. But CoffeeScript is actually a little looser and allows either one
to be a statement if the SeqOp itself is a statement. This is why you can
sometimes use `break`, `continue`, or `return` inside a SeqOp. To fix, I change
it to no longer be a binary operator and only force its children to be
expressions when it is an expression.