### PR TITLE
fix: extract loop variables to their own name when necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "automatic-semicolon-insertion": "^1.0.2",
     "babylon": "^6.12.0",
     "coffee-lex": "^7.0.0",
-    "decaffeinate-coffeescript": "1.10.0-patch22",
+    "decaffeinate-coffeescript": "1.10.0-patch24",
     "decaffeinate-parser": "^17.1.3",
     "detect-indent": "^4.0.0",
     "esnext": "^3.1.0",

--- a/src/stages/main/patchers/ForPatcher.js
+++ b/src/stages/main/patchers/ForPatcher.js
@@ -99,10 +99,25 @@ export default class ForPatcher extends LoopPatcher {
         // matching expression, so this should never happen.
         throw keyAssignee.error(`expected loop index to be an identifier`);
       }
-      return this.slice(keyAssignee.contentStart, keyAssignee.contentEnd);
+      if (this.needsUniqueIndexName()) {
+        return this.claimFreeBinding(this.indexBindingCandidates());
+      } else {
+        return this.getUserSpecifiedIndex();
+      }
     } else {
       return this.claimFreeBinding(this.indexBindingCandidates());
     }
+  }
+
+  getUserSpecifiedIndex() {
+    if (!this._userSpecifiedIndex) {
+      this._userSpecifiedIndex = this.slice(this.keyAssignee.contentStart, this.keyAssignee.contentEnd);
+    }
+    return this._userSpecifiedIndex;
+  }
+
+  needsUniqueIndexName() {
+    return false;
   }
 
   /**

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1439,4 +1439,63 @@ describe('for loops', () => {
       });
     `);
   });
+
+  it('does not allow modifying the loop index of a for-in loop', () => {
+    check(`
+      arr = [1, 2, 3]
+      for val, i in arr
+        console.log i
+        i = 10
+    `, `
+      let arr = [1, 2, 3];
+      for (let j = 0; j < arr.length; j++) {
+        let i = j;
+        let val = arr[j];
+        console.log(i);
+        i = 10;
+      }
+    `);
+  });
+
+  it('defensively sets the loop index when it might be set within a closure', () => {
+    check(`
+      arr = [1, 2, 3]
+      i = 0
+      f = -> i = 10
+      for val, i in arr
+        console.log i
+        f()
+    `, `
+      let arr = [1, 2, 3];
+      let i = 0;
+      let f = () => i = 10;
+      for (let j = 0; j < arr.length; j++) {
+        i = j;
+        let val = arr[j];
+        console.log(i);
+        f();
+      }
+    `);
+  });
+
+  it('does not defensively sets the loop index when running a loop twice', () => {
+    check(`
+      arr = [1, 2, 3]
+      for val, i in arr
+        console.log i
+      for val, i in arr
+        console.log i
+    `, `
+      let i, val;
+      let arr = [1, 2, 3];
+      for (i = 0; i < arr.length; i++) {
+        val = arr[i];
+        console.log(i);
+      }
+      for (i = 0; i < arr.length; i++) {
+        val = arr[i];
+        console.log(i);
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #1044

We need to do this when the loop body might assign to the loop variable. We can
detect this by determining if there are any assignments to the variable directly
in the loop body or if there are any instances of the variabble assigned from a
closure anywhere in the function scope.