### PR TITLE
fix: Revert "fix: tweak travis config to make releases work again"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ after_success:
   - 'curl -Lo travis_after_all.py https://git.io/travis_after_all'
   - python travis_after_all.py
   - export $(cat .to_export_back) &> /dev/null
-  - export GH_TOKEN=${ALANGPIERCE_GH_TOKEN}
   - npm run semantic-release
   - npm run update-website
 branches:


### PR DESCRIPTION
This reverts commit 5b9df237e659fb08e14d8042ac0a77931939fb21.

The original `GH_TOKEN` value was compromised in [some sort of vulnerability](https://blog.travis-ci.com/2016-11-23-security-vulnerability-environment-variables/). I created a new one, so we can use it instead of the one you so graciously contributed @alangpierce 😉 