### PR TITLE
fix: correctly handle expansion params with too few args specified

### DIFF
--- a/src/stages/normalize/patchers/FunctionPatcher.js
+++ b/src/stages/normalize/patchers/FunctionPatcher.js
@@ -196,6 +196,15 @@ export default class FunctionPatcher extends NodePatcher {
    * properly wrap it in Array.from.
    */
   getFirstRestParamIndex(): number {
+    // If there is any expansion param, all params need to be pulled into the
+    // array destructure, so set index 0. For example, in the param list
+    // `(a, ..., b, c)`, `b` is set to the second-to-last arg, which might be the
+    // same as `a`, so all args need to be included in the destructure.
+    if (this.parameters.some((param, i) =>
+        i < this.parameters.length - 1 && param instanceof ExpansionPatcher)) {
+      return 0;
+    }
+
     for (let i = 0; i < this.parameters.length; i++) {
       let parameter = this.parameters[i];
 

--- a/test/expansion_test.js
+++ b/test/expansion_test.js
@@ -121,12 +121,12 @@ describe('expansion', () => {
     `);
   });
 
-  it('allows getting the first and last elements of a parameter list, using the "rest" name', () => {
+  it('allows getting the first and last elements of a parameter list', () => {
     check(`
       (a, b, ..., c, d) ->
     `, `
-      (function(a, b, ...rest) {
-        let c = rest[rest.length - 2], d = rest[rest.length - 1];
+      (function(...args) {
+        let a = args[0], b = args[1], c = args[args.length - 2], d = args[args.length - 1];
       });
     `);
   });
@@ -145,8 +145,8 @@ describe('expansion', () => {
     check(`
       (a, b, ..., c, d) =>
     `, `
-      (a, b, ...rest) => {
-        let c = rest[rest.length - 2], d = rest[rest.length - 1];
+      (...args) => {
+        let a = args[0], b = args[1], c = args[args.length - 2], d = args[args.length - 1];
       };
     `);
   });
@@ -180,12 +180,12 @@ describe('expansion', () => {
       }) ->
         f
     `, `
-      var f = function(a, b, ...rest) {
-        let {
+      var f = function(...args) {
+        let a = args[0], b = args[1], {
           c,
           d,
           e,
-        } = rest[rest.length - 1];
+        } = args[args.length - 1];
         return f;
       };
     `);
@@ -371,5 +371,20 @@ describe('expansion', () => {
     `, `
       let obj = b.slice(0, b.length - 0), val = obj.a, a = val != null ? val : 1;
     `);
+  });
+
+  it('handles expansion params with not enough values specified', () => {
+    validate(`
+      f = (a, ..., b, c, d) ->
+        return [a, b, c, d]
+      setResult(f(1, 2))
+    `, [1, undefined, 1, 2]);
+  });
+
+  it('handles an expansion destructure with not enough values specified', () => {
+    validate(`
+      [a, ..., b, c, d] = [1, 2]
+      setResult([a, b, c, d])
+    `, [1, undefined, 1, 2]);
   });
 });


### PR DESCRIPTION
Progress toward #1043

The general behavior was correct, but limiting the rest params to the ones
starting at the expansion was wrong, since variables can reference earlier
values in the param list.