### PR TITLE
fix: repeat `this` expressions for dynamically-added methods using super in initClass

### DIFF
--- a/src/stages/main/patchers/AssignOpPatcher.js
+++ b/src/stages/main/patchers/AssignOpPatcher.js
@@ -264,6 +264,8 @@ export default class AssignOpPatcher extends NodePatcher {
     classRefPatcher.setRequiresRepeatableExpression({
       parens: true,
       ref: 'cls',
+      // Inside an initClass method, we might use `this` for the class.
+      forceRepeat: classRefPatcher instanceof ThisPatcher,
     });
     if (methodAccessPatcher instanceof DynamicMemberAccessOpPatcher) {
       methodAccessPatcher.indexingExpr.setRequiresRepeatableExpression({

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1671,4 +1671,19 @@ describe('classes', () => {
       setResult((new A).f())
     `, 1);
   });
+
+  it('generates proper class accesses in super used in initClass', () => {
+    check(`
+      class A extends B
+        @::f = -> super
+    `, `
+      class A extends B {
+        static initClass() {
+          let cls;
+          (cls = this).prototype.f = function() { return cls.prototype.__proto__.f.call(this, ...arguments); };
+        }
+      }
+      A.initClass();
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #1076