### PR TITLE
fix: avoid block comments when processing literate coffeescript

### DIFF
--- a/src/stages/literate/index.js
+++ b/src/stages/literate/index.js
@@ -53,9 +53,9 @@ function convertCodeFromLiterate(code: string): string {
 
 /**
  * Format a comment from an array of lines, including all trailing whitespace
- * lines. Multiline comments without a star-slash or a ### are turned into block
- * comments which become JS multiline comments. Other comments become normal //
- * comments in JS.
+ * lines. All comments become normal // comments in JS, since block comments are
+ * treated specially by the CoffeeScript parser and can cause trouble if they
+ * are introduced at the wrong indentation level.
  *
  * All blank lines between the comment lines and the following code are removed,
  * which generally matches JS comment style.
@@ -68,13 +68,7 @@ function convertCommentLines(commentLines: ?Array<string>): Array<string> {
   while (commentLines.length > 0 && lineIsEmpty(commentLines[commentLines.length - 1])) {
     commentLines.pop();
   }
-
-  let fullComment = commentLines.join('\n');
-  if (commentLines.length === 1 || fullComment.includes('###') || fullComment.includes('*/')) {
-    return [...commentLines.map(line => `# ${line}`)];
-  } else {
-    return ['###', ...commentLines.map(line => `# ${line}`), '###'];
-  }
+  return commentLines.map(line => `# ${line}`);
 }
 
 function lineIsEmpty(line: string): boolean {

--- a/test/literate_test.js
+++ b/test/literate_test.js
@@ -14,10 +14,8 @@ describe('literate mode', () => {
             if foo % 2 == 0
               foo + 1
     `, `
-      /*
-       * This is a *thing*.
-       * It doesn't do much.
-       */
+      // This is a *thing*.
+      // It doesn't do much.
       let thing = 1;
       
       // This is another thing. It's a little more interesting.
@@ -58,46 +56,44 @@ describe('literate mode', () => {
       
           exceptNow = true
     `, `
-      /*
-       * I can
-       *   indent
-       *     all that I want
-       *       and it still will be in a comment.
-       */
+      // I can
+      //   indent
+      //     all that I want
+      //       and it still will be in a comment.
       let exceptNow = true;
     `, { literate: true });
   });
 
-  it('handles a file with `###` and `*/`', () => {
+  it('handles increasing indentation across distinct code sections', () => {
     check(`
-      This won't be a multiline comment
-      because it has a ###.
+      This is a
+      multiline comment.
       
-          a = 1
+          if a
       
-      This will be a multiline comment
-      because /* is ok.
+      This is another
+      multiline comment.      
+
+            if b
       
-          b = 2
+      This is yet another
+      multiline comment.      
       
-      But this line also can't be multiline
-      because it has a */.
-      
-          c = 3
+              c
     `, `
-      // This won't be a multiline comment
-      // because it has a ###.
-      let a = 1;
+      // This is a
+      // multiline comment.
+      if (a) {
       
-      /*
-       * This will be a multiline comment
-       * because /* is ok.
-       */
-      let b = 2;
+      // This is another
+      // multiline comment.      
+        if (b) {
       
-      // But this line also can't be multiline
-      // because it has a */.
-      let c = 3;
+      // This is yet another
+      // multiline comment.      
+          c;
+        }
+      }
     `, { literate: true });
   });
 


### PR DESCRIPTION
Since CoffeeScript block comments have a meaningful indentation level, it's
actually unsafe to insert them anywhere in the file, since indentation
differences can cause the normalize stage to break. Instead, we now take the
boring approach of always using `//` comments. Theoretically, we could be
smarter about this and convert them to multiline comments on the JS side where
the indentation doesn't matter, but that seems like it's probably not worth it.