### PR TITLE
fix: always remove `then` tokens from switch cases

### DIFF
--- a/src/stages/main/patchers/SwitchCasePatcher.js
+++ b/src/stages/main/patchers/SwitchCasePatcher.js
@@ -159,6 +159,15 @@ export default class SwitchCasePatcher extends NodePatcher {
       this.consequent !== null ? this.consequent.outerStart : this.contentEnd,
       token => token.type === SourceType.THEN
     );
-    return thenTokenIndex ? this.sourceTokenAtIndex(thenTokenIndex) : null;
+    if (thenTokenIndex) {
+      return this.sourceTokenAtIndex(thenTokenIndex);
+    }
+    // In some cases, the node bounds are wrong and the `then` is after our
+    // current node, so just use that.
+    let nextToken = this.nextToken();
+    if (nextToken && nextToken.type === SourceType.THEN) {
+      return nextToken;
+    }
+    return null;
   }
 }

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -332,11 +332,9 @@ describe('switch', () => {
         # Do nothing
     `, `
       switch (a) {
-        case b: then;
-          break;
+        case b:  break;
           // Do nothing
-        case c: then;
-          break;
+        case c:  break;
       }
           // Do nothing
     `);


### PR DESCRIPTION
Fixes #958

The switch case bounds were wrong here, which I think is another CoffeeScript
parser bug, but I'm not 100% sure. Regardless, it's easy and safe to just look
for `then` as the next token, so I'll do that as a fallback.