### PR TITLE
fix: make super code more defensive about computed names

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -1237,12 +1237,12 @@ export default class NodePatcher {
   }
 
   /**
-   * Check if this expression has been marked as repeatable. Generally this
-   * should only be used for advanced cases, like transferring the repeat code
-   * result from one patcher to another.
+   * Check if this expression has been marked as repeatable, and if so, the
+   * repeat options used. Generally this should only be used for advanced cases,
+   * like transferring the repeat code result from one patcher to another.
    */
-  isSetAsRepeatableExpression(): boolean {
-    return Boolean(this._repeatableOptions);
+  getRepeatableOptions(): ?RepeatableOptions {
+    return this._repeatableOptions;
   }
 
   /**

--- a/src/stages/main/patchers/AssignOpPatcher.js
+++ b/src/stages/main/patchers/AssignOpPatcher.js
@@ -264,8 +264,7 @@ export default class AssignOpPatcher extends NodePatcher {
     classRefPatcher.setRequiresRepeatableExpression({
       parens: true,
       ref: 'cls',
-      // Inside an initClass method, we might use `this` for the class.
-      forceRepeat: classRefPatcher instanceof ThisPatcher,
+      forceRepeat: true,
     });
     if (methodAccessPatcher instanceof DynamicMemberAccessOpPatcher) {
       methodAccessPatcher.indexingExpr.setRequiresRepeatableExpression({

--- a/src/stages/main/patchers/ClassAssignOpPatcher.js
+++ b/src/stages/main/patchers/ClassAssignOpPatcher.js
@@ -4,6 +4,7 @@ import IdentifierPatcher from './IdentifierPatcher';
 import ManuallyBoundFunctionPatcher from './ManuallyBoundFunctionPatcher';
 import MemberAccessOpPatcher from './MemberAccessOpPatcher';
 import ObjectBodyMemberPatcher from './ObjectBodyMemberPatcher';
+import StringPatcher from './StringPatcher';
 import ThisPatcher from './ThisPatcher';
 import type NodePatcher from './../../../patchers/NodePatcher';
 import type { Node } from './../../../patchers/types';
@@ -42,7 +43,14 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
   markKeyRepeatableIfNecessary() {
     if (this.expression instanceof FunctionPatcher &&
         this.expression.containsSuperCall()) {
-      this.key.setRequiresRepeatableExpression();
+      this.key.setRequiresRepeatableExpression({
+        ref: 'method',
+        // String interpolations are the only way to have computed keys, so we
+        // need to be defensive in that case. For other cases, like number
+        // literals, we still mark as repeatable so later code can safely get
+        // the repeat code.
+        forceRepeat: this.key instanceof StringPatcher && this.key.expressions.length > 0,
+      });
     }
   }
 

--- a/src/stages/main/patchers/ObjectBodyMemberPatcher.js
+++ b/src/stages/main/patchers/ObjectBodyMemberPatcher.js
@@ -63,14 +63,14 @@ export default class ObjectBodyMemberPatcher extends NodePatcher {
       // Since we're replacing an expression like `"#{foo}"` with just `foo`,
       // the outer string expression might be marked as repeatable, in which case
       // we should delegate that to the inner expression.
-      let shouldPropagateRepeatable = this.key.isSetAsRepeatableExpression();
-      if (shouldPropagateRepeatable) {
-        computedKeyPatcher.setRequiresRepeatableExpression();
+      let repeatOptions = this.key.getRepeatableOptions();
+      if (repeatOptions) {
+        computedKeyPatcher.setRequiresRepeatableExpression(repeatOptions);
       }
       this.overwrite(this.key.outerStart, computedKeyPatcher.outerStart, '[');
       computedKeyPatcher.patch();
       this.overwrite(computedKeyPatcher.outerEnd, this.key.outerEnd, ']');
-      if (shouldPropagateRepeatable) {
+      if (repeatOptions) {
         this.key.overrideRepeatCode(computedKeyPatcher.getRepeatCode());
       }
     } else {

--- a/test/super_test.js
+++ b/test/super_test.js
@@ -55,7 +55,8 @@ describe('super', () => {
     check(`
       a.b.prototype.c = -> super
     `, `
-      a.b.prototype.c = function() { return a.b.prototype.__proto__.c.call(this, ...arguments); };
+      let cls;
+      (cls = a.b).prototype.c = function() { return cls.prototype.__proto__.c.call(this, ...arguments); };
     `);
   });
 
@@ -105,9 +106,9 @@ describe('super', () => {
       class A
         "#{b()}": -> super
     `, `
-      let ref;
+      let method;
       class A {
-        [ref = b()]() { return super[ref](...arguments); }
+        [method = b()]() { return super[method](...arguments); }
       }
     `);
   });


### PR DESCRIPTION
Fixes #1082

In both computed method names and when computing the class to use in a dynamic
method assignment, we now save it to a variable so that at `super` time we know
it hasn't changed.

This makes some existing code uglier, and it could probably be improved by
adding some additional checks to see if the variables are ever reassigned or
modified, but all of these cases are obscure enough that this is probably fine
for now.