### PR TITLE
test: rework the validate function to be more flexible

### DIFF
--- a/test/chained_comparison_test.js
+++ b/test/chained_comparison_test.js
@@ -139,7 +139,7 @@ describe('chained comparison', () => {
 
   it('obeys operator precedence with chained comparison ops', () => {
     validate(`
-      o = 1 | 2 < 3 < 4
+      setResult(1 | 2 < 3 < 4)
     `, 1);
   });
 });

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1142,7 +1142,7 @@ describe('classes', () => {
       class B extends A
       B::c = -> super + 1
       b = new B()
-      o = b.c()
+      setResult(b.c())
     `, 4);
   });
 
@@ -1156,7 +1156,7 @@ describe('classes', () => {
             super
           f(x + 3)
       b = new B()
-      o = b.c(1)
+      setResult(b.c(1))
     `, 9);
   });
 
@@ -1227,7 +1227,7 @@ describe('classes', () => {
   it('has the proper runtime behavior for a named class in an expression context', () => {
     validate(`
       A = class B
-      o = B.name
+      setResult(B.name)
     `, 'B');
   });
 
@@ -1380,7 +1380,7 @@ describe('classes', () => {
   it('assigns the right name to a normal class constructor', () => {
     validate(`
       class A
-      o = A.name
+      setResult(A.name)
     `, 'A');
   });
 
@@ -1388,7 +1388,7 @@ describe('classes', () => {
     validate(`
       A = {}
       class A.B
-      o = A.B.name
+      setResult(A.B.name)
     `, 'B');
   });
 
@@ -1396,7 +1396,7 @@ describe('classes', () => {
     validate(`
       A = {}
       class A.for
-      o = A.for.name
+      setResult(A.for.name)
     `, '_for');
   });
 
@@ -1404,7 +1404,7 @@ describe('classes', () => {
     validate(`
       A = {}
       class A.or
-      o = A.or.name
+      setResult(A.or.name)
     `, 'or');
   });
 

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -696,7 +696,7 @@ describe('conditionals', () => {
           2
         else
           3
-      o = b
+      setResult(b)
     `, 1);
   });
 

--- a/test/expansion_test.js
+++ b/test/expansion_test.js
@@ -294,7 +294,7 @@ describe('expansion', () => {
     validate(`
       arr = [1, 2, 3, 4, 5, 6]
       [a, [b, c..., d]..., e] = arr
-      o = a + b + d + e + c.length
+      setResult(a + b + d + e + c.length)
     `, 16);
   });
 
@@ -302,7 +302,7 @@ describe('expansion', () => {
     validate(`
       arr = {length: 1, 0: 'Hello'}
       [value] = arr
-      o = value
+      setResult(value)
     `, 'Hello');
   });
 
@@ -310,7 +310,7 @@ describe('expansion', () => {
     validate(`
       arr = {length: 1, 0: 'World'}
       [[value]] = [arr]
-      o = value
+      setResult(value)
     `, 'World');
   });
 
@@ -318,13 +318,13 @@ describe('expansion', () => {
     validate(`
       arr = {length: 2, 0: 'Hello', 1: 'World'}
       [..., secondWord] = arr
-      o = secondWord
+      setResult(secondWord)
     `, 'World');
   });
 
   it('allows an empty destructure', () => {
     validate(`
-      o = ([] = 3)
+      setResult([] = 3)
     `, 3);
   });
 
@@ -346,7 +346,7 @@ describe('expansion', () => {
     validate(`
       b = [1, 2, 3]
       c = [a] = b
-      o = b == c
+      setResult(b == c)
     `, true);
   });
 
@@ -354,13 +354,14 @@ describe('expansion', () => {
     validate(`
       a = [1]
       o = [[]] = a
+      setResult(o)
     `, [1]);
   });
 
   it('does not generate crashing code when doing a destructure on undefined', () => {
     validate(`
       {} = undefined
-      o = true
+      setResult(true)
     `, true);
   });
 

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -702,7 +702,7 @@ describe('for loops', () => {
     validate(`
       sum = (arr) ->
         arr.reduce (a, b) -> a + b
-      o = sum(3*x + i + 1 for x, i in [2, 5, 8])
+      setResult(sum(3*x + i + 1 for x, i in [2, 5, 8]))
     `, 51);
   });
 

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -494,7 +494,7 @@ describe('functions', () => {
       f = -> (
         true
       )
-      o = f()
+      setResult(f())
     `, true)
   );
 
@@ -503,7 +503,7 @@ describe('functions', () => {
       x = 'original'
       f = ([x]) -> x
       f(['new'])
-      o = x
+      setResult(x)
     `, 'original')
   );
 
@@ -513,7 +513,7 @@ describe('functions', () => {
       f = ({a} = {a: 2}) ->
         return
       f({a: 3})
-      o = a
+      setResult(a)
     `, 1)
   );
 });

--- a/test/regular_expression_test.js
+++ b/test/regular_expression_test.js
@@ -140,7 +140,7 @@ describe('regular expressions', () => {
 
   it('behaves correctly with \\0 within heregexes', () => {
     validate(`
-      o = ///\\0 1///.test '\x001'
+      setResult(///\\0 1///.test '\x001')
       `, true);
   });
 

--- a/test/slice_test.js
+++ b/test/slice_test.js
@@ -58,7 +58,7 @@ describe('slice', () => {
       a = [1, 2, 3, 4, 5]
       start = '1'
       end = '3'
-      o = a[start..end]
+      setResult(a[start..end])
     `, [2, 3, 4]);
   });
 
@@ -156,15 +156,17 @@ describe('slice', () => {
 
   it('allows overwriting with an array', () => {
     validate(`
-      o = ['a', 'b', 'c', 'd']
-      o[1...3] = ['Hello', 'World']
+      arr = ['a', 'b', 'c', 'd']
+      arr[1...3] = ['Hello', 'World']
+      setResult(arr)
     `, ['a', 'Hello', 'World', 'd']);
   });
 
   it('allows overwriting with an individual element', () => {
     validate(`
-      o = ['a', 'b', 'c', 'd']
-      o[1...3] = 'Hello';
+      arr = ['a', 'b', 'c', 'd']
+      arr[1...3] = 'Hello';
+      setResult(arr)
     `, ['a', 'Hello', 'd']);
   });
 
@@ -187,7 +189,7 @@ describe('slice', () => {
   it('behaves properly when there is a logical operator in a slice range', () => {
     validate(`
       a = [1..4]
-      o = a[..2 or 3]
+      setResult(a[..2 or 3])
     `, [1, 2, 3]);
   });
 });

--- a/test/soaked_test.js
+++ b/test/soaked_test.js
@@ -133,14 +133,14 @@ describe('soaked expressions', () => {
     it('evaluates soaked function calls', () => {
       validate(`
         f = -> 3
-        o = f?()
+        setResult(f?())
       `, 3);
     });
 
     it('skips soaked function invocations on non-functions', () => {
       validate(`
         f = 3
-        o = '' + f?()
+        setResult('' + f?())
       `, 'undefined');
     });
 
@@ -153,6 +153,7 @@ describe('soaked expressions', () => {
               o = true
         }
         a.b?()
+        setResult(o)
       `, true);
     });
 
@@ -167,6 +168,7 @@ describe('soaked expressions', () => {
               o = true
         }
         a.b()
+        setResult(o)
       `, true);
     });
 
@@ -179,6 +181,7 @@ describe('soaked expressions', () => {
               o = true
         }
         a['b']?()
+        setResult(o)
       `, true);
     });
   });
