### PR TITLE
feat: add support for Literate CoffeeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ problems you run into.
 
 ## Options
 
+* `--literate`: Treat the input file as Literate CoffeeScript.
 * `--keep-commonjs`: Do not convert `require` and `module.exports` to `import`
   and `export`.
 * `--force-default-export`: When converting to `export`, use a single

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,7 +6,7 @@ import type { Readable, Writable } from 'stream';
 import type { WriteStream } from 'tty';
 import { convert } from './index';
 import type { Options } from './index';
-import { join, dirname, basename, extname } from 'path';
+import { join, dirname, basename } from 'path';
 import { stat, readdir, createReadStream, createWriteStream } from 'fs';
 
 /**
@@ -126,7 +126,10 @@ function runWithPaths(paths: Array<string>, baseOptions: Options, callback: ?((e
       else {
         pending.unshift(
           ...children
-            .filter(child => extname(child) === '.coffee')
+            .filter(child =>
+              child.endsWith('.coffee') ||
+              child.endsWith('.litcoffee') ||
+              child.endsWith('.coffee.md'))
             .map(child => join(path, child))
         );
       }
@@ -135,7 +138,11 @@ function runWithPaths(paths: Array<string>, baseOptions: Options, callback: ?((e
   }
 
   function processFile(path: string) {
-    let outputPath = join(dirname(path), basename(path, extname(path))) + '.js';
+    let filename = basename(path)
+      .replace(/\.coffee$/, '.js')
+      .replace(/\.litcoffee$/, '.js')
+      .replace(/\.coffee\.md$/, '.js');
+    let outputPath = join(dirname(path), filename);
     console.log(`${path} → ${outputPath}`);
     runWithStream(
       path,

--- a/src/cli.js
+++ b/src/cli.js
@@ -40,6 +40,10 @@ function parseArguments(args: Array<string>): CLIOptions {
         process.exit(0);
         break;
 
+      case '--literate':
+        baseOptions.literate = true;
+        break;
+
       case '--keep-commonjs':
         baseOptions.keepCommonJS = true;
         break;
@@ -206,6 +210,7 @@ function usage() {
   console.log('OPTIONS');
   console.log();
   console.log('  -h, --help               Display this help message.');
+  console.log('  --literate               Treat the input file as Literate CoffeeScript.');
   console.log('  --keep-commonjs          Do not convert require and module.exports to import and export.');
   console.log('  --force-default-export   When converting to export, use a single "export default" rather ');
   console.log('                           than trying to generate named imports where possible.');

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { tokens } from 'decaffeinate-coffeescript';
 import AddVariableDeclarationsStage from './stages/add-variable-declarations/index';
 import SemicolonsStage from './stages/semicolons/index';
 import EsnextStage from './stages/esnext/index';
+import LiterateStage from './stages/literate/index';
 import MainStage from './stages/main/index';
 import NormalizeStage from './stages/normalize/index';
 import convertNewlines from './utils/convertNewlines';
@@ -21,6 +22,7 @@ export { PatchError };
 export type Options = {
   filename: ?string,
   runToStage: ?string,
+  literate: ?boolean,
   keepCommonJS: ?boolean,
   forceDefaultExport: ?boolean,
   safeImportFunctionIdentifiers: ?Array<string>,
@@ -37,6 +39,7 @@ export type Options = {
 const DEFAULT_OPTIONS = {
   filename: 'input.coffee',
   runToStage: null,
+  literate: false,
   keepCommonJS: false,
   forceDefaultExport: false,
   safeImportFunctionIdentifiers: [],
@@ -68,7 +71,12 @@ export function convert(source: string, options: ?Options={}): ConversionResult 
   options = Object.assign({}, DEFAULT_OPTIONS, options);
   let originalNewlineStr = detectNewlineStr(source);
   source = convertNewlines(source, '\n');
+
+  let literate = options.literate ||
+    options.filename.endsWith('.litcoffee') ||
+    options.filename.endsWith('.coffee.md');
   let stages = [
+    ...(literate ? [LiterateStage] : []),
     NormalizeStage,
     MainStage,
     AddVariableDeclarationsStage,

--- a/src/stages/literate/index.js
+++ b/src/stages/literate/index.js
@@ -1,0 +1,98 @@
+const VALID_INDENTATIONS = ['    ', '   \t', '  \t', ' \t', '\t'];
+
+/**
+ * Convert Literate CoffeeScript into regular CoffeeScript.
+ */
+export default class LiterateStage {
+  static run(content: string): { code: string } {
+    return {
+      code: convertCodeFromLiterate(content),
+    };
+  }
+}
+
+/**
+ * Every line is either indented, unindented, or empty. A code section starts
+ * when there is an empty line (or the start of the program) followed by an
+ * indented line. A code section ends when there is an unindented line.
+ *
+ * This should match the behavior of helpers.invertLiterate in CoffeeScript,
+ * while also forming the result into nice-looking comment blocks.
+ */
+function convertCodeFromLiterate(code: string): string {
+  let lines = code.split('\n');
+  let resultLines = [];
+
+  // null if we're in a code section; otherwise the comment lines so far for the
+  // current comment.
+  let commentLines = null;
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
+    if (commentLines === null) {
+      if (lineIsEmpty(line) || lineIsIndented(line)) {
+        resultLines.push(removeIndentation(line));
+      } else {
+        commentLines = [line];
+      }
+    } else {
+      // Remain a comment on an empty line, an unindented line, or if the last
+      // line was nonempty.
+      if (lineIsEmpty(line) || !lineIsIndented(line) ||
+          (i > 0 && !lineIsEmpty(lines[i - 1]))) {
+        commentLines.push(line);
+      } else {
+        resultLines.push(...convertCommentLines(commentLines));
+        commentLines = null;
+        resultLines.push(removeIndentation(line));
+      }
+    }
+  }
+  resultLines.push(...convertCommentLines(commentLines));
+  return resultLines.join('\n');
+}
+
+/**
+ * Format a comment from an array of lines, including all trailing whitespace
+ * lines. Multiline comments without a star-slash or a ### are turned into block
+ * comments which become JS multiline comments. Other comments become normal //
+ * comments in JS.
+ *
+ * All blank lines between the comment lines and the following code are removed,
+ * which generally matches JS comment style.
+ */
+function convertCommentLines(commentLines: ?Array<string>): Array<string> {
+  if (commentLines === null) {
+    return [];
+  }
+  commentLines = commentLines.slice();
+  while (commentLines.length > 0 && lineIsEmpty(commentLines[commentLines.length - 1])) {
+    commentLines.pop();
+  }
+
+  let fullComment = commentLines.join('\n');
+  if (commentLines.length === 1 || fullComment.includes('###') || fullComment.includes('*/')) {
+    return [...commentLines.map(line => `# ${line}`)];
+  } else {
+    return ['###', ...commentLines.map(line => `# ${line}`), '###'];
+  }
+}
+
+function lineIsEmpty(line: string): boolean {
+  return /^\s*$/.test(line);
+}
+
+function lineIsIndented(line: string): boolean {
+  return VALID_INDENTATIONS.some(indent => line.startsWith(indent));
+}
+
+function removeIndentation(line: string): string {
+  for (let indent of VALID_INDENTATIONS) {
+    if (line.startsWith(indent)) {
+      return line.slice(indent.length);
+    }
+  }
+  if (lineIsEmpty(line)) {
+    return line;
+  }
+  throw new Error('Unexpectedly removed indentation from an unindented line.');
+}

