### PR TITLE
fix: remove semicolons when turning blocks into expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babylon": "^6.12.0",
     "coffee-lex": "^7.0.0",
     "decaffeinate-coffeescript": "1.10.0-patch24",
-    "decaffeinate-parser": "^17.1.4",
+    "decaffeinate-parser": "^17.1.6",
     "detect-indent": "^4.0.0",
     "esnext": "^3.1.0",
     "lines-and-columns": "^1.1.5",

--- a/src/stages/main/patchers/BlockPatcher.js
+++ b/src/stages/main/patchers/BlockPatcher.js
@@ -190,6 +190,10 @@ export default class BlockPatcher extends SharedBlockPatcher {
         }
       );
     }
+    let lastToken = this.lastToken();
+    if (lastToken.type === SourceType.SEMICOLON) {
+      this.remove(lastToken.start, lastToken.end);
+    }
     if (rightBrace) {
       this.insert(this.innerEnd, ')');
     }

--- a/test/conditional_test.js
+++ b/test/conditional_test.js
@@ -811,4 +811,28 @@ describe('conditionals', () => {
       setResult('' + f())
     `, 'undefined');
   });
+
+  it('handles an expression-style conditional ending in a semicolon', () => {
+    check(`
+      x = if a
+        ;
+    `, `
+      let x = a ?
+        undefined : undefined;
+    `);
+  });
+
+  it('handles an expression-style conditional with semicolon consequent', () => {
+    check(`
+      x = if a
+        ;
+      else
+        b
+    `, `
+      let x = a ?
+        undefined
+      :
+        b;
+    `);
+  });
 });

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -1728,4 +1728,24 @@ describe('for loops', () => {
       setResult('did not crash')
     `, 'did not crash');
   });
+
+  it('does not crash on a semicolon-only body for a loop expression', () => {
+    check(`
+      x = for a in b
+        ;
+    `, `
+      let x = Array.from(b).map((a) =>
+        undefined);
+    `);
+  });
+
+  it('does not crash on a body ending in a semicolon', () => {
+    check(`
+      x = for a in b
+        c;
+    `, `
+      let x = Array.from(b).map((a) =>
+        c);
+    `);
+  });
 });

--- a/test/function_call_test.js
+++ b/test/function_call_test.js
@@ -739,4 +739,27 @@ describe('function calls', () => {
       a((b = d[0], c = d[d.length - 1], d));
     `);
   });
+
+  it('properly handles a semicolon-terminated function followed by a comma', () => {
+    check(`
+      fn1((done) ->
+        fn2('string', (object) ->
+          ;
+        , (err, data) ->
+          p = data
+          done(err)
+        )
+      )
+    `, `
+      fn1(done =>
+        fn2('string', function(object) {
+          
+        }
+        , function(err, data) {
+          let p = data;
+          return done(err);
+        })
+      );
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #1108

Now that all lone semicolons are treated in the AST as empty blocks, they turn
into `undefined` as expected when treated as an expression, but the semicolon is
still there. To fix this, we can just detect if the block ends in a semicolon
(even for non-empty blocks) and remove it.