### PR TITLE
fix: properly handle bound static methods

### DIFF
--- a/src/stages/normalize/patchers/ClassPatcher.js
+++ b/src/stages/normalize/patchers/ClassPatcher.js
@@ -201,6 +201,12 @@ export default class ClassPatcher extends NodePatcher {
       return true;
     }
     if (this.isClassAssignment(patcher.node)) {
+      // Bound static methods must be moved to initClass so they are properly
+      // bound.
+      if (patcher.node.type === 'AssignOp' &&
+          ['BoundFunction', 'BoundGeneratorFunction'].indexOf(patcher.expression.node.type) >= 0) {
+        return false;
+      }
       if (patcher.expression instanceof FunctionPatcher) {
         return true;
       }

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1578,4 +1578,33 @@ describe('classes', () => {
       });
     `);
   });
+
+  it('properly handles bound static methods', () => {
+    check(`
+      class A
+        @b = =>
+          @c
+    `, `
+      class A {
+        static initClass() {
+          this.b = () => {
+            return this.c;
+          };
+        }
+      }
+      A.initClass();
+    `);
+  });
+
+  it('has the right behavior with bound static methods', () => {
+    validate(`
+      class A
+        @b = =>
+          @c
+        @c = 5
+      
+      b = A.b
+      setResult(b())
+    `, 5);
+  });
 });


### PR DESCRIPTION
Fixes #1056

The existing `initClass` code path already properly handled this case, since the
arrow function binds the proper `this`, but we were treating it as a regular
method and effectively ignoring the fact that it was bound. To fix, we can just
add a special case to move it to `initClass`.