### PR TITLE
test: increase the test timeout to 10 seconds

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,3 @@
 --compilers ts:ts-node/register,js:./test/support/babel-register.js
 --recursive
+--timeout 10000


### PR DESCRIPTION
This should avoid timeouts in the CLI tests.