### PR TITLE
fix: properly handle negated parenthesized soak operations

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -1014,6 +1014,21 @@ export default class NodePatcher {
    */
   negate() {
     this.insert(this.contentStart, '!');
+    this._hadUnparenthesizedNegation = true;
+  }
+
+  /**
+   * Check if this node has been negated by simply adding a `!` to the front.
+   * In some cases, this node may be later changed into an expression that would
+   * require additional parens, e.g. a soak container being transformed into a
+   * ternary expression, so track the negation so we know to add parens if
+   * necessary.
+   *
+   * Note that most custom negate() implementations already add parens, so they
+   * don't need to return true here.
+   */
+  hadUnparenthesizedNegation() {
+    return this._hadUnparenthesizedNegation || false;
   }
 
   /**

--- a/src/utils/ternaryNeedsParens.js
+++ b/src/utils/ternaryNeedsParens.js
@@ -20,6 +20,9 @@ import type NodePatcher from '../patchers/NodePatcher';
  * slightly ugly code rather than incorrect code.
  */
 export default function ternaryNeedsParens(patcher: NodePatcher): boolean {
+  if (patcher.hadUnparenthesizedNegation()) {
+    return true;
+  }
   let { parent } = patcher;
   return !(
     patcher.isSurroundedByParentheses() ||

--- a/test/soaked_test.js
+++ b/test/soaked_test.js
@@ -919,4 +919,72 @@ describe('soaked expressions', () => {
       }
     `);
   });
+
+  it('handles a parenthesized soak operation within `unless`', () => {
+    check(`
+      a = {b: 1}
+      unless (a?.b)
+        c
+    `, `
+      let a = {b: 1};
+      if (!(a != null ? a.b : undefined)) {
+        c;
+      }
+    `);
+  });
+
+  it('handles a nested parenthesized soak operation within `unless`', () => {
+    check(`
+      a = {b: 1}
+      unless (a?.b.c)
+        d
+    `, `
+      let a = {b: 1};
+      if (!(a != null ? a.b.c : undefined)) {
+        d;
+      }
+    `);
+  });
+
+  it('handles a parenthesized soak operation within `until`', () => {
+    check(`
+      a = {b: 1}
+      until (a?.b)
+        c
+    `, `
+      let a = {b: 1};
+      while (!(a != null ? a.b : undefined)) {
+        c;
+      }
+    `);
+  });
+
+  it('handles a parenthesized soak operation within a negated logical operator', () => {
+    check(`
+      a = {b: 1}
+      unless c and (a?.b)
+        d
+    `, `
+      let a = {b: 1};
+      if (!c || (!(a != null ? a.b : undefined))) {
+        d;
+      }
+    `);
+  });
+
+  it('handles a parenthesized soak operation within a negated switch case', () => {
+    check(`
+      a = {b: 1}
+      switch
+        when (a?.b)
+          c
+    `, `
+      let a = {b: 1};
+      switch (false) {
+        case (!(a != null ? a.b : undefined)):
+          c;
+          break;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #995

When a node is negated and then changed to a ternary as part of a soak
operation, we weren't always adding parens when we needed to. In particular,
when the expression was already surrounded in parens, the soak code would view
extra parens as unnecessary even though a `!` had been inserted within those
parens. Now, we track when we negate in that way and always add parens in that
case when changing a soak container to a ternary.