### PR TITLE
fix: surround ChainedComparisonOpPatcher in parens when necessary

### DIFF
--- a/src/stages/main/patchers/ChainedComparisonOpPatcher.js
+++ b/src/stages/main/patchers/ChainedComparisonOpPatcher.js
@@ -24,10 +24,15 @@ export default class ChainedComparisonOpPatcher extends NodePatcher {
     }
   }
 
-  patchAsExpression() {
+  patchAsExpression({ needsParens=false }={}) {
     let negateEntireExpression = this.shouldNegateEntireExpression();
+    let addParens = negateEntireExpression ||
+      (needsParens && !this.isSurroundedByParentheses());
     if (negateEntireExpression) {
-      this.insert(this.contentStart, '!(');
+      this.insert(this.contentStart, '!');
+    }
+    if (addParens) {
+      this.insert(this.contentStart, '(');
     }
 
     let middle = this.getMiddleOperands();
@@ -61,7 +66,7 @@ export default class ChainedComparisonOpPatcher extends NodePatcher {
       );
     }
 
-    if (negateEntireExpression) {
+    if (addParens) {
       this.insert(this.contentEnd, ')');
     }
   }

--- a/test/chained_comparison_test.js
+++ b/test/chained_comparison_test.js
@@ -1,4 +1,5 @@
 import check from './support/check';
+import validate from './support/validate';
 
 describe('chained comparison', () => {
   it('repeats the middle operand when it is safe', () => {
@@ -134,5 +135,11 @@ describe('chained comparison', () => {
     `, `
       (a === b) === c && c === d && d === e;
     `);
+  });
+
+  it('obeys operator precedence with chained comparison ops', () => {
+    validate(`
+      o = 1 | 2 < 3 < 4
+    `, 1);
   });
 });

--- a/test/soaked_test.js
+++ b/test/soaked_test.js
@@ -140,8 +140,8 @@ describe('soaked expressions', () => {
     it('skips soaked function invocations on non-functions', () => {
       validate(`
         f = 3
-        o = f?()
-      `, undefined);
+        o = '' + f?()
+      `, 'undefined');
     });
 
     it('properly sets this in soaked method calls', () => {
@@ -459,8 +459,8 @@ describe('soaked expressions', () => {
     it('correctly handles missing soaked access', () => {
       validate(`
         a = {b: null}
-        o = a.b?.c
-      `, undefined);
+        o = '' + a.b?.c
+      `, 'undefined');
     });
 
     it('correctly handles dynamic soaked access', () => {
@@ -473,15 +473,15 @@ describe('soaked expressions', () => {
     it('correctly handles missing dynamic soaked access', () => {
       validate(`
         a = {b: null}
-        o = a.b?['c']
-      `, undefined);
+        o = '' + a.b?['c']
+      `, 'undefined');
     });
 
     it('stops evaluating the expression when hitting a soak failure', () => {
         validate(`
         a = {b: 5}
-        o = a.d?.e.f()
-      `, undefined);
+        o = '' + a.d?.e.f()
+      `, 'undefined');
     });
 
     it('skips assignment when a soak fails', () => {


### PR DESCRIPTION
Fixes #1034

I also changed the test code to do strict primitive checks, which it wasn't
doing before.