### PR TITLE
refactor: get rid of source map code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,12 +48,11 @@ const DEFAULT_OPTIONS = {
 
 type ConversionResult = {
   code: string,
-  maps: Array<Object>
 };
 
 type Stage = {
   name: string;
-  run: (content: string, options: Options) => { code: string, map: Object }
+  run: (content: string, options: Options) => { code: string }
 };
 
 /**
@@ -87,19 +86,15 @@ export function convert(source: string, options: ?Options={}): ConversionResult 
 }
 
 function runStages(initialContent: string, options: Options, stages: Array<Stage>): ConversionResult {
-  let maps = [];
   let content = initialContent;
   stages.forEach(stage => {
-    let { code, map } = runStage(stage, content, options);
-    if (code !== content) {
-      maps.push(map);
-      content = code;
-    }
+    let { code } = runStage(stage, content, options);
+    content = code;
   });
-  return { code: content, maps };
+  return { code: content };
 }
 
-function runStage(stage: Stage, content: string, options: Options): { code: string, map: Object } {
+function runStage(stage: Stage, content: string, options: Options): { code: string } {
   try {
     return stage.run(content, options);
   } catch (err) {
@@ -116,22 +111,18 @@ function convertCustomStage(source: string, stageName: string): ConversionResult
   if (stageName === 'coffeescript-lexer') {
     return {
       code: formatCoffeeScriptLexerTokens(tokens(source), ast.context),
-      maps: [],
     };
   } else if (stageName === 'coffeescript-parser') {
     return {
       code: formatCoffeeScriptAst(ast.context),
-      maps: [],
     };
   } else if (stageName === 'coffee-lex') {
     return {
       code: formatCoffeeLexAst(ast.context),
-      maps: [],
     };
   } else if (stageName === 'decaffeinate-parser') {
     return {
       code: formatDecaffeinateParserAst(ast),
-      maps: [],
     };
   } else {
     throw new Error(`Unrecognized stage name: ${stageName}`);

--- a/src/stages/TransformCoffeeScriptStage.js
+++ b/src/stages/TransformCoffeeScriptStage.js
@@ -3,14 +3,12 @@ import NodePatcher from '../patchers/NodePatcher';
 import PatchError from '../utils/PatchError';
 import parse from '../utils/parse';
 import type { Node, ParseContext, Editor } from '../patchers/types';
-import { basename } from 'path';
 import { childPropertyNames } from '../utils/traverse';
 import { logger } from '../utils/debug';
 import type { Options } from '../index';
 
 export default class TransformCoffeeScriptStage {
-  static run(content: string, options: Options): { code: string, map: Object } {
-    let { filename } = options;
+  static run(content: string, options: Options): { code: string } {
     let log = logger(this.name);
     log(content);
 
@@ -21,11 +19,6 @@ export default class TransformCoffeeScriptStage {
     patcher.patch();
     return {
       code: editor.toString(),
-      map: editor.generateMap({
-        source: filename,
-        file: `${basename(filename, this.inputExtension)}-${this.name}${this.outputExtension}`,
-        includeContent: true
-      })
     };
   }
 

--- a/src/stages/add-variable-declarations/index.js
+++ b/src/stages/add-variable-declarations/index.js
@@ -1,12 +1,9 @@
 import addVariableDeclarations from 'add-variable-declarations';
 import MagicString from 'magic-string';
-import { basename } from 'path';
 import { logger } from '../../utils/debug';
-import type { Options } from '../../index';
 
 export default class AddVariableDeclarationsStage {
-  static run(content: string, options: Options): { code: string, map: Object } {
-    let { filename } = options;
+  static run(content: string): { code: string } {
     let log = logger(this.name);
     log(content);
 
@@ -14,11 +11,6 @@ export default class AddVariableDeclarationsStage {
     addVariableDeclarations(content, editor);
     return {
       code: editor.toString(),
-      map: editor.generateMap({
-        source: filename,
-        file: `${basename(filename, '.js')}-${this.name}.js`,
-        includeContent: true
-      })
     };
   }
 }

--- a/src/stages/esnext/index.js
+++ b/src/stages/esnext/index.js
@@ -31,6 +31,6 @@ export default class EsnextStage {
         }
       }
     });
-    return { code, map: {} };
+    return { code };
   }
 }

--- a/src/stages/semicolons/index.js
+++ b/src/stages/semicolons/index.js
@@ -1,10 +1,8 @@
 import MagicString from 'magic-string';
 import asi from 'automatic-semicolon-insertion';
 import buildConfig from 'ast-processor-babylon-config';
-import { basename } from 'path';
 import { logger } from '../../utils/debug';
 import { parse } from 'babylon';
-import type { Options } from '../../index';
 
 const BABYLON_PLUGINS = [
   'flow',
@@ -24,8 +22,7 @@ const BABYLON_PLUGINS = [
 ];
 
 export default class SemicolonsStage {
-  static run(content: string, options: Options): { code: string, map: Object } {
-    let { filename } = options;
+  static run(content: string): { code: string } {
     let log = logger(this.name);
     log(content);
 
@@ -44,11 +41,6 @@ export default class SemicolonsStage {
 
     return {
       code: editor.toString(),
-      map: editor.generateMap({
-        source: filename,
-        file: `${basename(filename, '.js')}-${this.name}.js`,
-        includeContent: true
-      })
     };
   }
 }


### PR DESCRIPTION
Closes #119

It didn't work anyway, since esnext doesn't support source maps, and made it
sort of a pain to add new stages or work with the code outside of stages.

I still kept around the response format of an object with a `code` property
rather than making it just a string, since I have vague plans for decaffeinate
outputting a list of warnings or cleanup suggestions or things like that, and
having a flexible output format would make that easier.