### PR TITLE
fix: properly set canPatchAsExpression for TryPatcher

### DIFF
--- a/src/stages/main/patchers/TryPatcher.js
+++ b/src/stages/main/patchers/TryPatcher.js
@@ -27,6 +27,19 @@ export default class TryPatcher extends NodePatcher {
     }
   }
 
+  canPatchAsExpression() {
+    if (this.body && !this.body.canPatchAsExpression()) {
+      return false;
+    }
+    if (this.catchBody && !this.catchBody.canPatchAsExpression()) {
+      return false;
+    }
+    if (this.finallyBody && !this.finallyBody.canPatchAsExpression()) {
+      return false;
+    }
+    return true;
+  }
+
   /**
    * 'try' BODY ( 'catch' ASSIGNEE? CATCH-BODY? )? ( 'finally' FINALLY-BODY )?
    */

--- a/test/try_test.js
+++ b/test/try_test.js
@@ -359,4 +359,26 @@ describe('try', () => {
       });
     `);
   });
+
+  it('properly handles continue within try within a loop expression', () => {
+    check(`
+      x = for a in b
+        try
+          continue
+        catch error
+          continue
+    `, `
+      let x = (() => {
+        let result = [];
+        for (let a of Array.from(b)) {
+          try {
+            continue;
+          } catch (error) {
+            continue;
+          }
+        }
+        return result;
+      })();
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #986

In some cases, we would try using `map` instead of an IIFE for a try within a
loop, which only works if the try can actually be used in an expression context.
When a try has a statement like `continue`, we need to disallow it from becoming
an expression.