### PR TITLE
fix: don't crash when using a binary operator with range or extends

### DIFF
--- a/src/stages/main/patchers/BinaryOpPatcher.js
+++ b/src/stages/main/patchers/BinaryOpPatcher.js
@@ -85,6 +85,9 @@ export default class BinaryOpPatcher extends NodePatcher {
     return this.sourceTokenAtIndex(operatorTokenIndex);
   }
 
+  /**
+   * Subclasses may override this to provide a custom token predicate.
+   */
   operatorTokenPredicate(): (token: SourceToken) => boolean {
     return (token: SourceToken) => token.type === SourceType.OPERATOR || token.type === SourceType.EXISTENCE;
   }

--- a/src/stages/main/patchers/ExtendsOpPatcher.js
+++ b/src/stages/main/patchers/ExtendsOpPatcher.js
@@ -1,3 +1,5 @@
+import { SourceType } from 'coffee-lex';
+
 import BinaryOpPatcher from './BinaryOpPatcher';
 
 const EXTENDS_HELPER = `
@@ -32,5 +34,13 @@ export default class ExtendsOpPatcher extends BinaryOpPatcher {
    */
   statementNeedsParens(): boolean {
     return false;
+  }
+
+  operatorTokenPredicate(): (token: SourceToken) => boolean {
+    // Right now the "extends" token is an identifier rather than a binary
+    // operator, so treat it as a special case for this node type.
+    return (token: SourceToken) =>
+      token.type === SourceType.IDENTIFIER &&
+        this.sourceOfToken(token) === 'extends';
   }
 }

--- a/src/stages/main/patchers/RangePatcher.js
+++ b/src/stages/main/patchers/RangePatcher.js
@@ -1,3 +1,5 @@
+import { SourceType } from 'coffee-lex';
+
 import BinaryOpPatcher from './BinaryOpPatcher';
 
 const RANGE_HELPER =
@@ -113,5 +115,9 @@ export default class RangePatcher extends BinaryOpPatcher {
    */
   isInclusive(): boolean {
     return this.node.isInclusive;
+  }
+
+  operatorTokenPredicate(): (token: SourceToken) => boolean {
+    return (token: SourceToken) => token.type === SourceType.RANGE;
   }
 }

--- a/test/binary_operator_test.js
+++ b/test/binary_operator_test.js
@@ -306,4 +306,37 @@ describe('binary operators', () => {
       let a = b;
     `);
   });
+
+  it('handles a range literal on the RHS of a binary operator', () => {
+    check(`
+      a or [b...c]
+    `, `
+      a || __range__(b, c, false);
+      function __range__(left, right, inclusive) {
+        let range = [];
+        let ascending = left < right;
+        let end = !inclusive ? right : ascending ? right + 1 : right - 1;
+        for (let i = left; ascending ? i < end : i > end; ascending ? i++ : i--) {
+          range.push(i);
+        }
+        return range;
+      }
+    `);
+  });
+
+  it('handles an "extends" usage on the RHS of a binary operator', () => {
+    check(`
+      a or (b extends c)
+    `, `
+      a || (__extends__(b, c));
+      function __extends__(child, parent) {
+        Object.getOwnPropertyNames(parent).forEach(
+          name => child[name] = parent[name]
+        );
+        child.prototype = Object.create(parent.prototype);
+        child.__super__ = parent.prototype;
+        return child;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #1113

Most binary operations have a plain operator token in them or already handled a
custom token type as a special case, but these two cases weren't handled.