### PR TITLE
fix: add a custom code path for the extracted variable `in` case

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -336,7 +336,7 @@ export default class NodePatcher {
    * @protected
    */
   patchAsRepeatableExpression(repeatableOptions: RepeatableOptions={}, patchOptions={}): string {
-    if (this.isRepeatable()) {
+    if (this.isRepeatable() && !repeatableOptions.forceRepeat) {
       return this.captureCodeForPatchOperation(() => {
         this.patchAsForcedExpression(patchOptions);
         this.commitDeferredSuffix();

--- a/src/patchers/types.js
+++ b/src/patchers/types.js
@@ -39,6 +39,7 @@ export type RepeatableOptions = {
   parens: ?boolean,
   ref: ?string,
   isForAssignment: ?boolean,
+  forceRepeat: ?boolean,
 };
 
 export type SourceType = number;

--- a/test/in_test.js
+++ b/test/in_test.js
@@ -164,6 +164,15 @@ describe('in operator', () => {
     `);
   });
 
+  it('extracts a variable correctly for `not in` operations', () => {
+    check(`
+      a() not in b
+    `, `
+      let needle;
+      (needle = a(), !Array.from(b).includes(needle));
+    `);
+  });
+
   it('uses includes with complicated expressions in the array', () => {
     check(`
       if a in [b and c, +d]
@@ -192,5 +201,17 @@ describe('in operator', () => {
       arr.push('first') in [arr.push('second')]
       setResult(arr)
     `, ['first', 'second'], { requireNode6: true });
+  });
+
+  it('handles an impure soak LHS', () => {
+    check(`
+      if a?.b() in c
+        d
+    `, `
+      let needle;
+      if ((needle = typeof a !== 'undefined' && a !== null ? a.b() : undefined, Array.from(c).includes(needle))) {
+        d;
+      }
+    `);
   });
 });


### PR DESCRIPTION
Fixes #1052

Since the full expressions are in order for this case, it's best to just patch
in-place rather than getting the code, since otherwise some inserted
magic-string fragments can be left over and cause issues. Since the patching
strategy is different enough, I just made it a completely separate function.