### PR TITLE
fix: overhaul implicit return code to handle switch within loop expressions

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -732,6 +732,13 @@ export default class NodePatcher {
   }
 
   /**
+   * Return null to indicate that no empty case code should be generated.
+   */
+  getEmptyImplicitReturnCode() {
+    return null;
+  }
+
+  /**
    * Patch the end of an implicitly-returned descendant.
    */
   patchImplicitReturnEnd(patcher: NodePatcher) { // eslint-disable-line no-unused-vars

--- a/src/stages/main/patchers/ConditionalPatcher.js
+++ b/src/stages/main/patchers/ConditionalPatcher.js
@@ -259,6 +259,14 @@ export default class ConditionalPatcher extends NodePatcher {
     } else if (elseTokenIndex !== null) {
       let elseToken = this.sourceTokenAtIndex(elseTokenIndex);
       this.insert(elseToken.end, ' {}');
+    } else if (super.implicitlyReturns()) {
+      let emptyImplicitReturnCode =
+        this.implicitReturnPatcher().getEmptyImplicitReturnCode();
+      if (emptyImplicitReturnCode) {
+        this.insert(this.contentEnd, ' else {\n');
+        this.insert(this.contentEnd, `${this.getIndent(1)}${emptyImplicitReturnCode}\n`);
+        this.insert(this.contentEnd, `${this.getIndent()}}`);
+      }
     }
   }
 

--- a/src/stages/main/patchers/ForPatcher.js
+++ b/src/stages/main/patchers/ForPatcher.js
@@ -58,11 +58,11 @@ export default class ForPatcher extends LoopPatcher {
 
     if (filter) {
       this.body.insertLineBefore(`if (${this.getFilterCode()}) {`, this.getOuterLoopBodyIndent());
-      this.patchBodyWithPossibleItemVariable();
+      this.patchBody();
       body.insertLineAfter('}', this.getOuterLoopBodyIndent());
       body.insertLineAfter('}', this.getLoopIndent());
     } else {
-      this.patchBodyWithPossibleItemVariable();
+      this.patchBody();
       body.insertLineAfter('}', this.getLoopIndent());
     }
   }

