### PR TITLE
fix: skip implicitly-returned break and continue in more cases

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -720,6 +720,13 @@ export default class NodePatcher {
    * surrounding parens.
    */
   patchImplicitReturnStart(patcher: NodePatcher) {
+    if (patcher.node.type === 'Break' || patcher.node.type === 'Continue') {
+      if (patcher.isSurroundedByParentheses()) {
+        this.remove(patcher.outerStart, patcher.innerStart);
+        this.remove(patcher.innerEnd, patcher.outerEnd);
+      }
+      return;
+    }
     patcher.setRequiresExpression();
     this.insert(patcher.outerStart, 'return ');
   }

--- a/src/stages/main/patchers/SwitchPatcher.js
+++ b/src/stages/main/patchers/SwitchPatcher.js
@@ -1,5 +1,4 @@
 import NodePatcher from '../../../patchers/NodePatcher';
-import BreakPatcher from './BreakPatcher';
 import type { PatcherContext, SourceToken } from '../../../patchers/types';
 import { SourceType } from 'coffee-lex';
 
@@ -87,17 +86,6 @@ export default class SwitchPatcher extends NodePatcher {
 
   canHandleImplicitReturn(): boolean {
     return this.willPatchAsExpression();
-  }
-
-  patchImplicitReturnStart(patcher: NodePatcher) {
-    if (patcher instanceof BreakPatcher) {
-      if (patcher.isSurroundedByParentheses()) {
-        this.remove(patcher.outerStart, patcher.innerStart);
-        this.remove(patcher.innerEnd, patcher.outerEnd);
-      }
-      return;
-    }
-    super.patchImplicitReturnStart(patcher);
   }
 
   /**

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -516,4 +516,20 @@ describe('switch', () => {
       } })();
     `);
   });
+
+  it('handles break within switch in an implicit return context', () => {
+    check(`
+      ->
+        switch a
+          when b
+            break
+    `, `
+      (function() {
+        switch (a) {
+          case b:
+            break;
+        }
+      });
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #987

Since we can generally assume the CoffeeScript we get is valid, it's generally
the case that any `break` and `continue` statements that are implicitly returned
should just be kept as-is, so we now apply that more broadly in `NodePatcher`.
In particular, a `break` within a non-IIFE switch that's implicitly returned was
causing a crash.