### PR TITLE
fix: preserve order for `in` operations when necessary

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -1201,6 +1201,17 @@ export default class NodePatcher {
   }
 
   /**
+   * Determines whether this code might have side-effects when run. Most of the
+   * time this is the same as isRepeatable, but sometimes the node is
+   * long/complicated enough that it's better to extract it as a variable rather
+   * than repeat the expression. In that case, a node may declare itself as pure
+   * but not repeatable.
+   */
+  isPure(): boolean {
+    return this.isRepeatable();
+  }
+
+  /**
    * Determines whether this node can be repeated without side-effects. Most
    * nodes are not repeatable, so that is the default. Subclasses should
    * override this to indicate whether they are repeatable without any changes.

--- a/src/stages/main/patchers/ArrayInitialiserPatcher.js
+++ b/src/stages/main/patchers/ArrayInitialiserPatcher.js
@@ -37,4 +37,8 @@ export default class ArrayInitialiserPatcher extends NodePatcher {
       }
     });
   }
+
+  isPure() {
+    return this.members.every(member => member.isPure());
+  }
 }

--- a/src/stages/main/patchers/BinaryOpPatcher.js
+++ b/src/stages/main/patchers/BinaryOpPatcher.js
@@ -33,6 +33,10 @@ export default class BinaryOpPatcher extends NodePatcher {
     this.binaryOpNegated = !this.binaryOpNegated;
   }
 
+  isPure() {
+    return this.left.isPure() && this.right.isPure();
+  }
+
   /**
    * LEFT OP RIGHT
    */

--- a/src/stages/main/patchers/BoolPatcher.js
+++ b/src/stages/main/patchers/BoolPatcher.js
@@ -14,4 +14,8 @@ export default class BoolPatcher extends NodePatcher {
         break;
     }
   }
+
+  isRepeatable() {
+    return true;
+  }
 }

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -365,9 +365,11 @@ describe('function calls', () => {
           e)
         )
     `, `
-      a =>
-        !Array.from(b.map(a, e => e)).includes(a)
-      ;
+      (function(a) {
+        let needle;
+        return ((needle = a, !Array.from(b.map(a, e => e)).includes(needle))
+        );
+      });
     `);
   });
 

--- a/test/in_test.js
+++ b/test/in_test.js
@@ -1,4 +1,5 @@
 import check from './support/check';
+import validate from './support/validate';
 
 describe('in operator', () => {
   it('handles the simple identifier case', () => {
@@ -142,14 +143,24 @@ describe('in operator', () => {
     `);
   });
 
-  it('uses includes when the left side is not repeatable', () => {
+  it('extracts a variable when the left side is not repeatable', () => {
     check(`
       if a() in [yes, no]
         b
     `, `
-      if ([true, false].includes(a())) {
+      let needle;
+      if ((needle = a(), [true, false].includes(needle))) {
         b;
       }
+    `);
+  });
+
+  it('extracts a variable when the right side is not repeatable', () => {
+    check(`
+      a in b()
+    `, `
+      let needle;
+      (needle = a, Array.from(b()).includes(needle));
     `);
   });
 
@@ -173,5 +184,13 @@ describe('in operator', () => {
         b;
       }
     `);
+  });
+
+  it('evaluates the expressions in order', () => {
+    validate(`
+      arr = []
+      arr.push('first') in [arr.push('second')]
+      setResult(arr)
+    `, ['first', 'second'], { requireNode6: true });
   });
 });

--- a/test/support/validate.js
+++ b/test/support/validate.js
@@ -21,7 +21,10 @@ import assertDeepEqual from './assertDeepEqual';
  * Optionally, expectedOutput can be specified. If it is, the the result of the
  * 'o' variable must be equal to that value.
  */
-export default function validate(source: string, expectedOutput: ?any) {
+export default function validate(source: string, expectedOutput: ?any, { requireNode6 = false } = {}) {
+  if (requireNode6 && !isAtLeastNode6()) {
+    return;
+  }
   try {
     runValidation(source, expectedOutput);
   } catch (err) {
@@ -79,7 +82,7 @@ ${err.message}`;
   }
 
   // Make sure babel and V8 behave the same if we're on node >= 6.
-  if (Number(process.version.slice(1).split('.')[0]) >= 6) {
+  if (isAtLeastNode6()) {
     let nodeOutput = runCodeAndExtract(decaffeinateES6);
     assertDeepEqual(decaffeinateOutput, nodeOutput);
   }
@@ -87,4 +90,8 @@ ${err.message}`;
   if (expectedOutput !== undefined) {
     assertDeepEqual(decaffeinateOutput, expectedOutput);
   }
+}
+
+function isAtLeastNode6() {
+  return Number(process.version.slice(1).split('.')[0]) >= 6;
 }


### PR DESCRIPTION
Fixes #1038

This makes some cases uglier, unfortunately, but from a scan through my codebase
it seems relatively rare to have impure operands to the `in` operator.

I also added an `isPure` method that is very similar to `isRepeatable`, but
doesn't interfere with some cases where it's better for an expression to not be
repeatable even if it's technically pure.