### PR TITLE
fix: consider enclosing parens when placing a function close-brace

### DIFF
--- a/src/stages/main/patchers/FunctionPatcher.js
+++ b/src/stages/main/patchers/FunctionPatcher.js
@@ -84,7 +84,8 @@ export default class FunctionPatcher extends NodePatcher {
    */
   placeCloseBraceBeforeFunctionCallEnd() {
     let closeParenIndex = this.parent.indexOfSourceTokenBetweenSourceIndicesMatching(
-      this.contentEnd, this.parent.contentEnd, token => token.type === SourceType.CALL_END
+      this.contentEnd, this.parent.contentEnd,
+      token => token.type === SourceType.CALL_END || token.type === SourceType.RPAREN
     );
     let closeParen = this.sourceTokenAtIndex(closeParenIndex);
     let shouldMoveCloseParen = !this.body.inline() &&

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -465,4 +465,16 @@ describe('functions', () => {
       });
     `)
   );
+
+  it('handles an arrow function argument that is wrapped in parens', () =>
+    check(`
+      a((=>
+        b
+      ))
+    `, `
+      a((() => {
+        return b;
+      }));
+    `)
+  );
 });


### PR DESCRIPTION
Fixes #958

Normally there's a CALL_END right after the function, but if the function itself
is wrapped in parens, we actually just want to take the RPAREN instead so we
don't get mismatched parens.