### PR TITLE
fix: convert explicit returns to implicit returns when necessary

### DIFF
--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -751,4 +751,18 @@ describe('conditionals', () => {
       if (b) { a; } c;
     `);
   });
+
+  it('handles a return within a returned conditional', () => {
+    check(`
+      ->
+        return if a
+          return b
+    `, `
+      (function() {
+        if (a) {
+          return b;
+        }
+      });
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #1002

In some cases, CoffeeScript allows you to `return` something that cannot be
converted to an expression according to CoffeeScript's rules, such as a
conditional containing control flow statements. We now allow this by removing
the `return` at patch time and marking the expression as implicitly returning.