### PR TITLE
fix: normalize separators within inline class blocks

### DIFF
--- a/src/stages/normalize/patchers/BlockPatcher.js
+++ b/src/stages/normalize/patchers/BlockPatcher.js
@@ -19,8 +19,11 @@ export default class BlockPatcher extends SharedBlockPatcher {
 
   patchAsStatement() {
     if (this.node.inline) {
-      for (let statement of this.statements) {
+      for (let [i, statement] of this.statements.entries()) {
         statement.patch();
+        if (i < this.statements.length - 1) {
+          this.normalizeBetweenStatements(statement, this.statements[i + 1]);
+        }
       }
       return;
     }


### PR DESCRIPTION
One change from https://github.com/decaffeinate/decaffeinate-parser/pull/222 is
that inline class blocks are now properly marked as inline. This caused
decaffeinate to go through a different code path that didn't change comma to
semicolon as necessary. Fixed by normalizing in that case as well.