### PR TITLE
feat: implement soaked slice and splice operations

### DIFF
--- a/src/stages/main/index.js
+++ b/src/stages/main/index.js
@@ -53,6 +53,7 @@ import SoakedDynamicMemberAccessOpPatcher from './patchers/SoakedDynamicMemberAc
 import SoakedFunctionApplicationPatcher from './patchers/SoakedFunctionApplicationPatcher';
 import SoakedMemberAccessOpPatcher from './patchers/SoakedMemberAccessOpPatcher';
 import SoakedNewOpPatcher from './patchers/SoakedNewOpPatcher';
+import SoakedSlicePatcher from './patchers/SoakedSlicePatcher';
 import SpreadPatcher from './patchers/SpreadPatcher';
 import StringPatcher from './patchers/StringPatcher';
 import SuperPatcher from './patchers/SuperPatcher';
@@ -249,6 +250,9 @@ export default class MainStage extends TransformCoffeeScriptStage {
 
       case 'Slice':
         return SlicePatcher;
+
+      case 'SoakedSlice':
+        return SoakedSlicePatcher;
 
       case 'Expansion':
         return ExpansionPatcher;

--- a/src/stages/main/patchers/AssignOpPatcher.js
+++ b/src/stages/main/patchers/AssignOpPatcher.js
@@ -211,7 +211,7 @@ export default class AssignOpPatcher extends NodePatcher {
       }
       return assignments;
     } else if (patcher instanceof SlicePatcher) {
-      return [`${patcher.getInitialSpliceCode()}, ...[].concat(${ref}))`];
+      return [patcher.getSpliceCode(ref)];
     } else if (patcher instanceof AssignOpPatcher) {
       if (!refIsRepeatable) {
         let valReference = this.claimFreeBinding('val');

--- a/src/stages/main/patchers/SoakedSlicePatcher.js
+++ b/src/stages/main/patchers/SoakedSlicePatcher.js
@@ -1,0 +1,44 @@
+/**
+ * Handles soaked array or string slicing, e.g. `names?[i..]`.
+ */
+import SlicePatcher from './SlicePatcher';
+import findSoakContainer from '../../../utils/findSoakContainer';
+
+const GUARD_HELPER =
+  `function __guard__(value, transform) {
+  return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
+}`;
+
+export default class SoakedSlicePatcher extends SlicePatcher {
+  patchAsExpression() {
+    this.registerHelper('__guard__', GUARD_HELPER);
+
+    let soakContainer = findSoakContainer(this);
+    let varName = soakContainer.claimFreeBinding('x');
+    let prefix = this.slice(soakContainer.contentStart, this.contentStart);
+
+    if (prefix.length > 0) {
+      this.remove(soakContainer.contentStart, this.contentStart);
+    }
+
+    this.insert(this.expression.outerEnd, `, ${varName} => ${prefix}${varName}`);
+
+    soakContainer.insert(soakContainer.contentStart, '__guard__(');
+
+    super.patchAsExpression();
+    soakContainer.appendDeferredSuffix(')');
+  }
+
+  /**
+   * For a soaked splice operation, we are the soak container.
+   */
+  getSpliceCode(expressionCode: string): string {
+    let spliceStart = this.captureCodeForPatchOperation(() => {
+      this.registerHelper('__guard__', GUARD_HELPER);
+      let varName = this.claimFreeBinding('x');
+      this.insert(this.expression.outerEnd, `, ${varName} => ${varName}`);
+      this.patchAsSpliceExpressionStart();
+    });
+    return `__guard__(${spliceStart}, ...[].concat(${expressionCode})))`;
+  }
+}

--- a/src/utils/traverse.js
+++ b/src/utils/traverse.js
@@ -119,6 +119,7 @@ const ORDER = {
   SoakedMemberAccessOp: ['expression', 'member'],
   SoakedNewOp: ['ctor', 'arguments'],
   SoakedProtoMemberAccessOp: ['expression'],
+  SoakedSlice: ['expression', 'left', 'right'],
   Spread: ['expression'],
   String: ['quasis', 'expressions'],
   SubtractOp: ['left', 'right'],


### PR DESCRIPTION
Fixes #871

For the most part these can derive from the existing slice/splice code. Also
refactor splice code a little so the SlicePatcher can control both the beginning
and end of the code snippet.