### PR TITLE
fix: don't remove parens for implicitly-returned expressions

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -714,7 +714,10 @@ export default class NodePatcher {
   }
 
   /**
-   * Patch the beginning of an implicitly-returned descendant.
+   * Patch the beginning of an implicitly-returned descendant. Unlike most
+   * statements, implicitly-returned statements will not have their surrounding
+   * parens removed, so the implicit return patching may need to remove
+   * surrounding parens.
    */
   patchImplicitReturnStart(patcher: NodePatcher) {
     patcher.setRequiresExpression();

--- a/src/stages/main/patchers/BlockPatcher.js
+++ b/src/stages/main/patchers/BlockPatcher.js
@@ -78,15 +78,18 @@ export default class BlockPatcher extends SharedBlockPatcher {
   }
 
   patchInnerStatement(statement) {
-    if (statement.isSurroundedByParentheses() && !statement.statementNeedsParens()) {
-      this.remove(statement.outerStart, statement.innerStart);
-      this.remove(statement.innerEnd, statement.outerEnd);
-    }
-
     let hasImplicitReturn = (
       statement.implicitlyReturns() &&
       !statement.explicitlyReturns()
     );
+
+    if (statement.isSurroundedByParentheses() &&
+        !statement.statementNeedsParens() &&
+        !hasImplicitReturn) {
+      this.remove(statement.outerStart, statement.innerStart);
+      this.remove(statement.innerEnd, statement.outerEnd);
+    }
+
     let implicitReturnPatcher = hasImplicitReturn ?
       this.implicitReturnPatcher() : null;
     if (implicitReturnPatcher) {

--- a/src/stages/main/patchers/LoopPatcher.js
+++ b/src/stages/main/patchers/LoopPatcher.js
@@ -139,6 +139,8 @@ export default class LoopPatcher extends NodePatcher {
    */
   patchImplicitReturnStart(patcher: NodePatcher) {
     // Control flow statements like break and continue should be skipped.
+    // Unlike some other control flow statements, CoffeeScript does not allow
+    // them to be wrapped in parens, so we don't need to remove any parens here.
     if (!patcher.canPatchAsExpression()) {
       return;
     }

--- a/src/stages/main/patchers/SwitchPatcher.js
+++ b/src/stages/main/patchers/SwitchPatcher.js
@@ -1,4 +1,5 @@
 import NodePatcher from '../../../patchers/NodePatcher';
+import BreakPatcher from './BreakPatcher';
 import type { PatcherContext, SourceToken } from '../../../patchers/types';
 import { SourceType } from 'coffee-lex';
 
@@ -86,6 +87,17 @@ export default class SwitchPatcher extends NodePatcher {
 
   canHandleImplicitReturn(): boolean {
     return this.willPatchAsExpression();
+  }
+
+  patchImplicitReturnStart(patcher: NodePatcher) {
+    if (patcher instanceof BreakPatcher) {
+      if (patcher.isSurroundedByParentheses()) {
+        this.remove(patcher.outerStart, patcher.innerStart);
+        this.remove(patcher.innerEnd, patcher.outerEnd);
+      }
+      return;
+    }
+    super.patchImplicitReturnStart(patcher);
   }
 
   /**

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -1,4 +1,5 @@
 import check from './support/check';
+import validate from './support/validate';
 
 describe('functions', () => {
   it('handles functions without a body', () => {
@@ -476,5 +477,24 @@ describe('functions', () => {
         return b;
       }));
     `)
+  );
+
+  it('handles an implicit return wrapped in multiline parens', () =>
+    check(`
+      -> (
+        true
+      )
+    `, `
+      () => true;
+    `)
+  );
+
+  it('has the correct result for an implicit return wrapped in multiline parens', () =>
+    validate(`
+      f = -> (
+        true
+      )
+      o = f()
+    `, true)
   );
 });

--- a/test/object_test.js
+++ b/test/object_test.js
@@ -465,10 +465,10 @@ describe('objects', () => {
     `, `
       ({
         a() {
-          return b;
+          return (b);
         },
         c() {
-          return d;
+          return (d);
         }
       });
     `);

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -503,4 +503,17 @@ describe('switch', () => {
       });
     `);
   });
+
+  it('handles parenthesized break in a switch statement', () => {
+    check(`
+      x = switch a
+        when b
+          (break)
+    `, `
+      let x = (() => { switch (a) {
+        case b:
+          break;
+      } })();
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #978

The new spec for implicit returning is that the parens are always kept and must
be handled by the implicit return code if necessary. For `return`, we want to
keep the parens to avoid ASI issues (and since we know it will always be an
expression). For `break` in `switch`, we need to remove the parens if they
exist, so add a special case for that. In loops, the issue doesn't seem to come
up; parens aren't allowed around `break` or `continue` in loops.