### PR TITLE
fix: always repeat the method name for dynamic prototype assignments

### DIFF
--- a/src/stages/main/patchers/AssignOpPatcher.js
+++ b/src/stages/main/patchers/AssignOpPatcher.js
@@ -268,6 +268,7 @@ export default class AssignOpPatcher extends NodePatcher {
     if (methodAccessPatcher instanceof DynamicMemberAccessOpPatcher) {
       methodAccessPatcher.indexingExpr.setRequiresRepeatableExpression({
         ref: 'method',
+        forceRepeat: true,
       });
     }
   }

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1649,4 +1649,26 @@ describe('classes', () => {
       A.initClass();
     `);
   });
+
+  it('saves the method name for dynamic prototype method assignments', () => {
+    check(`
+      A::[m] = -> super
+    `, `
+      let method;
+      A.prototype[method = m] = function() { return A.prototype.__proto__[method].call(this, ...arguments); };
+    `);
+  });
+
+  it('behaves correctly for dynamic prototype method assignments', () => {
+    validate(`
+      class Base
+        f: -> 1
+        g: -> 2
+      class A extends Base
+      m = 'f'
+      A::[m] = -> super
+      m = 'g'
+      setResult((new A).f())
+    `, 1);
+  });
 });


### PR DESCRIPTION
Fixes #1075