### PR TITLE
docs: use `a` instead of `span` for IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,11 @@ Project                                                  | Lines of CoffeeScript
 **Project builder status:** [![Build Status](https://travis-ci.org/decaffeinate/decaffeinate-example-builder.svg?branch=master)](https://travis-ci.org/decaffeinate/decaffeinate-example-builder)
 
 **Notes:**
-1. <span id='autoprefixer-note'></span>
-   autoprefixer has fully moved to JavaScript via decaffeinate.
-   This build runs on the last commit before the switch to JS.
-2. <span id='coffeescript-note'></span>
-   Some CoffeeScript tests are disabled because they are difficult to fix and
-   test cases that do not seem to come up in real-world code. See
+1. <a id='autoprefixer-note'></a>autoprefixer has fully moved to JavaScript via
+   decaffeinate. This build runs on the last commit before the switch to JS.
+2. <a id='coffeescript-note'></a>Some CoffeeScript tests are disabled because
+   they are difficult to fix and test cases that do not seem to come up in
+   real-world code. See
    [How decaffeinate approaches correctness][correctness-issues] for full details.
 
 To contribute to this list, send a pull request to the [decaffeinate-examples]


### PR DESCRIPTION
Apparently GitHub-flavored markdown filters out all spans.