### PR TITLE
fix: always replace the extension with .js

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -6,7 +6,7 @@ import type { Readable, Writable } from 'stream';
 import type { WriteStream } from 'tty';
 import { convert } from './index';
 import type { Options } from './index';
-import { join, dirname, basename } from 'path';
+import { join, dirname, basename, extname } from 'path';
 import { stat, readdir, createReadStream, createWriteStream } from 'fs';
 
 /**
@@ -138,11 +138,8 @@ function runWithPaths(paths: Array<string>, baseOptions: Options, callback: ?((e
   }
 
   function processFile(path: string) {
-    let filename = basename(path)
-      .replace(/\.coffee$/, '.js')
-      .replace(/\.litcoffee$/, '.js')
-      .replace(/\.coffee\.md$/, '.js');
-    let outputPath = join(dirname(path), filename);
+    let extension = path.endsWith('.coffee.md') ? '.coffee.md' : extname(path);
+    let outputPath = join(dirname(path), basename(path, extension)) + '.js';
     console.log(`${path} → ${outputPath}`);
     runWithStream(
       path,


### PR DESCRIPTION
Fixes #1007

This fixes a regression caused by #1005 where the computed filename was only
changed if the original filename ended in .coffee, .litcoffee or .coffee.md.
Really, we want to keep the old behavior and always change whatever file
extension we find (or just add .js if there's no extension). But to properly
handle .coffee.md we should just special-case that.

I tested this manually, but plan to add automated tests for the CLI pretty soon.