### PR TITLE
fix: properly handle super calls within static methods in initClass

### DIFF
--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -1232,7 +1232,7 @@ export default class NodePatcher {
    * it possible to reference the value afterward with no additional
    * side-effects.
    */
-  setRequiresRepeatableExpression(repeatableOptions={}) {
+  setRequiresRepeatableExpression(repeatableOptions: RepeatableOptions = {}) {
     this._repeatableOptions = repeatableOptions;
   }
 

--- a/src/stages/main/patchers/AssignOpPatcher.js
+++ b/src/stages/main/patchers/AssignOpPatcher.js
@@ -16,6 +16,7 @@ import ThisPatcher from './ThisPatcher';
 import SpreadPatcher from './SpreadPatcher';
 import NodePatcher from './../../../patchers/NodePatcher';
 import canPatchAssigneeToJavaScript from '../../../utils/canPatchAssigneeToJavaScript';
+import containsSuperCall from '../../../utils/containsSuperCall';
 import extractPrototypeAssignPatchers from '../../../utils/extractPrototypeAssignPatchers';
 
 import type { PatcherContext } from './../../../patchers/types';
@@ -262,7 +263,7 @@ export default class AssignOpPatcher extends NodePatcher {
    * that the super transform can make use of it.
    */
   markProtoAssignmentRepeatableIfNecessary() {
-    if (!(this.expression instanceof FunctionPatcher && this.expression.containsSuperCall())) {
+    if (!(this.expression instanceof FunctionPatcher && containsSuperCall(this.expression.node))) {
       return null;
     }
     let prototypeAssignPatchers = extractPrototypeAssignPatchers(this);

--- a/src/stages/main/patchers/ClassAssignOpPatcher.js
+++ b/src/stages/main/patchers/ClassAssignOpPatcher.js
@@ -9,6 +9,7 @@ import StringPatcher from './StringPatcher';
 import ThisPatcher from './ThisPatcher';
 import type NodePatcher from './../../../patchers/NodePatcher';
 import type { Node } from './../../../patchers/types';
+import containsSuperCall from '../../../utils/containsSuperCall';
 import { SourceType } from 'coffee-lex';
 
 export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
@@ -50,7 +51,7 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
    */
   markKeyRepeatableIfNecessary() {
     if (this.expression instanceof FunctionPatcher &&
-        this.expression.containsSuperCall()) {
+        containsSuperCall(this.expression.node)) {
       if (this.isStaticMethod()) {
         if (this.key instanceof DynamicMemberAccessOpPatcher) {
           this.key.indexingExpr.setRequiresRepeatableExpression({

--- a/src/stages/main/patchers/FunctionPatcher.js
+++ b/src/stages/main/patchers/FunctionPatcher.js
@@ -1,7 +1,6 @@
 import NodePatcher from './../../../patchers/NodePatcher';
 import FunctionApplicationPatcher from './FunctionApplicationPatcher';
 import { SourceType } from 'coffee-lex';
-import traverse from '../../../utils/traverse';
 import type BlockPatcher from './BlockPatcher';
 import type { PatcherContext, SourceToken } from './../../../patchers/types';
 
@@ -160,22 +159,5 @@ export default class FunctionPatcher extends NodePatcher {
    */
   statementNeedsParens(): boolean {
     return true;
-  }
-
-  containsSuperCall(): boolean {
-    let foundSuper = false;
-    traverse(this.node, child => {
-      if (foundSuper) {
-        // Already found it, skip this one.
-        return false;
-      } else if (child.type === 'Super') {
-        // Found it.
-        foundSuper = true;
-      } else if (child.type === 'Class') {
-        // Don't go into other classes.
-        return false;
-      }
-    });
-    return foundSuper;
   }
 }

--- a/src/stages/main/patchers/SuperPatcher.js
+++ b/src/stages/main/patchers/SuperPatcher.js
@@ -45,6 +45,9 @@ export default class SuperPatcher extends NodePatcher {
           'Complex super calls within anonymous classes are not yet supported.');
       }
       let openParenToken = this.getFollowingOpenParenToken();
+      // Note that this code snippet works for instance methods but not static
+      // methods. Static methods that require the expanded call form like this
+      // have already been converted in the normalize step.
       this.overwrite(this.contentStart, openParenToken.end,
         `${classCode}.prototype.__proto__${accessCode}.call(this, `);
     }

--- a/src/stages/normalize/index.js
+++ b/src/stages/normalize/index.js
@@ -1,11 +1,11 @@
 import ArrayInitialiserPatcher from './patchers/ArrayInitialiserPatcher';
-import BareSuperFunctionApplicationPatcher from './patchers/BareSuperFunctionApplicationPatcher';
 import BlockPatcher from './patchers/BlockPatcher';
 import ClassPatcher from './patchers/ClassPatcher';
 import AssignOpPatcher from './patchers/AssignOpPatcher';
 import ConditionalPatcher from './patchers/ConditionalPatcher';
 import ConstructorPatcher from './patchers/ConstructorPatcher';
 import DoOpPatcher from './patchers/DoOpPatcher';
+import DynamicMemberAccessOpPatcher from './patchers/DynamicMemberAccessOpPatcher';
 import ExpansionPatcher from './patchers/ExpansionPatcher';
 import ForInPatcher from './patchers/ForInPatcher';
 import ForOfPatcher from './patchers/ForOfPatcher';
@@ -19,6 +19,8 @@ import PassthroughPatcher from '../../patchers/PassthroughPatcher';
 import ProgramPatcher from './patchers/ProgramPatcher';
 import ProtoMemberAccessOpPatcher from './patchers/ProtoMemberAccessOpPatcher';
 import SpreadPatcher from './patchers/SpreadPatcher';
+import SuperPatcher from './patchers/SuperPatcher';
+import ThisPatcher from './patchers/ThisPatcher';
 import TryPatcher from './patchers/TryPatcher';
 import TransformCoffeeScriptStage from '../TransformCoffeeScriptStage';
 import WhilePatcher from './patchers/WhilePatcher';
@@ -39,6 +41,9 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
 
       case 'MemberAccessOp':
         return MemberAccessOpPatcher;
+
+      case 'DynamicMemberAccessOp':
+        return DynamicMemberAccessOpPatcher;
 
       case 'Block':
         return BlockPatcher;
@@ -73,8 +78,9 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
       case 'SoakedNewOp':
         return FunctionApplicationPatcher;
 
+      case 'Super':
       case 'BareSuperFunctionApplication':
-        return BareSuperFunctionApplicationPatcher;
+        return SuperPatcher;
 
       case 'Identifier':
         return IdentifierPatcher;
@@ -115,6 +121,9 @@ export default class NormalizeStage extends TransformCoffeeScriptStage {
 
       case 'Try':
         return TryPatcher;
+
+      case 'This':
+        return ThisPatcher;
 
       default:
         return PassthroughPatcher;

--- a/src/stages/normalize/patchers/BareSuperFunctionApplicationPatcher.js
+++ b/src/stages/normalize/patchers/BareSuperFunctionApplicationPatcher.js
@@ -1,7 +1,0 @@
-import NodePatcher from './../../../patchers/NodePatcher';
-
-export default class BareSuperFunctionApplicationPatcher extends NodePatcher {
-  patchAsExpression() {
-    this.insert(this.contentEnd, '(arguments...)');
-  }
-}

--- a/src/stages/normalize/patchers/DynamicMemberAccessOpPatcher.js
+++ b/src/stages/normalize/patchers/DynamicMemberAccessOpPatcher.js
@@ -1,0 +1,14 @@
+import PassthroughPatcher from '../../../patchers/PassthroughPatcher';
+import type NodePatcher from '../../../patchers/NodePatcher';
+import type { PatcherContext } from '../../../patchers/types';
+
+export default class DynamicMemberAccessOpPatcher extends PassthroughPatcher {
+  expression: NodePatcher;
+  indexingExpr: NodePatcher;
+
+  constructor(patcherContext: PatcherContext, expression: NodePatcher, indexingExpr: NodePatcher) {
+    super(patcherContext, expression, indexingExpr);
+    this.expression = expression;
+    this.indexingExpr = indexingExpr;
+  }
+}

--- a/src/stages/normalize/patchers/MemberAccessOpPatcher.js
+++ b/src/stages/normalize/patchers/MemberAccessOpPatcher.js
@@ -1,8 +1,19 @@
 import PassthroughPatcher from '../../../patchers/PassthroughPatcher';
 import DefaultParamPatcher from './DefaultParamPatcher';
 import ObjectInitialiserMemberPatcher from './ObjectInitialiserMemberPatcher';
+import type NodePatcher from '../../../patchers/NodePatcher';
+import type { PatcherContext } from '../../../patchers/types';
 
 export default class MemberAccessOpPatcher extends PassthroughPatcher {
+  expression: NodePatcher;
+  member: NodePatcher;
+
+  constructor(patcherContext: PatcherContext, expression: NodePatcher, member: NodePatcher) {
+    super(patcherContext, expression, member);
+    this.expression = expression;
+    this.member = member;
+  }
+
   shouldTrimContentRange() {
     return true;
   }

--- a/src/stages/normalize/patchers/SuperPatcher.js
+++ b/src/stages/normalize/patchers/SuperPatcher.js
@@ -1,0 +1,59 @@
+import { SourceType } from 'coffee-lex';
+
+import AssignOpPatcher from './AssignOpPatcher';
+import ClassPatcher from './ClassPatcher';
+import NodePatcher from './../../../patchers/NodePatcher';
+
+export default class SuperPatcher extends NodePatcher {
+  patchAsExpression() {
+    let earlyTransformInfo = this.getEarlyTransformInfo();
+    if (earlyTransformInfo) {
+      this.patchEarlySuperTransform(earlyTransformInfo);
+    } else if (this.node.type === 'BareSuperFunctionApplication') {
+      this.insert(this.contentEnd, '(arguments...)');
+    }
+  }
+
+  /**
+   * When dynamically defining a static method on a class, we need to handle any
+   * super calls in the normalize stage. Otherwise, the code will move into an
+   * initClass method and super calls will refer to super.initClass.
+   */
+  patchEarlySuperTransform({classCode, accessCode}) {
+    // Note that this code snippet works for static methods but not instance
+    // methods. Expanded super calls for instance methods are handled in the
+    // main stage.
+    let replacement = `${classCode}.__proto__${accessCode}.call(this, `;
+    if (this.node.type === 'BareSuperFunctionApplication') {
+      this.overwrite(this.contentStart, this.contentEnd, `${replacement}arguments...)`);
+    } else {
+      let followingOpenParen = this.getFollowingOpenParenToken();
+      this.overwrite(this.contentStart, followingOpenParen.end, replacement);
+    }
+  }
+
+  getEarlyTransformInfo() {
+    let parent = this.parent;
+    while (parent) {
+      if (parent instanceof AssignOpPatcher) {
+        let earlyTransformInfo = parent.getEarlySuperTransformInfo();
+        if (earlyTransformInfo) {
+          return earlyTransformInfo;
+        }
+      } else if (parent instanceof ClassPatcher) {
+        return null;
+      }
+      parent = parent.parent;
+    }
+    return null;
+  }
+
+  getFollowingOpenParenToken(): SourceToken {
+    let openParenTokenIndex = this.indexOfSourceTokenAfterSourceTokenIndex(
+      this.contentEndTokenIndex, SourceType.CALL_START);
+    if (!openParenTokenIndex) {
+      throw this.error('Expected open-paren after super.');
+    }
+    return this.sourceTokenAtIndex(openParenTokenIndex);
+  }
+}

--- a/src/stages/normalize/patchers/ThisPatcher.js
+++ b/src/stages/normalize/patchers/ThisPatcher.js
@@ -1,0 +1,22 @@
+import { SourceType } from 'coffee-lex';
+import PassthroughPatcher from '../../../patchers/PassthroughPatcher';
+import MemberAccessOpPatcher from './MemberAccessOpPatcher';
+
+export default class ThisPatcher extends PassthroughPatcher {
+  /**
+   * When patching a shorthand like `@a` as repeatable, we need to add a dot to
+   * make the result still syntactically valid.
+   */
+  patchAsRepeatableExpression(repeatableOptions: RepeatableOptions={}, patchOptions={}): string {
+    let ref = super.patchAsRepeatableExpression(repeatableOptions, patchOptions);
+    let addedParens = (!this.isRepeatable() || repeatableOptions.forceRepeat) &&
+      repeatableOptions.parens;
+    if (addedParens && this.parent instanceof MemberAccessOpPatcher) {
+      let nextToken = this.nextSemanticToken();
+      if (!nextToken || nextToken.type !== SourceType.DOT) {
+        this.insert(this.innerEnd, '.');
+      }
+    }
+    return ref;
+  }
+}

--- a/src/utils/containsSuperCall.js
+++ b/src/utils/containsSuperCall.js
@@ -1,0 +1,20 @@
+import traverse from './traverse';
+
+import type { Node } from '../patchers/types';
+
+export default function containsSuperCall(node: Node) {
+  let foundSuper = false;
+  traverse(node, child => {
+    if (foundSuper) {
+      // Already found it, skip this one.
+      return false;
+    } else if (child.type === 'Super' || child.type === 'BareSuperFunctionApplication') {
+      // Found it.
+      foundSuper = true;
+    } else if (child.type === 'Class') {
+      // Don't go into other classes.
+      return false;
+    }
+  });
+  return foundSuper;
+}


### PR DESCRIPTION
Fixes #860

This `initClass` transform can reposition static methods so that they no longer
have the proper `super` semantics according to CoffeeScript's algorithm.
Instead, the `super` matches the `initClass` method itself. Since the code after
the normalize stage is incorrect, there's no way to fix this properly in the
main stage; instead, this commit moves some of the `super` logic to the
normalize stage, while most of it is still in the main stage.

This ended up being kind of a pain, but seems to be working. Some details:
* One role of the normalize stage is to add explicit arguments to all bare super
  calls. Since I'm now doing some super transformations in the normalize stage,
  I need to handle those two cases specifically.
* We need to extract out the `this` reference, but an expression like `@a` would
  then become `(cls = @)a`, which doesn't parse. To address this, we now have a
  special case for patching that form of `this` as repeatable in the normalize
  stage.
* The `containsSuperCall` method needed to be extracted out into a shared
  function so it's usable from the normalize stage.
* We need to do some custom logic to detect if the super call should be
  early-transformed in the first place. It needs to be a static method
  declaration within a class, but not a top-level one that would become a
  regular static method.
* The code snippet for manually calling super for a static method is different
  than for an instance method, so the normalize case uses the static method code
  snippet and the main stage case uses the instance method code snippet.