### PR TITLE
fix: add class expression close-parens at innerEnd

### DIFF
--- a/src/stages/main/patchers/ClassPatcher.js
+++ b/src/stages/main/patchers/ClassPatcher.js
@@ -94,7 +94,7 @@ export default class ClassPatcher extends NodePatcher {
       this.body.patch({ leftBrace: false });
     }
     if (needsParens) {
-      this.insert(this.contentEnd, ')');
+      this.insert(this.innerEnd, ')');
     }
   }
 

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1563,4 +1563,19 @@ describe('classes', () => {
       new (A = class A {});
     `);
   });
+
+  it('handles an expression-style class ending in a comment', () => {
+    check(`
+      x = class A
+        b: ->
+          c # d
+    `, `
+      let A;
+      let x = (A = class A {
+        b() {
+          return c; // d
+        }
+      });
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #988

Various code snippets inserted at the end of the class are already inserted at
`innerEnd`, so if we write to `contentEnd`, we might end up putting the
close-paren too early.