### PR TITLE
fix: be more defensive when wrapping the `new` operand in parens

### DIFF
--- a/src/stages/main/patchers/ClassPatcher.js
+++ b/src/stages/main/patchers/ClassPatcher.js
@@ -52,10 +52,10 @@ export default class ClassPatcher extends NodePatcher {
     }
   }
 
-  patchAsExpression() {
+  patchAsExpression({ skipParens = false } = {}) {
     let needsAssignment = this.nameAssignee &&
       (this.isNamespaced() || this.isNameAlreadyDeclared() || this.willPatchAsExpression());
-    let needsParens = needsAssignment &&
+    let needsParens = !skipParens && needsAssignment &&
       this.willPatchAsExpression() &&
       !this.isSurroundedByParentheses();
     if (needsParens) {

--- a/src/stages/main/patchers/FunctionApplicationPatcher.js
+++ b/src/stages/main/patchers/FunctionApplicationPatcher.js
@@ -22,10 +22,16 @@ export default class FunctionApplicationPatcher extends NodePatcher {
    * Note that we don't need to worry about implicit function applications,
    * since the normalize stage would have already added parens.
    */
-  patchAsExpression() {
+  patchAsExpression({ fnNeedsParens = false } = {}) {
     let { args, outerEndTokenIndex } = this;
 
-    this.fn.patch();
+    if (fnNeedsParens) {
+      this.insert(this.fn.outerStart, '(');
+    }
+    this.fn.patch({ skipParens: fnNeedsParens });
+    if (fnNeedsParens) {
+      this.insert(this.fn.outerEnd, ')');
+    }
 
     args.forEach((arg, i) => {
       arg.patch();

--- a/src/stages/main/patchers/ManuallyBoundFunctionPatcher.js
+++ b/src/stages/main/patchers/ManuallyBoundFunctionPatcher.js
@@ -1,5 +1,4 @@
 import FunctionPatcher from './FunctionPatcher';
-import NewOpPatcher from './NewOpPatcher';
 
 /**
  * Handles bound functions that cannot become arrow functions.
@@ -12,12 +11,6 @@ export default class ManuallyBoundFunctionPatcher extends FunctionPatcher {
   }
 
   patchAsExpression(options={}) {
-    let needsParens = this.parent instanceof NewOpPatcher;
-
-    if (needsParens) {
-      this.insert(this.innerStart, '(');
-    }
-
     super.patchAsExpression(options);
     // If we're instructed to patch as a method, then it won't be legal to add
     // `.bind(this)`, so skip that step. Calling code is expected to bind us
@@ -25,10 +18,6 @@ export default class ManuallyBoundFunctionPatcher extends FunctionPatcher {
     // code will be added to the constructor to bind the method properly.
     if (!options.method) {
       this.insert(this.innerEnd, '.bind(this)');
-    }
-
-    if (needsParens) {
-      this.insert(this.innerEnd, ')');
     }
   }
 

--- a/src/stages/main/patchers/NewOpPatcher.js
+++ b/src/stages/main/patchers/NewOpPatcher.js
@@ -1,6 +1,15 @@
 import FunctionApplicationPatcher from './FunctionApplicationPatcher';
+import IdentifierPatcher from './IdentifierPatcher';
+import MemberAccessOpPatcher from './MemberAccessOpPatcher';
 
 /**
  * Handles construction of objects with `new`.
  */
-export default class NewOpPatcher extends FunctionApplicationPatcher {}
+export default class NewOpPatcher extends FunctionApplicationPatcher {
+  patchAsExpression() {
+    let fnNeedsParens = !this.fn.isSurroundedByParentheses() &&
+      !(this.fn instanceof IdentifierPatcher) &&
+      !(this.fn instanceof MemberAccessOpPatcher);
+    super.patchAsExpression({ fnNeedsParens });
+  }
+}

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1542,7 +1542,7 @@ describe('classes', () => {
     check(`
       rethinkdb.monday = new (class extends RDBConstant then tt: protoTermType.MONDAY, st: 'monday')()
     `, `
-      rethinkdb.monday = new (function() {
+      rethinkdb.monday = new ((function() {
         let Cls = (class extends RDBConstant {
           static initClass() {
             this.prototype.tt = protoTermType.MONDAY; this.prototype.st = 'monday';
@@ -1551,7 +1551,7 @@ describe('classes', () => {
         });
         Cls.initClass();
         return Cls();
-      })();
+      })());
     `);
   });
 

--- a/test/new_op_test.js
+++ b/test/new_op_test.js
@@ -73,7 +73,7 @@ describe('`new` operator', () => {
     check(`
       new -> a
     `, `
-      (new function() { return a; });
+      (new (function() { return a; }));
     `);
   });
 
@@ -82,6 +82,22 @@ describe('`new` operator', () => {
       new => a
     `, `
       (new (function() { return a; }.bind(this)));
+    `);
+  });
+
+  it('wraps parens around an IIFE `try` used with `new`', () => {
+    check(`
+      new try Array
+    `, `
+      new ((() => { try { return Array; } catch (error) {} })());
+    `);
+  });
+
+  it('wraps parens around a `do` used with `new`', () => {
+    check(`
+      new do -> ->
+    `, `
+      new ((() => function() {})());
     `);
   });
 });


### PR DESCRIPTION
Fixes #1039

We now only skip the parens in the common cases of identifiers and member access
expressions.