### PR TITLE
fix: change loop index code to account for modifications

### DIFF
--- a/src/stages/main/patchers/ForInPatcher.js
+++ b/src/stages/main/patchers/ForInPatcher.js
@@ -314,14 +314,14 @@ export default class ForInPatcher extends ForPatcher {
     // that only looks at assignments within the loop body. But assignments
     // within closures could also happen temporally in the loop, so bail out if
     // we see one of those.
-    if (this.node.scope.hasInnerClosureAssignment(userIndex)) {
+    if (this.node.scope.hasInnerClosureModification(userIndex)) {
       return true;
     }
-    let fakeScope = new Scope(this.body.node, null);
-    traverse(this.body.node, child => {
+    let fakeScope = new Scope(this.node, null);
+    traverse(this.node, child => {
       fakeScope.processNode(child);
     });
-    return fakeScope.hasBinding(userIndex);
+    return fakeScope.hasModificationAfterDeclaration(userIndex);
   }
 
   getInitCode(): string {

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1638,4 +1638,46 @@ describe('for loops', () => {
       })();
     `);
   });
+
+  it('saves the loop index when it is modified but not assigned in the body', () => {
+    check(`
+      for a, i in arr
+        i += 5
+    `, `
+      for (let j = 0, i = j; j < arr.length; j++, i = j) {
+        let a = arr[i];
+        i += 5;
+      }
+    `);
+  });
+
+  it('saves the loop index when it is modified in an increment but not assigned in the body', () => {
+    check(`
+      for a, i in arr
+        i++
+    `, `
+      for (let j = 0, i = j; j < arr.length; j++, i = j) {
+        let a = arr[i];
+        i++;
+      }
+    `);
+  });
+
+  it('saves the loop index when it is modified in an inner closure but not assigned in the body', () => {
+    check(`
+      i = 0
+      f = ->
+        i++
+      for a, i in arr
+        f()
+    `, `
+      let j;
+      let i = 0;
+      let f = () => i++;
+      for (j = 0, i = j; j < arr.length; j++, i = j) {
+        let a = arr[i];
+        f();
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #1084

The scope code is now smarter and distinguishes between variables being
declared, variables being modified, and variables being modified from an inner
closure. This allows us to account for cases like `++` and `+=` that modify a
variable without creating a binding.