### PR TITLE
refactor: add an initial suggestions system that isn't hooked up

### DIFF
--- a/eslint-rules/no-const-except-at-top.js
+++ b/eslint-rules/no-const-except-at-top.js
@@ -3,7 +3,7 @@ module.exports = function(context) {
     'VariableDeclaration': function(node) {
       if (node.kind === 'const') {
         var parent = node.parent;
-        if (parent.type !== 'Program') {
+        if (parent.type !== 'Program' && parent.type !== 'ExportNamedDeclaration') {
           context.report({
             message: '`const` declarations are only allowed at the top of the program',
             node: node,

--- a/src/patchers/NodePatcher.js
+++ b/src/patchers/NodePatcher.js
@@ -32,13 +32,14 @@ export default class NodePatcher {
   adjustedIndentLevel: number = 0;
   _containsYield: boolean = false;
 
-  constructor({node, context, editor, options}: PatcherContext) {
+  constructor({node, context, editor, options, addSuggestion}: PatcherContext) {
     this.log = logger(this.constructor.name);
 
     this.node = node;
     this.context = context;
     this.editor = editor;
     this.options = options;
+    this.addSuggestion = addSuggestion;
 
     this.withPrettyErrors(() => this.setupLocationInformation());
   }

--- a/src/patchers/types.js
+++ b/src/patchers/types.js
@@ -1,5 +1,6 @@
 import type Scope from '../utils/Scope';
 import type Options from '../index';
+import type { Suggestion } from '../suggestions';
 
 export type Range = [number, number];
 
@@ -33,6 +34,7 @@ export type PatcherContext = {
   context: ParseContext;
   editor: Editor;
   options: Options;
+  addSuggestion: (Suggestion) => void;
 };
 
 export type RepeatableOptions = {

--- a/src/stages/TransformCoffeeScriptStage.js
+++ b/src/stages/TransformCoffeeScriptStage.js
@@ -5,10 +5,10 @@ import parse from '../utils/parse';
 import type { Node, ParseContext, Editor } from '../patchers/types';
 import { childPropertyNames } from '../utils/traverse';
 import { logger } from '../utils/debug';
-import type { Options } from '../index';
+import type { Options, StageResult } from '../index';
 
 export default class TransformCoffeeScriptStage {
-  static run(content: string, options: Options): { code: string } {
+  static run(content: string, options: Options): StageResult {
     let log = logger(this.name);
     log(content);
 
@@ -19,6 +19,7 @@ export default class TransformCoffeeScriptStage {
     patcher.patch();
     return {
       code: editor.toString(),
+      suggestions: stage.suggestions,
     };
   }
 
@@ -37,6 +38,7 @@ export default class TransformCoffeeScriptStage {
     this.options = options;
     this.root = null;
     this.patchers = [];
+    this.suggestions = [];
   }
 
   /**
@@ -80,7 +82,8 @@ export default class TransformCoffeeScriptStage {
       node,
       context: this.context,
       editor: this.editor,
-      options: this.options
+      options: this.options,
+      addSuggestion: suggestion => { this.suggestions.push(suggestion); },
     };
     let patcher = new constructor(patcherContext, ...children);
     this.patchers.push(patcher);

--- a/src/stages/add-variable-declarations/index.js
+++ b/src/stages/add-variable-declarations/index.js
@@ -2,8 +2,10 @@ import addVariableDeclarations from 'add-variable-declarations';
 import MagicString from 'magic-string';
 import { logger } from '../../utils/debug';
 
+import type { StageResult } from '../../index';
+
 export default class AddVariableDeclarationsStage {
-  static run(content: string): { code: string } {
+  static run(content: string): StageResult {
     let log = logger(this.name);
     log(content);
 
@@ -11,6 +13,7 @@ export default class AddVariableDeclarationsStage {
     addVariableDeclarations(content, editor);
     return {
       code: editor.toString(),
+      suggestions: [],
     };
   }
 }

--- a/src/stages/esnext/index.js
+++ b/src/stages/esnext/index.js
@@ -1,9 +1,9 @@
 import { allPlugins, convert } from 'esnext';
 import { logger } from '../../utils/debug';
-import type { Options } from '../../index';
+import type { Options, StageResult } from '../../index';
 
 export default class EsnextStage {
-  static run(content: string, options: Options): { code: string } {
+  static run(content: string, options: Options): StageResult {
     let log = logger(this.name);
     log(content);
     let plugins = allPlugins;
@@ -35,6 +35,9 @@ export default class EsnextStage {
         safeFunctionIdentifiers: options.safeImportFunctionIdentifiers,
       },
     });
-    return { code };
+    return {
+      code,
+      suggestions: [],
+    };
   }
 }

--- a/src/stages/literate/index.js
+++ b/src/stages/literate/index.js
@@ -1,12 +1,15 @@
+import type { StageResult } from '../../index';
+
 const VALID_INDENTATIONS = ['    ', '   \t', '  \t', ' \t', '\t'];
 
 /**
  * Convert Literate CoffeeScript into regular CoffeeScript.
  */
 export default class LiterateStage {
-  static run(content: string): { code: string } {
+  static run(content: string): StageResult {
     return {
       code: convertCodeFromLiterate(content),
+      suggestions: [],
     };
   }
 }

--- a/src/stages/main/patchers/ClassBlockPatcher.js
+++ b/src/stages/main/patchers/ClassBlockPatcher.js
@@ -8,6 +8,7 @@ import getBindingCodeForMethod from '../../../utils/getBindingCodeForMethod';
 import getInvalidConstructorErrorMessage from '../../../utils/getInvalidConstructorErrorMessage';
 import type ClassPatcher from './ClassPatcher';
 import type { Node } from './../../../patchers/types';
+import { REMOVE_BABEL_WORKAROUND } from '../../../suggestions';
 
 export default class ClassBlockPatcher extends BlockPatcher {
   static patcherClassForChildNode(node: Node, property: string): ?Class<NodePatcher> {
@@ -65,7 +66,11 @@ export default class ClassBlockPatcher extends BlockPatcher {
   }
 
   shouldEnableBabelWorkaround() {
-    return this.options.enableBabelConstructorWorkaround;
+    let shouldEnable = this.options.enableBabelConstructorWorkaround;
+    if (shouldEnable) {
+      this.addSuggestion(REMOVE_BABEL_WORKAROUND);
+    }
+    return shouldEnable;
   }
   
   getClassPatcher(): ClassPatcher {

--- a/src/stages/main/patchers/ConstructorPatcher.js
+++ b/src/stages/main/patchers/ConstructorPatcher.js
@@ -8,6 +8,7 @@ import { isFunction } from '../../../utils/types';
 import type FunctionPatcher from './FunctionPatcher';
 import type NodePatcher from '../../../patchers/NodePatcher';
 import type { PatcherContext } from './../../../patchers/types';
+import { REMOVE_BABEL_WORKAROUND } from '../../../suggestions';
 
 export default class ConstructorPatcher extends ObjectBodyMemberPatcher {
   constructor(patcherContext: PatcherContext, assignee: NodePatcher, expression: FunctionPatcher) {
@@ -69,8 +70,12 @@ export default class ConstructorPatcher extends ObjectBodyMemberPatcher {
   }
 
   shouldAddBabelWorkaround(): boolean {
-    return this.options.enableBabelConstructorWorkaround &&
+    let shouldEnable = this.options.enableBabelConstructorWorkaround &&
       this.getInvalidConstructorMessage() !== null;
+    if (shouldEnable) {
+      this.addSuggestion(REMOVE_BABEL_WORKAROUND);
+    }
+    return shouldEnable;
   }
 
   /**

--- a/src/stages/semicolons/index.js
+++ b/src/stages/semicolons/index.js
@@ -4,6 +4,8 @@ import buildConfig from 'ast-processor-babylon-config';
 import { logger } from '../../utils/debug';
 import { parse } from 'babylon';
 
+import type { StageResult } from '../../index';
+
 const BABYLON_PLUGINS = [
   'flow',
   'jsx',
@@ -22,7 +24,7 @@ const BABYLON_PLUGINS = [
 ];
 
 export default class SemicolonsStage {
-  static run(content: string): { code: string } {
+  static run(content: string): StageResult {
     let log = logger(this.name);
     log(content);
 
@@ -41,6 +43,7 @@ export default class SemicolonsStage {
 
     return {
       code: editor.toString(),
+      suggestions: [],
     };
   }
 }

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -1,0 +1,19 @@
+/* @flow */
+
+export type Suggestion = {
+  suggestionCode: string,
+  message: string,
+};
+
+export const REMOVE_BABEL_WORKAROUND = {
+  suggestionCode: 'DS001',
+  message: 'Remove Babel constructor workaround',
+};
+
+export function mergeSuggestions(suggestions: Array<Suggestion>): Array<Suggestion> {
+  let suggestionsByCode = {};
+  for (let suggestion of suggestions) {
+    suggestionsByCode[suggestion.suggestionCode] = suggestion;
+  }
+  return Object.keys(suggestionsByCode).sort().map(code => suggestionsByCode[code]);
+}

--- a/test/chained_comparison_test.js
+++ b/test/chained_comparison_test.js
@@ -93,7 +93,11 @@ describe('chained comparison', () => {
       if (a >= b || b > c) {
         d;
       }
-    `, { looseComparisonNegation: true });
+    `, {
+      options: {
+        looseComparisonNegation: true,
+      }
+    });
   });
 
   it('does not flip the inequalities when used in an `unless` by default', () => {

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -78,7 +78,11 @@ describe('classes', () => {
       (class extends Parent {
         constructor() {}
       });
-    `, { allowInvalidConstructors: true });
+    `, {
+      options: {
+        allowInvalidConstructors: true
+      }
+    });
   });
 
   it('preserves class constructors without arguments', () => {
@@ -241,7 +245,11 @@ describe('classes', () => {
             super(...arguments);
           }
         }
-      `, { allowInvalidConstructors: true });
+      `, {
+        options: {
+          allowInvalidConstructors: true
+        }
+      });
     });
 
     it('does not error when specified when a subclass constructor omits super', () => {
@@ -255,7 +263,11 @@ describe('classes', () => {
             this.a = 2;
           }
         }
-      `, { allowInvalidConstructors: true });
+      `, {
+        options: {
+          allowInvalidConstructors: true
+        }
+      });
     });
 
     it('creates a constructor for bound methods with a `super` call in extended classes when requested', () => {
@@ -274,7 +286,11 @@ describe('classes', () => {
           return 1;
         }
       }
-    `, { allowInvalidConstructors: true });
+    `, {
+        options: {
+          allowInvalidConstructors: true
+        }
+      });
     });
 
     it('adds to an existing constructor for bound methods before a `super` call when requested', () => {
@@ -298,7 +314,11 @@ describe('classes', () => {
           this.b = 2;
         }
       }
-    `, { allowInvalidConstructors: true });
+    `, {
+        options: {
+          allowInvalidConstructors: true
+        }
+      });
     });
 
     it('generates workaround code when specified when using this before super in a constructor', () => {
@@ -321,7 +341,11 @@ describe('classes', () => {
             super(...arguments);
           }
         }
-      `, { enableBabelConstructorWorkaround: true });
+      `, {
+        options: {
+          enableBabelConstructorWorkaround: true
+        }
+      });
     });
 
     it('generates workaround code when specified when a subclass constructor omits super', () => {
@@ -342,7 +366,11 @@ describe('classes', () => {
             this.a = 2;
           }
         }
-      `, { enableBabelConstructorWorkaround: true });
+      `, {
+        options: {
+          enableBabelConstructorWorkaround: true
+        }
+      });
     });
 
     it('generates workaround code when specified when a subclass has a bound method and no constructor', () => {
@@ -368,7 +396,11 @@ describe('classes', () => {
             return null;
           }
         }
-      `, { enableBabelConstructorWorkaround: true });
+      `, {
+        options: {
+          enableBabelConstructorWorkaround: true
+        }
+      });
     });
 
     it('generates workaround code when specified when a subclass has a bound method and a normal constructor', () => {
@@ -399,7 +431,11 @@ describe('classes', () => {
             return null;
           }
         }
-      `, { enableBabelConstructorWorkaround: true });
+      `, {
+        options: {
+          enableBabelConstructorWorkaround: true
+        }
+      });
     });
 
     it('generates workaround code when specified when a subclass has a bound method and an empty constructor', () => {
@@ -426,7 +462,11 @@ describe('classes', () => {
             return null;
           }
         }
-      `, { enableBabelConstructorWorkaround: true });
+      `, {
+        options: {
+          enableBabelConstructorWorkaround: true
+        }
+      });
     });
 
     it('does not generate workaround code when the flag is set but the workaround is unnecessary', () => {
@@ -442,7 +482,11 @@ describe('classes', () => {
             this.x = 3;
           }
         }
-      `, { enableBabelConstructorWorkaround: true });
+      `, {
+        options: {
+          enableBabelConstructorWorkaround: true
+        }
+      });
     });
 
     it('properly generates workaround code when constructors have default parameters', () => {
@@ -466,7 +510,11 @@ describe('classes', () => {
             super(...arguments);
           }
         }
-      `, { enableBabelConstructorWorkaround: true });
+      `, {
+        options: {
+          enableBabelConstructorWorkaround: true
+        }
+      });
     });
 
     it('chooses variables that do not conflict', () => {
@@ -542,7 +590,11 @@ describe('classes', () => {
         (function(a, b = this.c) {
           this.a = a;
         });
-      `, { looseDefaultParams: true });
+      `, {
+        options: {
+          looseDefaultParams: true
+        }
+      });
     });
 
     it('uses correct value for default param when reusing an already implicitly assigned param', () => {
@@ -565,7 +617,11 @@ describe('classes', () => {
       class A extends B {
         constructor() {}
       }
-    `, { allowInvalidConstructors: true });
+    `, {
+      options: {
+        allowInvalidConstructors: true
+      }
+    });
   });
 
   it('preserves class constructors extending non-identifier superclasses', () => {
@@ -577,7 +633,11 @@ describe('classes', () => {
       class A extends (B = class B extends C {}) {
         constructor() {}
       }
-    `, { allowInvalidConstructors: true });
+    `, {
+      options: {
+        allowInvalidConstructors: true
+      }
+    });
   });
 
   it('turns non-method properties into prototype assignments', () => {
@@ -957,7 +1017,11 @@ describe('classes', () => {
       
         add() {}
       }
-    `, { allowInvalidConstructors: true });
+    `, {
+      options: {
+        allowInvalidConstructors: true
+      }
+    });
   });
 
   it('handles a bound method and an empty constructor', () => {
@@ -1020,7 +1084,11 @@ describe('classes', () => {
       
         add() {}
       }
-    `, { allowInvalidConstructors: true });
+    `, {
+      options: {
+        allowInvalidConstructors: true
+      }
+    });
   });
 
   it('places method bindings at the start of the constructor if there is no super', () => {

--- a/test/comparison_test.js
+++ b/test/comparison_test.js
@@ -19,7 +19,11 @@ describe('comparisons', () => {
       if (a >= b) {
         c;
       }
-    `, { looseComparisonNegation: true });
+    `, {
+      options: {
+        looseComparisonNegation: true
+      }
+    });
   });
 
   it('does not flip comparisons when used with an `unless` by default', () => {
@@ -41,7 +45,11 @@ describe('comparisons', () => {
       if ((a >= b) || (b <= c)) {
         d;
       }
-    `, { looseComparisonNegation: true });
+    `, {
+      options: {
+        looseComparisonNegation: true
+      }
+    });
   });
 
   it('does not flip nested comparisons when used with an `unless` by default', () => {

--- a/test/declaration_test.js
+++ b/test/declaration_test.js
@@ -149,6 +149,10 @@ describe('declarations', () => {
   });
 
   it('uses const rather than let if specified', () => {
-    check('a = 1', 'const a = 1;', { preferConst: true });
+    check('a = 1', 'const a = 1;', {
+      options: {
+        preferConst: true
+      }
+    });
   });
 });

--- a/test/default_param_test.js
+++ b/test/default_param_test.js
@@ -2,19 +2,35 @@ import check from './support/check';
 
 describe('default params', () => {
   it('keeps default value with loose mode enabled', () => {
-    check(`(a=2) ->`, `(function(a=2) {});`, { looseDefaultParams: true });
+    check(`(a=2) ->`, `(function(a=2) {});`, {
+      options: {
+        looseDefaultParams: true,
+      }
+    });
   });
 
   it('ensures transforms happen on the default value in loose mode', () => {
-    check(`(a=b c) ->`, `(function(a=b(c)) {});`, { looseDefaultParams: true });
+    check(`(a=b c) ->`, `(function(a=b(c)) {});`, {
+      options: {
+        looseDefaultParams: true,
+      }
+    });
   });
 
   it('ensures @foo is transformed correctly in loose mode', () => {
-    check(`(a=@b) ->`, `(function(a=this.b) {});`, { looseDefaultParams: true });
+    check(`(a=@b) ->`, `(function(a=this.b) {});`, {
+      options: {
+        looseDefaultParams: true,
+      }
+    });
   });
 
   it('patches value as an expression in loose mode', () => {
-    check(`(a=b: c) ->`, `(function(a={b: c}) {});`, { looseDefaultParams: true });
+    check(`(a=b: c) ->`, `(function(a={b: c}) {});`, {
+      options: {
+        looseDefaultParams: true,
+      }
+    });
   });
 
   it('changes default params to conditional assignments by default', () => {

--- a/test/for_test.js
+++ b/test/for_test.js
@@ -96,7 +96,11 @@ describe('for loops', () => {
       for (let a of b) {
         a;
       }
-    `, { looseForOf: true });
+    `, {
+      options: {
+        looseForOf: true
+      }
+    });
   });
 
   it('skips Array.from when iterating over an array literal', () => {
@@ -586,7 +590,11 @@ describe('for loops', () => {
       a(e for e in l)
     `, `
       a(l.map((e) => e));
-    `, { looseForExpressions: true });
+    `, {
+      options: {
+        looseForExpressions: true
+      }
+    });
   });
 
   it('does not wrap in Array.from for for-in expressions over an array literal', () => {

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -330,7 +330,11 @@ describe('functions', () => {
   });
 
   it('keeps function with a single assignment as a parameter in braces in loose param mode', () => {
-    check(`(args=false) =>`, `(args=false) => {};`, { looseDefaultParams: true });
+    check(`(args=false) =>`, `(args=false) => {};`, {
+      options: {
+        looseDefaultParams: true,
+      }
+    });
   });
 
   it('places the function end in the right place when ending in an implicit function call', () =>

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -19,7 +19,9 @@ describe('imports', () => {
       let x = require('x');
       module.exports.y = 3;
     `, {
-      keepCommonJS: true
+      options: {
+        keepCommonJS: true,
+      },
     });
   });
 
@@ -37,7 +39,9 @@ describe('imports', () => {
       bar();
       let z = require('z');
     `, {
-      safeImportFunctionIdentifiers: ['foo']
+      options: {
+        safeImportFunctionIdentifiers: ['foo'],
+      },
     });
   });
 
@@ -51,7 +55,9 @@ describe('imports', () => {
       defaultExport.c = d;
       export default defaultExport;
     `, {
-      forceDefaultExport: true
+      options: {
+        forceDefaultExport: true,
+      },
     });
   });
 });

--- a/test/in_test.js
+++ b/test/in_test.js
@@ -15,7 +15,11 @@ describe('in operator', () => {
       a in b
     `, `
       b.includes(a);
-    `, { looseIncludes: true });
+    `, {
+      options: {
+        looseIncludes: true,
+      }
+    });
   });
 
   it('handles a property access as the LHS', () => {

--- a/test/literate_test.js
+++ b/test/literate_test.js
@@ -30,7 +30,11 @@ describe('literate mode', () => {
         }
         return result;
       })();
-    `, { literate: true });
+    `, {
+      options: {
+        literate: true,
+      }
+    });
   });
 
   it('handles a file starting with code and ending with a comment', () => {
@@ -44,7 +48,11 @@ describe('literate mode', () => {
       let b = 2;
       let c = 3;
       // Those are the first three letters of the alphabet.
-    `, { literate: true });
+    `, {
+      options: {
+        literate: true,
+      }
+    });
   });
 
   it('requires a blank line before moving to a code section', () => {
@@ -61,7 +69,11 @@ describe('literate mode', () => {
       //     all that I want
       //       and it still will be in a comment.
       let exceptNow = true;
-    `, { literate: true });
+    `, {
+      options: {
+        literate: true,
+      }
+    });
   });
 
   it('handles increasing indentation across distinct code sections', () => {
@@ -94,7 +106,11 @@ describe('literate mode', () => {
           c;
         }
       }
-    `, { literate: true });
+    `, {
+      options: {
+        literate: true,
+      }
+    });
   });
 
   it('treats normal coffee files as non-literate', () => {
@@ -102,7 +118,11 @@ describe('literate mode', () => {
       a = 1
     `, `
       let a = 1;
-    `, { filename: 'foo.coffee' });
+    `, {
+      options: {
+        filename: 'foo.coffee',
+      }
+    });
   });
 
   it('treats .coffee.md files as literate', () => {
@@ -110,7 +130,11 @@ describe('literate mode', () => {
       a = 1
     `, `
       // a = 1
-    `, { filename: 'foo.coffee.md' });
+    `, {
+      options: {
+        filename: 'foo.coffee.md',
+      }
+    });
   });
 
   it('treats .litcoffee files as literate', () => {
@@ -118,6 +142,10 @@ describe('literate mode', () => {
       a = 1
     `, `
       // a = 1
-    `, { filename: 'foo.litcoffee' });
+    `, {
+      options: {
+        filename: 'foo.litcoffee',
+      }
+    });
   });
 });

--- a/test/suggestions_test.js
+++ b/test/suggestions_test.js
@@ -1,0 +1,89 @@
+import check from './support/check';
+import { REMOVE_BABEL_WORKAROUND } from '../src/suggestions';
+
+describe('suggestions', () => {
+  it('provides a suggestion for the babel constructor workaround', () => {
+    check(`
+      class A extends B
+        c: =>
+          d
+    `, `
+      class A extends B {
+        constructor(...args) {
+          {
+            // Hack: trick babel into allowing this before super.
+            if (false) { super(); }
+            let thisFn = (() => { this; }).toString();
+            let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
+            eval(\`\${thisName} = this;\`);
+          }
+          this.c = this.c.bind(this);
+          super(...args);
+        }
+      
+        c() {
+          return d;
+        }
+      }
+    `, {
+      options: {enableBabelConstructorWorkaround: true},
+      expectedSuggestions: [
+        REMOVE_BABEL_WORKAROUND,
+      ],
+    });
+  });
+
+  it('provides no suggestions for an ordinary file', () => {
+    check(`
+      x = 1
+    `, `
+      let x = 1;
+    `, {
+      expectedSuggestions: [],
+    });
+  });
+
+  it('only shows one of each suggestion', () => {
+    check(`
+      class A extends B
+        constructor: (@c) ->
+          super
+      class E extends F
+        constructor: (@g) ->
+          super
+    `, `
+      class A extends B {
+        constructor(c) {
+          {
+            // Hack: trick babel into allowing this before super.
+            if (false) { super(); }
+            let thisFn = (() => { this; }).toString();
+            let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
+            eval(\`$\{thisName} = this;\`);
+          }
+          this.c = c;
+          super(...arguments);
+        }
+      }
+      class E extends F {
+        constructor(g) {
+          {
+            // Hack: trick babel into allowing this before super.
+            if (false) { super(); }
+            let thisFn = (() => { this; }).toString();
+            let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
+            eval(\`$\{thisName} = this;\`);
+          }
+          this.g = g;
+          super(...arguments);
+        }
+      }
+    `, {
+      options: {enableBabelConstructorWorkaround: true},
+      expectedSuggestions: [
+        REMOVE_BABEL_WORKAROUND,
+      ],
+    });
+  });
+
+});

--- a/test/support/check.js
+++ b/test/support/check.js
@@ -1,15 +1,18 @@
 import PatchError from '../../src/utils/PatchError';
 import stripSharedIndent from '../../src/utils/stripSharedIndent';
 import { convert } from '../../src/index';
-import { strictEqual } from 'assert';
+import { deepEqual, strictEqual } from 'assert';
 
-export default function check(source, expected, options={}) {
+export default function check(source, expected, {options={}, expectedSuggestions}={}) {
   if (source[0] === '\n') { source = stripSharedIndent(source); }
   if (expected[0] === '\n') { expected = stripSharedIndent(expected); }
 
   try {
     let converted = convert(source, options);
     strictEqual(converted.code, expected);
+    if (expectedSuggestions) {
+      deepEqual(expectedSuggestions, converted.suggestions);
+    }
   } catch (err) {
     if (PatchError.detect(err)) {
       console.error(PatchError.prettyPrint(err));

--- a/test/switch_test.js
+++ b/test/switch_test.js
@@ -232,7 +232,11 @@ describe('switch', () => {
         case score >= 90: 'B'; break;
         default: 'A';
       }
-    `, { looseComparisonNegation: true });
+    `, {
+      options: {
+        looseComparisonNegation: true,
+      }
+    });
   });
 
   it('converts a switch without an expression with function call cases', () => {


### PR DESCRIPTION
Progress toward #1107

At the moment, we never print suggestions, but we do return them from the
convert function. Each suggestion has a shorthand code and a summary string, but
doesn't include any context like where in the code the transformation happened.
Suggestions are sorted by code, although in the future it may be better to
independently sort them by priority.