### PR TITLE
fix: properly handle incomplete conditionals ending in comments

### DIFF
--- a/src/stages/main/patchers/ConditionalPatcher.js
+++ b/src/stages/main/patchers/ConditionalPatcher.js
@@ -263,9 +263,9 @@ export default class ConditionalPatcher extends NodePatcher {
       let emptyImplicitReturnCode =
         this.implicitReturnPatcher().getEmptyImplicitReturnCode();
       if (emptyImplicitReturnCode) {
-        this.insert(this.contentEnd, ' else {\n');
-        this.insert(this.contentEnd, `${this.getIndent(1)}${emptyImplicitReturnCode}\n`);
-        this.insert(this.contentEnd, `${this.getIndent()}}`);
+        this.insert(this.innerEnd, ' else {\n');
+        this.insert(this.innerEnd, `${this.getIndent(1)}${emptyImplicitReturnCode}\n`);
+        this.insert(this.innerEnd, `${this.getIndent()}}`);
       }
     }
   }

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1593,4 +1593,24 @@ describe('for loops', () => {
       })();
     `);
   });
+
+  it('handles an incomplete conditional ending in a comment in a loop expression', () => {
+    check(`
+      arr = for a in b
+        if c
+          d  # e
+    `, `
+      let arr = (() => {
+        let result = [];
+        for (let a of Array.from(b)) {
+          if (c) {
+            result.push(d);  // e
+          } else {
+            result.push(undefined);
+          }
+        }
+        return result;
+      })();
+    `);
+  });
 });


### PR DESCRIPTION
We were patching in the wrong place in some cases. `innerEnd` is more reliable
here.