### PR TITLE
fix: force `throw` targets to be expressions

### DIFF
--- a/src/stages/main/patchers/ThrowPatcher.js
+++ b/src/stages/main/patchers/ThrowPatcher.js
@@ -10,6 +10,10 @@ export default class ThrowPatcher extends NodePatcher {
     this.expression = expression;
   }
 
+  initialize() {
+    this.expression.setRequiresExpression();
+  }
+
   /**
    * Throw in JavaScript is a statement only, so we'd prefer it stay that way.
    */

--- a/test/throw_test.js
+++ b/test/throw_test.js
@@ -68,4 +68,12 @@ describe('throw', () => {
       throw a;
     `);
   });
+
+  it('treats the throw target as an expression', () => {
+    check(`
+      throw(res.data?.error)
+    `, `
+      throw(res.data != null ? res.data.error : undefined);
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #1096