@@ -452,35 +455,35 @@ describe('soaked expressions', () => {
     it('correctly handles normal soaked access', () => {
       validate(`
         a = {b: 5}
-        o = a?.b
+        setResult(a?.b)
       `, 5);
     });
 
     it('correctly handles missing soaked access', () => {
       validate(`
         a = {b: null}
-        o = '' + a.b?.c
+        setResult('' + a.b?.c)
       `, 'undefined');
     });
 
     it('correctly handles dynamic soaked access', () => {
       validate(`
         a = {b: 5}
-        o = a?['b']
+        setResult(a?['b'])
       `, 5);
     });
 
     it('correctly handles missing dynamic soaked access', () => {
       validate(`
         a = {b: null}
-        o = '' + a.b?['c']
+        setResult('' + a.b?['c'])
       `, 'undefined');
     });
 
     it('stops evaluating the expression when hitting a soak failure', () => {
         validate(`
         a = {b: 5}
-        o = '' + a.d?.e.f()
+        setResult('' + a.d?.e.f())
       `, 'undefined');
     });
 
@@ -491,7 +494,7 @@ describe('soaked expressions', () => {
         z = {}
         y?.a = x++
         z?.a = x++
-        o = x
+        setResult(x)
       `, 2);
     });
   });
@@ -763,7 +766,7 @@ describe('soaked expressions', () => {
   it('has the correct runtime behavior with a soak operation inside a ternary', () => {
     validate(`
       a = {b: 'should not return'}
-      o = if a?.b then 'should return'
+      setResult(if a?.b then 'should return')
     `, 'should return');
   });
 

--- a/test/spread_test.js
+++ b/test/spread_test.js
@@ -21,7 +21,7 @@ describe('spread', () => {
   it('has the correct runtime behavior when spreading null in a function call', () => {
     validate(`
       f = -> arguments.length
-      o = f(null...)
+      setResult(f(null...))
     `, 0);
   });
 
@@ -29,7 +29,7 @@ describe('spread', () => {
     validate(`
       f = -> arguments.length
       obj = {length: 2, 0: 'a', 1: 'b'}
-      o = f(1, 2, obj...)
+      setResult(f(1, 2, obj...))
     `, 4);
   });
 
@@ -52,7 +52,7 @@ describe('spread', () => {
   it('has the correct runtime behavior when spreading a fake array in an array literal', () => {
     validate(`
       obj = {length: 2, 0: 'a', 1: 'b'}
-      o = [1, 2, obj...]
+      setResult([1, 2, obj...])
     `, [1, 2, 'a', 'b']);
   });
 });

--- a/test/string_integration_test.js
+++ b/test/string_integration_test.js
@@ -25,7 +25,7 @@ function generateThreeLineTests(strings) {
 function runAssignmentTest(quote, string) {
   validate(
 `testVariable = "test variable"
-o=${quote}${string}${quote}`);
+setResult(${quote}${string}${quote})`);
 }
 
 function runFunctionTest(quote, string) {
@@ -33,7 +33,7 @@ function runFunctionTest(quote, string) {
 `runTest = () ->
   testVariable = "test variable"
   return ${quote}${string}${quote}
-o = runTest()`);
+setResult(runTest())`);
 }
 
 describe('string integration', function() {

--- a/test/string_test.js
+++ b/test/string_test.js
@@ -156,10 +156,10 @@ describe('strings', () => {
 
   it('handles \\0 followed by a number', () => {
     validate(`
-      o = '
+      setResult('
         \\0\\
         1
-      '
+      ')
       `, '\x001');
   });
 });

--- a/test/support/assertDeepEqual.js
+++ b/test/support/assertDeepEqual.js
@@ -1,0 +1,29 @@
+import { fail } from 'assert';
+
+/**
+ * Variant on assert.deepStrictEqual that does not do prototype checking so that
+ * it can be used on values originating from different V8 contexts.
+ */
+export default function assertDeepEqual(actual, expected, message) {
+  if (!isDeepEqual(actual, expected)) {
+    fail(actual, expected, message, 'assertDeepEqual');
+  }
+}
+
+function isDeepEqual(actual, expected) {
+  if (actual === expected) {
+    return true;
+  }
+  if (actual === null || actual === undefined || expected === null || expected === undefined) {
+    return false;
+  }
+  if (actual.constructor.name === 'Array' && expected.constructor.name === 'Array') {
+    return actual.length === expected.length &&
+      actual.every((val, i) => isDeepEqual(val, expected[i]));
+  }
+  if (actual.constructor.name === 'Object' && expected.constructor.name === 'Object') {
+    return isDeepEqual(Object.keys(actual).sort(), Object.keys(expected).sort()) &&
+      Object.keys(actual).every(key => isDeepEqual(actual[key], expected[key]));
+  }
+  return false;
+}

--- a/test/unary_operator_test.js
+++ b/test/unary_operator_test.js
@@ -119,7 +119,7 @@ describe('unary operators', () => {
     validate(`
       n = 1
       (n++)?.toString()
-      o = n
+      setResult(n)
     `, 2);
   });
 });


### PR DESCRIPTION
Previously it was doing a JSON conversion to avoid the issue of prototype
differences between V8 contexts, but now it uses a custom deep equality function
instead.

Also, it now compares the result when run directly in V8, to guard against
differences between babel and V8. This required changing the spec to call a
function on the result rather than assigning the result to a variable.