### PR TITLE
fix: rework loop index saving to happen within the init and update

### DIFF
--- a/src/stages/main/patchers/ForPatcher.js
+++ b/src/stages/main/patchers/ForPatcher.js
@@ -99,25 +99,10 @@ export default class ForPatcher extends LoopPatcher {
         // matching expression, so this should never happen.
         throw keyAssignee.error(`expected loop index to be an identifier`);
       }
-      if (this.needsUniqueIndexName()) {
-        return this.claimFreeBinding(this.indexBindingCandidates());
-      } else {
-        return this.getUserSpecifiedIndex();
-      }
+      return this.slice(keyAssignee.contentStart, keyAssignee.contentEnd);
     } else {
       return this.claimFreeBinding(this.indexBindingCandidates());
     }
-  }
-
-  getUserSpecifiedIndex() {
-    if (!this._userSpecifiedIndex) {
-      this._userSpecifiedIndex = this.slice(this.keyAssignee.contentStart, this.keyAssignee.contentEnd);
-    }
-    return this._userSpecifiedIndex;
-  }
-
-  needsUniqueIndexName() {
-    return false;
   }
 
   /**

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1448,9 +1448,8 @@ describe('for loops', () => {
         i = 10
     `, `
       let arr = [1, 2, 3];
-      for (let j = 0; j < arr.length; j++) {
-        let i = j;
-        let val = arr[j];
+      for (let j = 0, i = j; j < arr.length; j++, i = j) {
+        let val = arr[i];
         console.log(i);
         i = 10;
       }
@@ -1466,12 +1465,12 @@ describe('for loops', () => {
         console.log i
         f()
     `, `
+      let j;
       let arr = [1, 2, 3];
       let i = 0;
       let f = () => i = 10;
-      for (let j = 0; j < arr.length; j++) {
-        i = j;
-        let val = arr[j];
+      for (j = 0, i = j; j < arr.length; j++, i = j) {
+        let val = arr[i];
         console.log(i);
         f();
       }
@@ -1495,6 +1494,32 @@ describe('for loops', () => {
       for (i = 0; i < arr.length; i++) {
         val = arr[i];
         console.log(i);
+      }
+    `);
+  });
+
+  it('properly sets the loop variable before and after', () => {
+    validate(`
+      values = []
+      i = 50
+      arr = [10, 20, 30]
+      for val, i in arr
+        values.push(i)
+        i = 100
+      values.push(i)
+      setResult(values)
+    `, [0, 1, 2, 3]);
+  });
+
+  it('properly saves the loop assignee for range loops', () => {
+    check(`
+      for i in [a..b]
+        console.log i
+        i = 100
+    `, `
+      for (let j = a, i = j, end = b, asc = a <= end; asc ? j <= end : j >= end; asc ? j++ : j--, i = j) {
+        console.log(i);
+        i = 100;
       }
     `);
   });


### PR DESCRIPTION
Fixes #1083

In order to have the proper index value both on the first iteration and after
the loop is finished, we need to put the index saving code in both the loop init
and the loop update code.

This also ends up implementing index saving for all types of loops, I think;
previously, range loops had the same bug.

The scope-related details are the same, but the other details have been
reworked; rather than there being an "index binding" and a "user-specified index
binding", we now have an "internal index binding" and an "index binding". The
loop details work with the internal binding, and save to the normal index
binding if they're different.