### PR TITLE
fix: avoid parameter assignments assigning to outer variables

### DIFF
--- a/src/stages/normalize/patchers/DefaultParamPatcher.js
+++ b/src/stages/normalize/patchers/DefaultParamPatcher.js
@@ -1,8 +1,6 @@
 import AssignOpPatcher from './AssignOpPatcher';
 import DoOpPatcher from './DoOpPatcher';
 import FunctionPatcher from './FunctionPatcher';
-import IdentifierPatcher from './IdentifierPatcher';
-import MemberAccessOpPatcher from './MemberAccessOpPatcher';
 import PassthroughPatcher from '../../../patchers/PassthroughPatcher';
 
 export default class DefaultParamPatcher extends PassthroughPatcher {
@@ -28,10 +26,7 @@ export default class DefaultParamPatcher extends PassthroughPatcher {
       if (callback) {
         let paramCode = this.slice(this.param.contentStart, this.param.contentEnd);
         let valueCode = this.slice(this.value.contentStart, this.value.contentEnd);
-        let assigneeIsValidExpression = this.param instanceof IdentifierPatcher ||
-          this.param instanceof MemberAccessOpPatcher;
-
-        let newParamCode = callback(paramCode, valueCode, assigneeIsValidExpression);
+        let newParamCode = callback(paramCode, valueCode, this.param.node);
         this.overwrite(this.param.contentStart, this.param.contentEnd, newParamCode);
         this.remove(this.param.outerEnd, this.value.outerEnd);
       }

--- a/src/utils/getAssigneeBindings.js
+++ b/src/utils/getAssigneeBindings.js
@@ -1,0 +1,33 @@
+/**
+ * @flow
+ */
+import type { Node } from '../patchers/types';
+
+/**
+ * Determine the variables introduced by this assignee (array destructure,
+ * object destructure, rest, etc.).
+ */
+export default function getAssigneeBindings(node: Node): Array<string> {
+  if (node.type === 'Identifier') {
+    return [node.data];
+  } else if (node.type === 'ArrayInitialiser') {
+    let bindings = [];
+    for (let member of node.members) {
+      bindings.push(...getAssigneeBindings(member));
+    }
+    return bindings;
+  } else if (node.type === 'ObjectInitialiser') {
+    let bindings = [];
+    for (let member of node.members) {
+      bindings.push(...getAssigneeBindings(member));
+    }
+    return bindings;
+  } else if (node.type === 'ObjectInitialiserMember') {
+    return getAssigneeBindings(node.expression);
+  } else if (node.type === 'AssignOp') {
+    return getAssigneeBindings(node.assignee);
+  } else if (node.type === 'Spread' || node.type === 'Rest') {
+    return getAssigneeBindings(node.expression);
+  }
+  return [];
+}

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -300,6 +300,7 @@ describe('function calls', () => {
           _authenticate(authKey, cb) {
             return this._getSession(authKey, function(err, param) {
                 let org, person, user;
+                let authKey;
                 if (param == null) { param = {}; }
                 ({person, user, authKey, org} = param);
                 return cb(null, {person, authKey, user, org});

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -497,4 +497,23 @@ describe('functions', () => {
       o = f()
     `, true)
   );
+
+  it('does not overwrite outer variables when doing parameter array destructuring', () =>
+    validate(`
+      x = 'original'
+      f = ([x]) -> x
+      f(['new'])
+      o = x
+    `, 'original')
+  );
+
+  it('does not overwrite outer variables when doing parameter object destructuring', () =>
+    validate(`
+      a = 1
+      f = ({a} = {a: 2}) ->
+        return
+      f({a: 3})
+      o = a
+    `, 1)
+  );
 });


### PR DESCRIPTION
Fixes #1010

We resolve parameter assignments in the normalize stage, so the way to ensure
that they're scoped to the function is to add `var`. To avoid excessive
independent variable declarations, we only do this when there's actually a
variale in the outer scope.