### PR TITLE
fix: skip continuation tokens where the range has already been overwritten

### DIFF
--- a/src/stages/main/patchers/ProgramPatcher.js
+++ b/src/stages/main/patchers/ProgramPatcher.js
@@ -27,7 +27,14 @@ export default class ProgramPatcher extends SharedProgramPatcher {
   patchContinuations() {
     this.getProgramSourceTokens().forEach(token => {
       if (token.type === SourceType.CONTINUATION) {
-        this.remove(token.start, token.end);
+        try {
+          this.remove(token.start, token.end);
+        } catch (e) {
+          this.log(
+            'Warning: Ignoring a continuation token because it could not be ' +
+            'removed. Most likely, this is because its range has already ' +
+            'been overwritten.');
+        }
       }
     });
   }

--- a/test/binary_operator_test.js
+++ b/test/binary_operator_test.js
@@ -195,6 +195,15 @@ describe('binary operators', () => {
     `);
   });
 
+  it('handles multiline binary existence operator with escaped newline', () => {
+    check(`
+      a ? \\
+        b
+    `, `
+      if (typeof a === 'undefined' || a === null) { b; }
+    `);
+  });
+
   it('handles left shift as a nested operator', () => {
     check(`
       value = object.id << 8 | object.type


### PR DESCRIPTION
Fixes #964

Also add a warning, since this seems a bit fragile. But there are certainly some
cases where we no longer care about the continuation token because other code
got rid of it.