### PR TITLE
fix: properly add variable declarations for IIFE loop assignees

### DIFF
--- a/src/stages/TransformCoffeeScriptStage.js
+++ b/src/stages/TransformCoffeeScriptStage.js
@@ -48,6 +48,7 @@ export default class TransformCoffeeScriptStage {
 
   build(): NodePatcher {
     this.root = this.patcherForNode(this.ast);
+    // Note that initialize is called in bottom-up order.
     this.patchers.forEach(patcher => patcher.initialize());
     return this.root;
   }

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1704,4 +1704,28 @@ describe('for loops', () => {
       for (let a of Object.keys(b || {})) {} 
     `);
   });
+
+  it('declares bindings for IIFE-style loops in an outer scope if necessary', () => {
+    check(`
+      a
+      x = (a for a in [])
+    `, `
+      let a;
+      a;
+      let x = ((() => {
+        let result = [];
+        for (a of []) {     result.push(a);
+        }
+        return result;
+      })());
+    `);
+  });
+
+  it('does not crash with a variable access followed by an IIFE-style loop declaring the variable', () => {
+    validate(`
+      a
+      x = (a for a in [])
+      setResult('did not crash')
+    `, 'did not crash');
+  });
 });


### PR DESCRIPTION
Fixes #750

The solution here is similar in spirit to #639, but has some differences.
Rather than allowing the loop to become an IIFE and letting
add-variable-declarations put in the declaration for us, we now explicitly add
declarations for any index/value bindings that we know will be in IIFEs, as long
as there is at least one usage of the variable outside of the loop. This
required a lot of coordination between BlockPatcher and all of its descendant
ForPatchers during initialize so that patching can be done in the proper order.