### PR TITLE
fix: improve close-brace placement for arrow functions

### DIFF
--- a/src/stages/main/patchers/BoundFunctionPatcher.js
+++ b/src/stages/main/patchers/BoundFunctionPatcher.js
@@ -81,7 +81,12 @@ export default class BoundFunctionPatcher extends FunctionPatcher {
   patchFunctionBody() {
     if (this.body) {
       if (!this.willPatchBodyInline()) {
-        this.body.patch({ leftBrace: false });
+        if (this.isEndOfFunctionCall()) {
+          this.body.patch({ leftBrace: false, rightBrace: false });
+          this.placeCloseBraceBeforeFunctionCallEnd();
+        } else {
+          this.body.patch({ leftBrace: false });
+        }
       } else {
         let needsParens = blockStartsWithObjectInitialiser(this.body) &&
           !this.body.isSurroundedByParentheses();

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1109,10 +1109,8 @@ describe('classes', () => {
           return dolater(() => {
             return dolater(() => {
               return B.prototype.__proto__.foo.call(this, cb);
-            }
-            );
-          }
-          );
+            });
+          });
         }
       }
     `);

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -302,7 +302,8 @@ describe('function calls', () => {
                 let org, person, user;
                 if (param == null) { param = {}; }
                 ({person, user, authKey, org} = param);
-                return cb(null, {person, authKey, user, org});});
+                return cb(null, {person, authKey, user, org});
+        });
         }
       });
     `);
@@ -351,7 +352,8 @@ describe('function calls', () => {
       
         somefunc('something', ['something', function(ContactService) {}
       
-        ]));
+        ])
+      );
     `);
   });
 
@@ -396,8 +398,7 @@ describe('function calls', () => {
     `, `
       baz(() => {
         if (bar) { return foo; }
-      }
-      );
+      });
     `);
   });
 

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -452,4 +452,17 @@ describe('functions', () => {
       ;
     `)
   );
+
+  it('generates nice-looking code for a function call around an arrow function', () =>
+    check(`
+      f () =>
+        a = 1
+        a
+    `, `
+      f(() => {
+        let a = 1;
+        return a;
+      });
+    `)
+  );
 });

--- a/test/indentation_test.js
+++ b/test/indentation_test.js
@@ -44,8 +44,7 @@ describe('indentation', () => {
       (function() {
         a
           .b(() => {
-          }
-        );
+        });
         return 3;
       });
     `);

--- a/test/return_test.js
+++ b/test/return_test.js
@@ -68,8 +68,7 @@ describe('return', () => {
         b;  // comment
         }).c(() => {
         return d;
-      }
-      );
+      });
     `);
   });
 


### PR DESCRIPTION
Fixes #787

We already had some custom logic for non-arrow functions to place the
close-brace right before a close-paren on the next line, but that wasn't
happening for arrow functions. To fix, I factored it out into shared code used
in both places, and tweaked some of the logic in case the close-paren is at the
end of the line.