### PR TITLE
fix: handle class fields within nested blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babylon": "^6.12.0",
     "coffee-lex": "^7.0.0",
     "decaffeinate-coffeescript": "1.10.0-patch22",
-    "decaffeinate-parser": "^17.0.6",
+    "decaffeinate-parser": "^17.1.3",
     "detect-indent": "^4.0.0",
     "esnext": "^3.1.0",
     "lines-and-columns": "^1.1.5",

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1607,4 +1607,46 @@ describe('classes', () => {
       setResult(b())
     `, 5);
   });
+
+  it('handles conditional prototype assignments', () => {
+    check(`
+      class A
+        if b
+          c: d
+        else
+          e: f
+    `, `
+      class A {
+        static initClass() {
+          if (b) {
+            this.prototype.c = d;
+          } else {
+            this.prototype.e = f;
+          }
+        }
+      }
+      A.initClass();
+    `);
+  });
+
+  it('handles conditional methods', () => {
+    check(`
+      class A
+        if b
+          c: -> d
+        else
+          e: -> f
+    `, `
+      class A {
+        static initClass() {
+          if (b) {
+            this.prototype.c = () => d;
+          } else {
+            this.prototype.e = () => f;
+          }
+        }
+      }
+      A.initClass();
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #1057

Now that the parser correctly identifies the values as prototype assignments, we
can transform them when patching the body normally. We only do this for
properties that we know won't become methods.