### PR TITLE
fix: improve repl output for CoffeeScript switch statements

### DIFF
--- a/src/utils/formatCoffeeScriptAst.js
+++ b/src/utils/formatCoffeeScriptAst.js
@@ -35,7 +35,15 @@ function formatAstNodeLines(node, context) {
     } else if (Array.isArray(value)) {
       propLines.push(`${key}: [`);
       for (let child of value) {
-        propLines.push(...formatAstNodeLines(child, context).map(s => '  ' + s));
+        if (Array.isArray(child)) {
+          propLines.push(`  [`);
+          for (let grandchild of child) {
+            propLines.push(...formatAstNodeLines(grandchild, context).map(s => '    ' + s));
+          }
+          propLines.push(`  ]`);
+        } else {
+          propLines.push(...formatAstNodeLines(child, context).map(s => '  ' + s));
+        }
       }
       propLines.push(`]`);
     } else {
@@ -53,7 +61,7 @@ function formatAstNodeLines(node, context) {
 
 function shouldTraverse(value) {
   if (Array.isArray(value)) {
-    return value.length === 0 || isNode(value[0]);
+    return value.length === 0 || shouldTraverse(value[0]);
   }
   return isNode(value);
 }

--- a/test/utils/formatCoffeeScriptAst_test.js
+++ b/test/utils/formatCoffeeScriptAst_test.js
@@ -41,4 +41,44 @@ describe('formatCoffeeScriptAst', () => {
       }
     `) + '\n');
   });
+
+  it('properly formats switch statements', () => {
+    let source = stripSharedIndent(`
+      switch
+        when 1
+          2
+    `);
+    let context = parse(source).context;
+    let formattedTokens = formatCoffeeScriptAst(context);
+    strictEqual(formattedTokens, stripSharedIndent(`
+      Block [1:1(0)-3:6(21)] {
+        expressions: [
+          Switch [1:1(0)-3:6(21)] {
+            subject: null
+            otherwise: undefined
+            cases: [
+              [
+                Value [2:8(14)-2:9(15)] {
+                  base: Literal [2:8(14)-2:9(15)] {
+                    value: "1"
+                  }
+                  properties: []
+                }
+                Block [3:5(20)-3:6(21)] {
+                  expressions: [
+                    Value [3:5(20)-3:6(21)] {
+                      base: Literal [3:5(20)-3:6(21)] {
+                        value: "2"
+                      }
+                      properties: []
+                    }
+                  ]
+                }
+              ]
+            ]
+          }
+        ]
+      }
+    `) + '\n');
+  });
 });


### PR DESCRIPTION
Fixes #738

I just took the simple approach of allowing up to 2 levels of array nesting,
rather than supporting an arbitrary number of levels. I think that should be
fine.