### PR TITLE
fix: handle incomplete returned conditionals and switches

### DIFF
--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -775,4 +775,40 @@ describe('conditionals', () => {
       if (a) {}  
     `);
   });
+
+  it('allows falling through an empty conditional in a return statement', () => {
+    check(`
+      ->
+        return if a
+          b
+        c
+    `, `
+      (function() {
+        if (a) {
+          return b;
+        }
+        return c;
+      });
+    `);
+  });
+
+  it('gives the correct result when returning an incomplete conditional', () => {
+    validate(`
+      f = ->
+        return if 0
+          1
+        2
+      setResult(f())
+    `, 2);
+  });
+
+  it('gives the correct result when returning a parenthesized incomplete conditional', () => {
+    validate(`
+      f = ->
+        return (if 0
+          1)
+        2
+      setResult('' + f())
+    `, 'undefined');
+  });
 });

--- a/test/return_test.js
+++ b/test/return_test.js
@@ -22,7 +22,7 @@ describe('return', () => {
 
   it('forces the return value to be an expression', () =>
     check(`
-      -> return if true then null
+      -> return (if true then null)
     `, `
       () => true ? null : undefined;
     `)

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -1,4 +1,5 @@
 import check from './support/check';
+import validate from './support/validate';
 
 describe('switch', () => {
   it('works with a single case', () => {
@@ -553,5 +554,45 @@ describe('switch', () => {
           break;
       }
     `);
+  });
+
+  it('allows falling through in a returned switch', () => {
+    check(`
+      ->
+        return switch a
+          when b
+            c
+        d
+    `, `
+      (function() {
+        switch (a) {
+          case b:
+            return c;
+        }
+        return d;
+      });
+    `);
+  });
+
+  it('gives the correct result when returning an incomplete switch', () => {
+    validate(`
+      f = ->
+        return switch 1
+          when 2
+            3
+        4
+      setResult(f())
+    `, 4);
+  });
+
+  it('gives the correct result when returning a parenthesized incomplete switch', () => {
+    validate(`
+      f = ->
+        return (switch 1
+          when 2
+            3)
+        4
+      setResult('' + f())
+    `, 'undefined');
   });
 });


### PR DESCRIPTION
Fixes #1004

As far as I can tell, unparenthesized conditionals and switches are the only two
cases where the behavior is different from simply treating the returned node as
an expression, so I special-cased those and reused the same logic as from an
earlier fix.