### PR TITLE
fix: properly detect the `else` token in switch statements

### DIFF
--- a/src/stages/main/patchers/SwitchPatcher.js
+++ b/src/stages/main/patchers/SwitchPatcher.js
@@ -116,17 +116,22 @@ export default class SwitchPatcher extends NodePatcher {
    * @private
    */
   getElseToken(): ?SourceToken {
-    let searchEndToken;
-    if (this.alternate) {
-      searchEndToken = this.alternate.contentStartTokenIndex;
+    let searchStart;
+    if (this.cases.length > 0) {
+      searchStart = this.cases[this.cases.length - 1].outerEnd;
     } else {
-      searchEndToken = this.contentEndTokenIndex;
+      searchStart = this.expression.outerEnd;
     }
 
-    let tokens = this.context.sourceTokens;
-    let elseTokenIndex = tokens.lastIndexOfTokenMatchingPredicate(
-      token => token.type === SourceType.ELSE,
-      searchEndToken
+    let searchEnd;
+    if (this.alternate) {
+      searchEnd = this.alternate.outerStart;
+    } else {
+      searchEnd = this.contentEnd;
+    }
+
+    let elseTokenIndex = this.indexOfSourceTokenBetweenSourceIndicesMatching(
+      searchStart, searchEnd, token => token.type === SourceType.ELSE
     );
     if (!elseTokenIndex || elseTokenIndex.isBefore(this.contentStartTokenIndex)) {
       if (this.alternate) {

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1568,4 +1568,29 @@ describe('for loops', () => {
       })();
     `);
   });
+
+  it('properly handles an implicit-return switch with an if/else as a case', () => {
+    check(`
+      x = for a in b
+        switch c
+          when d
+            if e then f
+            else g
+    `, `
+      let x = (() => {
+        let result = [];
+        for (let a of Array.from(b)) {
+          switch (c) {
+            case d:
+              if (e) { result.push(f);
+              } else { result.push(g); }
+              break;
+            default:
+              result.push(undefined);
+          }
+        }
+        return result;
+      })();
+    `);
+  });
 });


### PR DESCRIPTION
The previous implementation had a chance of finding an unrelated `else` token,
so we need to change the search bounds to be more specific.