### PR TITLE
fix: properly handle \0 chars in heregexes

### DIFF
--- a/src/stages/main/patchers/HeregexPatcher.js
+++ b/src/stages/main/patchers/HeregexPatcher.js
@@ -21,4 +21,8 @@ export default class HeregexPatcher extends InterpolatedPatcher {
     this.processContents();
     this.escapeQuasis(/^\\\s/, ['`', '${', '\\']);
   }
+
+  shouldExcapeZeroChars() {
+    return true;
+  }
 }

--- a/src/stages/main/patchers/InterpolatedPatcher.js
+++ b/src/stages/main/patchers/InterpolatedPatcher.js
@@ -4,6 +4,7 @@ import repeat from 'repeating';
 import NodePatcher from './../../../patchers/NodePatcher';
 import escape from '../../../utils/escape';
 import escapeSpecialWhitespaceInRange from '../../../utils/escapeSpecialWhitespaceInRange';
+import escapeZeroCharsInRange from '../../../utils/escapeZeroCharsInRange';
 
 export default class InterpolatedPatcher extends NodePatcher {
   quasis: Array<NodePatcher>;
@@ -77,9 +78,16 @@ export default class InterpolatedPatcher extends NodePatcher {
           this.insert(token.start, ' \\');
         } else if (token.type === SourceType.STRING_CONTENT) {
           escapeSpecialWhitespaceInRange(token.start, token.end, this);
+          if (this.shouldExcapeZeroChars()) {
+            escapeZeroCharsInRange(token.start, token.end, this);
+          }
         }
       }
     }
+  }
+
+  shouldExcapeZeroChars() {
+    return false;
   }
 
   escapeQuasis(skipPattern, escapeStrings) {

--- a/src/utils/escapeSpecialWhitespaceInRange.js
+++ b/src/utils/escapeSpecialWhitespaceInRange.js
@@ -11,7 +11,7 @@ function isAlreadyEscaped(i: number, start: number, patcher: NodePatcher): boole
   return numLeadingBackslashes % 2 === 1;
 }
 
-export default function exportSpecialWhitespaceInRange(start: number, end: number, patcher: NodePatcher) {
+export default function escapeSpecialWhitespaceInRange(start: number, end: number, patcher: NodePatcher) {
   for (let i = start; i < end; i++) {
     let unicodeSequence = null;
     if (patcher.context.source[i] === '\u2028') {

--- a/src/utils/escapeZeroCharsInRange.js
+++ b/src/utils/escapeZeroCharsInRange.js
@@ -1,0 +1,16 @@
+/* @flow */
+
+import type NodePatcher from '../patchers/NodePatcher';
+
+export default function escapeZeroCharsInRange(start: number, end: number, patcher: NodePatcher) {
+  let numBackslashes = 0;
+  for (let i = start; i < end; i++) {
+    if (patcher.context.source[i] === '\\') {
+      numBackslashes++;
+      continue;
+    } else if (patcher.context.source[i] === '0' && numBackslashes % 2 === 1) {
+      patcher.overwrite(i, i + 1, 'x00');
+    }
+    numBackslashes = 0;
+  }
+}

--- a/test/regular_expression_test.js
+++ b/test/regular_expression_test.js
@@ -1,4 +1,5 @@
 import check from './support/check';
+import validate from './support/validate';
 
 describe('regular expressions', () => {
   it('passes regular expressions through as-is', () => {
@@ -127,6 +128,20 @@ describe('regular expressions', () => {
       `, `
       new RegExp(\`\\u2029\`);
     `);
+  });
+
+  it('handles \\0 within heregexes', () => {
+    check(`
+      ///\\0///
+      `, `
+      new RegExp(\`\\\\x00\`);
+    `);
+  });
+
+  it('behaves correctly with \\0 within heregexes', () => {
+    validate(`
+      o = ///\\0 1///.test '\x001'
+      `, true);
   });
 
   it('handles a double backslash followed by a space', () => {

--- a/test/string_test.js
+++ b/test/string_test.js
@@ -1,4 +1,5 @@
 import check from './support/check';
+import validate from './support/validate';
 
 describe('strings', () => {
   it('changes single-line triple-double-quotes to double-quotes', () => {
@@ -151,5 +152,14 @@ describe('strings', () => {
       `, `
       '\\\\\\u2028';
     `);
+  });
+
+  it('handles \\0 followed by a number', () => {
+    validate(`
+      o = '
+        \\0\\
+        1
+      '
+      `, '\x001');
   });
 });


### PR DESCRIPTION
Fixes #1028

In other cases, we don't remove intermediate whitespace, so we don't need to
worry, but for heregexes we might e.g. have `\0 1`, which would convert to
`\01`, which is an octal literal. Instead, we always convert `\0` to `\x00`.
This is a little dumber than CoffeeScript's approach, since we always do the
conversion in heregexes and CoffeeScript only does it if the next character is
0-7, but this case seems rare enough that we don't need to be too clever about
it.