### PR TITLE
fix: improve the output of dynamically named static methods

### DIFF
--- a/src/stages/main/patchers/SuperPatcher.js
+++ b/src/stages/main/patchers/SuperPatcher.js
@@ -58,7 +58,13 @@ export default class SuperPatcher extends NodePatcher {
     if (methodAssignment instanceof ClassAssignOpPatcher) {
       let accessCode;
       if (methodAssignment.isStaticMethod()) {
-        accessCode = `.${methodAssignment.key.node.member.data}`;
+        if (methodAssignment.key instanceof MemberAccessOpPatcher) {
+          accessCode = `.${methodAssignment.key.node.member.data}`;
+        } else if (methodAssignment.key instanceof DynamicMemberAccessOpPatcher) {
+          accessCode = `[${methodAssignment.key.indexingExpr.getRepeatCode()}]`;
+        } else {
+          throw this.error('Unexpected key type for static method.');
+        }
       } else {
         if (methodAssignment.key instanceof IdentifierPatcher) {
           accessCode = `.${methodAssignment.key.node.data}`;

--- a/src/stages/normalize/patchers/ClassPatcher.js
+++ b/src/stages/normalize/patchers/ClassPatcher.js
@@ -221,7 +221,7 @@ export default class ClassPatcher extends NodePatcher {
     }
     if (node.type === 'AssignOp') {
       let {assignee} = node;
-      if (assignee.type === 'MemberAccessOp') {
+      if (assignee.type === 'MemberAccessOp' || assignee.type === 'DynamicMemberAccessOp') {
         if (assignee.expression.type === 'This') {
           return true;
         }

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -1714,4 +1714,27 @@ describe('classes', () => {
       A.initClass();
     `);
   });
+
+  it('converts dynamically-named static methods properly', () => {
+    check(`
+      class A
+        @[b] = -> 'hello'
+    `, `
+      class A {
+        static [b]() { return 'hello'; }
+      }
+    `);
+  });
+
+  it('properly handles dynamic keys with static methods using super', () => {
+    check(`
+      class A extends B
+        @[c] = -> super
+    `, `
+      let method;
+      class A extends B {
+        static [method = c]() { return super[method](...arguments); }
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Progress toward #860

Previously, static methods with computed names were put in `initClass`, even
though JS has a syntax for static methods with computed names. Now, we consider
them to be static methods just like any other and also get the details figured
out for handling `super` calls (which can be compiled into plain old `super`).

It's still possible to have `super` calls in `initClass` that accidentally
reference `initClass`, but this fixes the most common case of that.