### PR TITLE
Change canPatchAsExpression to be more precise

### DIFF
--- a/src/stages/main/patchers/BlockPatcher.js
+++ b/src/stages/main/patchers/BlockPatcher.js
@@ -8,6 +8,12 @@ import { SourceType } from 'coffee-lex';
 export default class BlockPatcher extends SharedBlockPatcher {
   canPatchAsExpression(): boolean {
     return this.statements.every(
+      statement => statement.canPatchAsExpression()
+    );
+  }
+
+  prefersToPatchAsExpression(): boolean {
+    return this.statements.every(
       statement => statement.prefersToPatchAsExpression()
     );
   }
@@ -136,6 +142,7 @@ export default class BlockPatcher extends SharedBlockPatcher {
     } else {
       this.statements.forEach(
         (statement, i, statements) => {
+          statement.setRequiresExpression();
           statement.patch();
           if (i !== statements.length - 1) {
             let semicolonTokenIndex = this.getSemicolonSourceTokenBetween(

--- a/src/stages/main/patchers/ConditionalPatcher.js
+++ b/src/stages/main/patchers/ConditionalPatcher.js
@@ -5,7 +5,7 @@ import { SourceType } from 'coffee-lex';
 
 export default class ConditionalPatcher extends NodePatcher {
   condition: NodePatcher;
-  consequent: BlockPatcher;
+  consequent: ?BlockPatcher;
   alternate: ?BlockPatcher;
 
   negated: boolean = false;
@@ -19,6 +19,20 @@ export default class ConditionalPatcher extends NodePatcher {
 
   initialize() {
     this.condition.setRequiresExpression();
+  }
+
+  /**
+   * Anything like `break`, `continue`, or `return` inside a conditional means
+   * we can't even safely make it an IIFE.
+   */
+  canPatchAsExpression(): boolean {
+    if (this.consequent && !this.consequent.canPatchAsExpression()) {
+      return false;
+    }
+    if (this.alternate && !this.alternate.canPatchAsExpression()) {
+      return false;
+    }
+    return true;
   }
 
   prefersToPatchAsExpression(): boolean {

--- a/src/stages/main/patchers/ForInPatcher.js
+++ b/src/stages/main/patchers/ForInPatcher.js
@@ -97,7 +97,7 @@ export default class ForInPatcher extends ForPatcher {
     if (this.step !== null) {
       return false;
     }
-    if (!this.body.canPatchAsExpression()) {
+    if (!this.body.prefersToPatchAsExpression()) {
       return false;
     }
     // The high-level approach of a.filter(...).map((x, i) => ...) doesn't work,

--- a/test/try_test.js
+++ b/test/try_test.js
@@ -381,4 +381,12 @@ describe('try', () => {
       })();
     `);
   });
+
+  it('properly handles try used as an expression', () => {
+    check(`
+      x = try throw a catch then b
+    `, `
+      let x = (() => { try { throw a; } catch (error) { return b; } })();
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #993

`throw` is an example of a node type that can patch as an expression, but
prefers not to. Our existing BlockPatcher code was using that to say that the
block could not be patched as an expression when actually it could, so
decaffeinate was crashing on valid code. Fixing this had some cascading effects,
and generally some more code needed to be more precise about prefering an
expression vs requiring an expression.