--- a/test/literate_test.js
+++ b/test/literate_test.js
@@ -1,0 +1,127 @@
+import check from './support/check';
+
+describe('literate mode', () => {
+  it('handles a simple case', () => {
+    check(`
+      This is a *thing*.
+      It doesn't do much.
+      
+          thing = 1
+      
+      This is another thing. It's a little more interesting.
+      
+          otherThing = for foo in stuff
+            if foo % 2 == 0
+              foo + 1
+    `, `
+      /*
+       * This is a *thing*.
+       * It doesn't do much.
+       */
+      let thing = 1;
+      
+      // This is another thing. It's a little more interesting.
+      let otherThing = (() => {
+        let result = [];
+        for (let foo of Array.from(stuff)) {
+          let item;
+          if ((foo % 2) === 0) {
+            item = foo + 1;
+          }
+          result.push(item);
+        }
+        return result;
+      })();
+    `, { literate: true });
+  });
+
+  it('handles a file starting with code and ending with a comment', () => {
+    check(`
+          a = 1
+          b = 2
+          c = 3
+      Those are the first three letters of the alphabet.
+    `, `
+      let a = 1;
+      let b = 2;
+      let c = 3;
+      // Those are the first three letters of the alphabet.
+    `, { literate: true });
+  });
+
+  it('requires a blank line before moving to a code section', () => {
+    check(`
+      I can
+        indent
+          all that I want
+            and it still will be in a comment.
+      
+          exceptNow = true
+    `, `
+      /*
+       * I can
+       *   indent
+       *     all that I want
+       *       and it still will be in a comment.
+       */
+      let exceptNow = true;
+    `, { literate: true });
+  });
+
+  it('handles a file with `###` and `*/`', () => {
+    check(`
+      This won't be a multiline comment
+      because it has a ###.
+      
+          a = 1
+      
+      This will be a multiline comment
+      because /* is ok.
+      
+          b = 2
+      
+      But this line also can't be multiline
+      because it has a */.
+      
+          c = 3
+    `, `
+      // This won't be a multiline comment
+      // because it has a ###.
+      let a = 1;
+      
+      /*
+       * This will be a multiline comment
+       * because /* is ok.
+       */
+      let b = 2;
+      
+      // But this line also can't be multiline
+      // because it has a */.
+      let c = 3;
+    `, { literate: true });
+  });
+
+  it('treats normal coffee files as non-literate', () => {
+    check(`
+      a = 1
+    `, `
+      let a = 1;
+    `, { filename: 'foo.coffee' });
+  });
+
+  it('treats .coffee.md files as literate', () => {
+    check(`
+      a = 1
+    `, `
+      // a = 1
+    `, { filename: 'foo.coffee.md' });
+  });
+
+  it('treats .litcoffee files as literate', () => {
+    check(`
+      a = 1
+    `, `
+      // a = 1
+    `, { filename: 'foo.litcoffee' });
+  });
+});


### PR DESCRIPTION
Fixes #714

I maybe should have taken a simpler approach, but this was a fun exercise.
There's now an optional stage at the start that turns literate CoffeeScript into
regular CoffeeScript with some tweaks to make the result look nice. I don't use
magic-string, and instead just produce an array of lines that gets joined into
the final source code, which seems fine because source maps are unlikely to
happen and going line-by-line is a little easier for this case.