### PR TITLE
fix: handle list items ending in semicolon-terminated statements

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -871,12 +871,8 @@ export default class NodePatcher {
   /**
    * Gets the token after the end of this node, or null if there is none.
    */
-  nextToken(): ?SourceToken {
-    let nextTokenIndex = this.contentEndTokenIndex.next();
-    if (!nextTokenIndex) {
-      return null;
-    }
-    return this.sourceTokenAtIndex(nextTokenIndex);
+  nextSemanticToken(): ?SourceToken {
+    return this.getFirstSemanticToken(this.contentEnd, this.editor.original.length);
   }
 
   /**

--- a/src/stages/main/patchers/SwitchCasePatcher.js
+++ b/src/stages/main/patchers/SwitchCasePatcher.js
@@ -164,7 +164,7 @@ export default class SwitchCasePatcher extends NodePatcher {
     }
     // In some cases, the node bounds are wrong and the `then` is after our
     // current node, so just use that.
-    let nextToken = this.nextToken();
+    let nextToken = this.nextSemanticToken();
     if (nextToken && nextToken.type === SourceType.THEN) {
       return nextToken;
     }

--- a/src/stages/normalize/patchers/FunctionPatcher.js
+++ b/src/stages/normalize/patchers/FunctionPatcher.js
@@ -41,7 +41,7 @@ export default class FunctionPatcher extends NodePatcher {
       if (i === this.parameters.length - 1) {
         // Parameter lists allow trailing semicolons but not trailing commas, so
         // just get rid of it as a special case if it's there.
-        let nextToken = parameter.nextToken();
+        let nextToken = parameter.nextSemanticToken();
         if (nextToken && nextToken.type === SourceType.SEMICOLON) {
           this.remove(nextToken.start, nextToken.end);
         }

--- a/src/utils/postfixNodeNeedsOuterParens.js
+++ b/src/utils/postfixNodeNeedsOuterParens.js
@@ -12,7 +12,7 @@ import type NodePatcher from '../patchers/NodePatcher';
  * the block.
  */
 export default function postfixNodeNeedsOuterParens(patcher: NodePatcher): boolean {
-  let nextToken = patcher.nextToken();
+  let nextToken = patcher.nextSemanticToken();
   if (nextToken) {
     return nextToken.type === SourceType.COMMA || nextToken.type === SourceType.SEMICOLON;
   }

--- a/test/object_test.js
+++ b/test/object_test.js
@@ -425,4 +425,68 @@ describe('objects', () => {
       if (count) { ({a: {b: c}}); } else { ({d: {e: f}}); }
     `);
   });
+
+  it('handles an object with function values ending in semicolons', () => {
+    check(`
+      {
+        a: ->
+          b;
+        c: ->
+          d;
+      }
+    `, `
+      ({
+        a() {
+          return b;
+        },
+        c() {
+          return d;
+        }
+      });
+    `);
+  });
+
+  it('handles an object with parenthesized function values ending in semicolons', () => {
+    check(`
+      {
+        a: ->
+          (b);
+        c: ->
+          (d);
+      }
+    `, `
+      ({
+        a() {
+          return b;
+        },
+        c() {
+          return d;
+        }
+      });
+    `);
+  });
+
+  it('handles an object with semicolons on the next line', () => {
+    check(`
+      {
+        a: ->
+          b
+          ;
+        c: ->
+          d
+          ;
+      }
+    `, `
+      ({
+        a() {
+          return b;
+        },
+          
+        c() {
+          return d;
+        }
+          
+      });
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #970

Previously, any semicolons would be changed to commas in list items, but
sometimes, the semicolon is actually the end of a statement. In that case,
changing it to a comma would cause problems, so we just remove it instead, since
it's not necessary.