--- a/src/stages/main/patchers/SwitchCasePatcher.js
+++ b/src/stages/main/patchers/SwitchCasePatcher.js
@@ -22,6 +22,8 @@ export default class SwitchCasePatcher extends NodePatcher {
   }
 
   patchAsStatement() {
+    let lastCondition = this.conditions[this.conditions.length - 1];
+
     // `when a, b, c then d` → `a, b, c then d`
     //  ^^^^^
     let whenToken = this.getWhenToken();
@@ -52,7 +54,7 @@ export default class SwitchCasePatcher extends NodePatcher {
       if (this.consequent !== null) {
         this.remove(thenToken.start, this.consequent.outerStart);
       } else {
-        this.remove(thenToken.start, thenToken.end);
+        this.remove(lastCondition.outerEnd, thenToken.end);
       }
     }
 
@@ -73,7 +75,7 @@ export default class SwitchCasePatcher extends NodePatcher {
         if (this.consequent !== null) {
           this.insert(this.consequent.contentEnd, ' break');
         } else {
-          this.insert(thenToken.end, ' break');
+          this.insert(lastCondition.outerEnd, `\n${this.getIndent(1)}break`);
         }
       } else {
         this.appendLineAfter('break', 1);

--- a/src/stages/main/patchers/WhilePatcher.js
+++ b/src/stages/main/patchers/WhilePatcher.js
@@ -94,7 +94,7 @@ export default class WhilePatcher extends LoopPatcher {
 
     this.patchPossibleNewlineAfterLoopHeader(
       this.guard ? this.guard.outerEnd : this.condition.outerEnd);
-    this.patchBodyWithPossibleItemVariable();
+    this.patchBody();
 
     if (this.guard) {
       // Close the guard's `if` consequent block.

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -142,13 +142,13 @@ describe('for loops', () => {
         for (let k in object) {
           let v = object[k];
           if (x) {
-            let item;
             if (k) {
-              item = k;
+              result.push(k);
             } else if (v) {
-              item = v;
+              result.push(v);
+            } else {
+              result.push(undefined);
             }
-            result.push(item);
           }
         }
         return result;
@@ -820,13 +820,13 @@ describe('for loops', () => {
         for (let step = s, asc = step > 0, i = asc ? 0 : iterable.length - 1; asc ? i < iterable.length : i >= 0; i += step) {
           let x = iterable[i];
           if (x) {
-            let item;
             if (i) {
-              item = x;
+              result.push(x);
             } else if (x) {
-              item = i;
+              result.push(i);
+            } else {
+              result.push(undefined);
             }
-            result.push(item);
           }
         }
         return result;
@@ -848,11 +848,11 @@ describe('for loops', () => {
         (() => {
           let result = [];
           for (let a of Array.from(b)) {
-            let item;
             if (a) {
-              item = b;
+              result.push(b);
+            } else {
+              result.push(undefined);
             }
-            result.push(item);
           }
           return result;
         })()
@@ -961,13 +961,13 @@ describe('for loops', () => {
         for (let k of Object.keys(object || {})) {
           let v = object[k];
           if (x) {
-            let item;
             if (k) {
-              item = k;
+              result.push(k);
             } else if (v) {
-              item = v;
+              result.push(v);
+            } else {
+              result.push(undefined);
             }
-            result.push(item);
           }
         }
         return result;
@@ -1122,13 +1122,13 @@ describe('for loops', () => {
       let x = (() => {
         let result = [];
         for (let a of Array.from(b)) {
-          let item;
           if (a) {
-            item = a;
+            result.push(a);
           } else if (b) {
             continue;
+          } else {
+            result.push(undefined);
           }
-          result.push(item);
         }
         return result;
       })();
@@ -1496,6 +1496,76 @@ describe('for loops', () => {
         val = arr[i];
         console.log(i);
       }
+    `);
+  });
+
+  it('does not add elements for implicit return switch within a loop expression', () => {
+    check(`
+      arr = for a in b
+        switch a
+          when 0
+            a
+          when 1
+            break
+          when 2 then
+    `, `
+      let arr = (() => {
+        let result = [];
+        for (let a of Array.from(b)) {
+          switch (a) {
+            case 0:
+              result.push(a);
+              break;
+            case 1:
+              break;
+            case 2:
+              break;
+            default:
+              result.push(undefined);
+          }
+        }
+        return result;
+      })();
+    `);
+  });
+
+  it('does not add to the array with an explicit empty else case in a loop expression', () => {
+    check(`
+      arr = for a in b
+        switch c
+          when d then e
+          else
+    `, `
+      let arr = (() => {
+        let result = [];
+        for (let a of Array.from(b)) {
+          switch (c) {
+            case d: result.push(e); break;
+            default:
+          }
+        }
+        return result;
+      })();
+    `);
+  });
+
+  it('does not add to the array with an explicit empty else in a loop expression', () => {
+    check(`
+      arr = for i in [1, 2, 3]
+        if a
+          b
+        else
+    `, `
+      let arr = (() => {
+        let result = [];
+        for (let i of [1, 2, 3]) {
+          if (a) {
+            result.push(b);
+          }
+          else {}
+        }
+        return result;
+      })();
     `);
   });
 });

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -589,11 +589,11 @@ describe('function calls', () => {
         (() => {
           let result = [];
           for (let b of Array.from(c)) {
-            let item;
             if (d) {
-              item = e[f];
+              result.push(e[f]);
+            } else {
+              result.push(undefined);
             }
-            result.push(item);
           }
           return result;
         })());
@@ -615,11 +615,11 @@ describe('function calls', () => {
         (() => {
           let result = [];
           for (let b of Array.from(c)) {
-            let item;
             if (d) {
-              item = e;
+              result.push(e);
+            } else {
+              result.push(undefined);
             }
-            result.push(item);
           }
           return result;
         })());

--- a/test/literate_test.js
+++ b/test/literate_test.js
@@ -22,11 +22,11 @@ describe('literate mode', () => {
       let otherThing = (() => {
         let result = [];
         for (let foo of Array.from(stuff)) {
-          let item;
           if ((foo % 2) === 0) {
-            item = foo + 1;
+            result.push(foo + 1);
+          } else {
+            result.push(undefined);
           }
-          result.push(item);
         }
         return result;
       })();

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -332,9 +332,11 @@ describe('switch', () => {
         # Do nothing
     `, `
       switch (a) {
-        case b:  break;
+        case b:
+          break;
           // Do nothing
-        case c:  break;
+        case c:
+          break;
       }
           // Do nothing
     `);
@@ -395,13 +397,19 @@ describe('switch', () => {
           else
             e
     `, `
-      let x = Array.from(b).map((a) =>
-        (() => { switch (a) {
-          case 'c':
-            return d;
-          default:
-            return e;
-        } })());
+      let x = (() => {
+        let result = [];
+        for (let a of Array.from(b)) {
+          switch (a) {
+            case 'c':
+              result.push(d);
+              break;
+            default:
+              result.push(e);
+          }
+        }
+        return result;
+      })();
     `);
   });
 

--- a/test/while_test.js
+++ b/test/while_test.js
@@ -130,13 +130,13 @@ describe('while', () => {
         let result = [];
         
         while (b) {
-          let item;
           if (c) {
-            item = d;
+            result.push(d);
           } else if (e) {
-            item = f;
+            result.push(f);
+          } else {
+            result.push(undefined);
           }
-          result.push(item);
         }
 
         return result;
@@ -261,13 +261,13 @@ describe('while', () => {
         let result = [];
         while (a) {
           if (b) {
-            let item;
             if (c) {
-              item = d;
+              result.push(d);
             } else if (e) {
-              item = f;
+              result.push(f);
+            } else {
+              result.push(undefined);
             }
-            result.push(item);
           }
         }
         return result;


### PR DESCRIPTION
Fixes #1073

Previously, the general assumption was that all code paths (except ones
explicitly doing `continue` or `break`) in a loop would produce an array
element, but empty blocks and other similar cases should skip those.

This commit does a few things to fix that case:
* Get rid of the `item` case when generating loop expressions. Instead, loop
  expressions *always* call `.push` in each condition (except empty blocks).
* For unspecified `else` and `default` cases, we now need to explicitly generate
  an "empty case" if necessary. For the `return` style of implicit returns, the
  implicit return patcher returns null to instruct that no code needs to be
  added (since it will fall through and return `undefined`). I think this
  behavior will also be useful in #1004, although I haven't investigated that
  fully.
* Fix a formatting case for empty switch cases.
* Set `prefersToPatchAsExpression` to false for switch statements so that we
  don't trigger the for loop `map` code path.
* Don't crash on empty switch else cases.