### PR TITLE
feat: enable suggestions system, update default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,26 +115,27 @@ decaffeinate could be improved, feel free to file an issue on the [issues] page.
 * `--modernize-js`: Treat the input as JavaScript and only run the
   JavaScript-to-JavaScript transforms, modifying the file(s) in-place.
 * `--literate`: Treat the input file as Literate CoffeeScript.
-* `--keep-commonjs`: Do not convert `require` and `module.exports` to `import`
-  and `export`.
-* `--force-default-export`: When converting to `export`, use a single
-  `export default` rather than trying to generate named imports where possible.
+* `--disable-suggestion-comment`: Do not include a comment with followup
+  suggestions at the top of the output file.
+* `--use-js-modules`: Convert `require` and `module.exports` to `import` and
+  `export`.
+* `--loose-js-modules`: Allow named exports when converting to JS modules.
 * `--safe-import-function-identifiers`: Comma-separated list of function names
   that may safely be in the `import`/`require` section of the file. All other
   function calls will disqualify later `require`s from being converted to
   `import`s.
-* `--prefer-const`: Use `const` when possible in output code.
+* `--prefer-let`: Use `let` instead of `const` for most variables in output
+  code.
 * `--loose`: Enable all `--loose...` options.
 * `--loose-default-params`: Convert CS default params to JS default params.
 * `--loose-for-expressions`: Do not wrap expression loop targets in `Array.from`.
 * `--loose-for-of`: Do not wrap JS `for...of` loop targets in `Array.from`.
 * `--loose-includes`: Do not wrap in `Array.from` when converting `in` to `includes`.
 * `--loose-comparison-negation`: Allow unsafe simplifications like `!(a > b)` to `a <= b`.
-* `--allow-invalid-constructors`: Don't error when constructors use `this`
-  before super or omit the `super` call in a subclass.
-* `--enable-babel-constructor-workaround`: Use a hacky Babel-specific workaround
-  to allow `this` before `super` in constructors. Also works when using
-  TypeScript.
+* `--disable-babel-constructor-workaround`: Never include the Babel/TypeScript
+  workaround code to allow `this` before `super` in constructors.
+* `--disallow-invalid-constructors`: Give an error when constructors use `this`
+  before `super` or omit the `super` call in a subclass.
 
 For more usage details, see the output of `decaffeinate --help`.
 

--- a/docs/correctness-issues.md
+++ b/docs/correctness-issues.md
@@ -23,7 +23,7 @@ likely aren't worth sacrificing code quality for.
 
 **decaffeinate may not be fully correct in these situations:**
 * Test cases in the CoffeeScript test suite. While the vast majority of these
-  test cases can be handed by decaffeinate, some of them exercise edge cases in
+  test cases can be handled by decaffeinate, some of them exercise edge cases in
   the language that seem to never occur in other projects.
 * Other contrived examples that do not come up in the real world.
 

--- a/docs/suggestions.md
+++ b/docs/suggestions.md
@@ -8,8 +8,10 @@ about the JavaScript produced by decaffeinate and how to clean it up without
 introducing bugs.
 
 There are two ways to use this list:
-* When running decaffeinate on a CoffeeScript file, it prints a list of
-  suggestion codes with cleanup suggestions relevant to that file.
+* After running decaffeinate, each resulting JavaScript file has a list of
+  suggestion codes with cleanup suggestions relevant to that file. You can jump
+  to the docs for these specific suggestions, since they will be most useful to
+  you.
 * If you're trying to run decaffeinate on a large codebase, it's probably a good
   idea to read all points in this list to get an understanding of what cleanup
   steps will be required.
@@ -118,6 +120,10 @@ done during the super call and make sure that it is ok for the class fields to
 not be assigned yet. In some frameworks like Backbone, the `super` call does
 significant work, and you may need to rewrite some of your code to ensure that
 method bindings and field assignments are done before they are used.
+
+If you prefer, you can run decaffeinate with
+`--disable-babel-constructor-workaround` or `--disallow-invalid-constructors` to
+avoid generating the workaround code.
 
 # DS1XX: Common cleanup tasks
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -48,12 +48,16 @@ function parseArguments(args: Array<string>): CLIOptions {
         baseOptions.literate = true;
         break;
 
-      case '--keep-commonjs':
-        baseOptions.keepCommonJS = true;
+      case '--disable-suggestion-comment':
+        baseOptions.disableSuggestionComment = true;
         break;
 
-      case '--force-default-export':
-        baseOptions.forceDefaultExport = true;
+      case '--use-js-modules':
+        baseOptions.useJSModules = true;
+        break;
+
+      case '--loose-js-modules':
+        baseOptions.looseJSModules = true;
         break;
 
       case '--safe-import-function-identifiers':
@@ -61,8 +65,16 @@ function parseArguments(args: Array<string>): CLIOptions {
         baseOptions.safeImportFunctionIdentifiers = args[i].split(',');
         break;
 
-      case '--prefer-const':
-        baseOptions.preferConst = true;
+      case '--prefer-let':
+        baseOptions.preferLet = true;
+        break;
+
+      case '--disable-babel-constructor-workaround':
+        baseOptions.disableBabelConstructorWorkaround = true;
+        break;
+
+      case '--disallow-invalid-constructors':
+        baseOptions.disallowInvalidConstructors = true;
         break;
 
       case '--loose':
@@ -71,6 +83,7 @@ function parseArguments(args: Array<string>): CLIOptions {
         baseOptions.looseForOf = true;
         baseOptions.looseIncludes = true;
         baseOptions.looseComparisonNegation = true;
+        baseOptions.looseJSModules = true;
         break;
 
       case '--loose-default-params':
@@ -93,12 +106,19 @@ function parseArguments(args: Array<string>): CLIOptions {
         baseOptions.looseComparisonNegation = true;
         break;
 
-      case '--allow-invalid-constructors':
-        baseOptions.allowInvalidConstructors = true;
+      // Legacy options that are now a no-op.
+      case '--prefer-const':
+      case '--keep-commonjs':
+      case '--enable-babel-constructor-workaround':
         break;
 
-      case '--enable-babel-constructor-workaround':
-        baseOptions.enableBabelConstructorWorkaround = true;
+      // Legacy options that are now aliases for other options.
+      case '--force-default-export':
+        baseOptions.useJSModules = true;
+        break;
+
+      case '--allow-invalid-constructors':
+        baseOptions.disableBabelConstructorWorkaround = true;
         break;
 
       default:
@@ -231,14 +251,16 @@ function usage() {
   console.log('                           JavaScript-to-JavaScript transforms, modifying the file(s)');
   console.log('                           in-place.');
   console.log('  --literate               Treat the input file as Literate CoffeeScript.');
-  console.log('  --keep-commonjs          Do not convert require and module.exports to import and export.');
-  console.log('  --force-default-export   When converting to export, use a single "export default" rather ');
-  console.log('                           than trying to generate named imports where possible.');
+  console.log('  --disable-suggestion-comment');
+  console.log('                           Do not include a comment with followup suggestions at the');
+  console.log('                           top of the output file.');
+  console.log('  --use-js-modules         Convert require and module.exports to import and export.');
+  console.log('  --loose-js-modules       Allow named exports when converting to JS modules.');
   console.log('  --safe-import-function-identifiers');
   console.log('                           Comma-separated list of function names that may safely be in the ');
   console.log('                           import/require section of the file. All other function calls ');
   console.log('                           will disqualify later requires from being converted to imports.');
-  console.log('  --prefer-const           Use the const keyword for variables when possible.');
+  console.log('  --prefer-let             Use let instead of const for most variables in output code.');
   console.log('  --loose                  Enable all --loose... options.');
   console.log('  --loose-default-params   Convert CS default params to JS default params.');
   console.log('  --loose-for-expressions  Do not wrap expression loop targets in Array.from.');
@@ -246,12 +268,12 @@ function usage() {
   console.log('  --loose-includes         Do not wrap in Array.from when converting in to includes.');
   console.log('  --loose-comparison-negation');
   console.log('                           Allow unsafe simplifications like `!(a > b)` to `a <= b`.');
-  console.log('  --allow-invalid-constructors');
-  console.log('                           Don\'t error when constructors use this before super or omit');
-  console.log('                           the super call in a subclass.');
-  console.log('  --enable-babel-constructor-workaround');
-  console.log('                           Use a hacky Babel-specific workaround to allow this before');
-  console.log('                           super in constructors. Also works when using TypeScript.');
+  console.log('  --disable-babel-constructor-workaround');
+  console.log('                           Never include the Babel/TypeScript workaround code to allow');
+  console.log('                           this before super in constructors.');
+  console.log('  --disallow-invalid-constructors');
+  console.log('                           Give an error when constructors use this before super or');
+  console.log('                           omit the super call in a subclass.');
   console.log();
   console.log('EXAMPLES');
   console.log();

--- a/src/index.js
+++ b/src/index.js
@@ -26,36 +26,36 @@ export type Options = {
   filename: ?string,
   runToStage: ?string,
   literate: ?boolean,
-  disableSuggestions: ?boolean,
-  keepCommonJS: ?boolean,
-  forceDefaultExport: ?boolean,
+  disableSuggestionComment: ?boolean,
+  useJSModules: ?boolean,
+  looseJSModules: ?boolean,
   safeImportFunctionIdentifiers: ?Array<string>,
-  preferConst: ?boolean,
+  preferLet: ?boolean,
   looseDefaultParams: ?boolean,
   looseForExpressions: ?boolean,
   looseForOf: ?boolean,
   looseIncludes: ?boolean,
   looseComparisonNegation: ?boolean,
-  allowInvalidConstructors: ?boolean,
-  enableBabelConstructorWorkaround: ?boolean,
+  disableBabelConstructorWorkaround: ?boolean,
+  disallowInvalidConstructors: ?boolean,
 };
 
 const DEFAULT_OPTIONS = {
   filename: 'input.coffee',
   runToStage: null,
   literate: false,
-  disableSuggestions: true,
-  keepCommonJS: false,
-  forceDefaultExport: false,
+  disableSuggestionComment: false,
+  useJSModules: false,
+  looseJSModules: false,
   safeImportFunctionIdentifiers: [],
-  preferConst: false,
+  preferLet: false,
   looseDefaultParams: false,
   looseForExpressions: false,
   looseForOf: false,
   looseIncludes: false,
   looseComparisonNegation: false,
-  allowInvalidConstructors: false,
-  enableBabelConstructorWorkaround: false,
+  disableBabelConstructorWorkaround: false,
+  disallowInvalidConstructors: false,
 };
 
 type ConversionResult = {
@@ -103,7 +103,7 @@ export function convert(source: string, options: ?Options={}): ConversionResult 
     }
   }
   let result = runStages(source, options, stages);
-  if (!options.disableSuggestions) {
+  if (!options.disableSuggestionComment) {
     result.code = prependSuggestionComment(result.code, result.suggestions);
   }
   result.code = convertNewlines(result.code, originalNewlineStr);

--- a/src/stages/main/patchers/ClassBlockPatcher.js
+++ b/src/stages/main/patchers/ClassBlockPatcher.js
@@ -62,11 +62,11 @@ export default class ClassBlockPatcher extends BlockPatcher {
   }
 
   shouldAllowInvalidConstructors() {
-    return this.options.allowInvalidConstructors || this.options.enableBabelConstructorWorkaround;
+    return !this.options.disallowInvalidConstructors;
   }
 
   shouldEnableBabelWorkaround() {
-    let shouldEnable = this.options.enableBabelConstructorWorkaround;
+    let shouldEnable = !this.options.disableBabelConstructorWorkaround;
     if (shouldEnable) {
       this.addSuggestion(REMOVE_BABEL_WORKAROUND);
     }

--- a/src/stages/main/patchers/ConstructorPatcher.js
+++ b/src/stages/main/patchers/ConstructorPatcher.js
@@ -58,8 +58,7 @@ export default class ConstructorPatcher extends ObjectBodyMemberPatcher {
    * call or uses `this` before `super`.
    */
   checkForConstructorErrors() {
-    if (this.options.allowInvalidConstructors ||
-        this.options.enableBabelConstructorWorkaround) {
+    if (!this.options.disallowInvalidConstructors) {
       return;
     }
 
@@ -70,7 +69,7 @@ export default class ConstructorPatcher extends ObjectBodyMemberPatcher {
   }
 
   shouldAddBabelWorkaround(): boolean {
-    let shouldEnable = this.options.enableBabelConstructorWorkaround &&
+    let shouldEnable = !this.options.disableBabelConstructorWorkaround &&
       this.getInvalidConstructorMessage() !== null;
     if (shouldEnable) {
       this.addSuggestion(REMOVE_BABEL_WORKAROUND);

--- a/src/utils/babelConstructorWorkaroundLines.ts
+++ b/src/utils/babelConstructorWorkaroundLines.ts
@@ -1,26 +1,27 @@
 /**
  * A code snippet that can be placed at the top of a constructor to allow the
- * constructor to use `this` before `super`, at least when run through babel.
+ * constructor to use `this` before `super`, at least when run through Babel or
+ * TypeScript.
  *
  * This makes use of two techniques:
- * - babel does a static analysis check to make sure that all `this` accesses
+ * - Babel does a static analysis check to make sure that all `this` accesses
  *   at least have a chance of happening after the first `super` call. We can
  *   wrap a super call in an `if (false)` at the top to silence this check
  *   without changing the runtime behavior (and later super calls will still
  *   work).
- * - babel compiles `this` usages in constructors to a separate variable,
+ * - Babel compiles `this` usages in constructors to a separate variable,
  *   usually called `_this`, which gets assigned in the `super` line. However,
  *   the assignment to `_this` only happens when `super` actually runs, so it
  *   will normally be undefined before the `super` call. We can make `_this`
  *   resolve to `this` before the constructor by running `eval('_this = this;')`
- *   to escape babel's rewriting. However, the variable is not always called
+ *   to escape Babel's rewriting. However, the variable is not always called
  *   `_this`. We can still get the right variable name, though, but making an
  *   arrow function using `this`, calling `toString`, and parsing the variable
  *   name from it.
  */
 export default [
   '{',
-  '  // Hack: trick babel into allowing this before super.',
+  '  // Hack: trick Babel/TypeScript into allowing this before super.',
   '  if (false) { super(); }',
   '  let thisFn = (() => { this }).toString();',
   "  let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();",

--- a/src/utils/getInvalidConstructorErrorMessage.ts
+++ b/src/utils/getInvalidConstructorErrorMessage.ts
@@ -11,15 +11,7 @@ export default function getInvalidConstructorErrorMessage(firstSentence: string)
     * Constructors in subclasses that omit the \`super\` call.
     * Subclasses that use \`=>\` method syntax to automatically bind methods.
     
-    To convert these cases to JavaScript anyway, run decaffeinate with
-    --allow-invalid-constructors. You will then need to fix these cases after the
-    conversion to JavaScript. Alternatively, you may want to first edit your
-    CoffeeScript code to avoid the above cases, so that decaffeinate can run without
-    this error message.
-    
-    If you are using Babel or TypeScript, you can run decaffeinate with
-    --enable-babel-constructor-workaround to generate Babel-specific code to allow
-    constructors that don't call \`super\`. Note that this approach is fragile and
-    may break in future versions of Babel/TypeScript.
+    To convert these cases to JavaScript anyway, remove the option
+    --disallow-invalid-constructors when running decaffeinate.
   `);
 }

--- a/test/class_test.js
+++ b/test/class_test.js
@@ -80,8 +80,7 @@ describe('classes', () => {
       });
     `, {
       options: {
-        allowInvalidConstructors: true,
-        enableBabelConstructorWorkaround: false,
+        disableBabelConstructorWorkaround: true,
       }
     });
   });
@@ -178,13 +177,17 @@ describe('classes', () => {
       `);
     });
 
-    it('errors by default when using this before super in a constructor', () => {
+    it('errors when specified when using this before super in a constructor', () => {
       assertError(`
         class A extends B
           constructor: ->
             @a = 2
             super
-      `, 'Cannot automatically convert a subclass with a constructor that uses `this` before `super`.');
+      `,
+        'Cannot automatically convert a subclass with a constructor that uses `this` before `super`.',
+        {
+          disallowInvalidConstructors: true,
+        });
     });
 
     it('does not error when using `this` in a function before `super` in a constructor', () => {
@@ -205,23 +208,31 @@ describe('classes', () => {
       `);
     });
 
-    it('errors by default when a subclass constructor omits super', () => {
+    it('errors when specified when a subclass constructor omits super', () => {
       assertError(`
         class A extends B
           constructor: ->
             @a = 2
-      `, 'Cannot automatically convert a subclass with a constructor that does not call super.');
+      `,
+        'Cannot automatically convert a subclass with a constructor that does not call super.',
+        {
+          disallowInvalidConstructors: true,
+        });
     });
 
-    it('errors by default when a subclass uses a bound method', () => {
+    it('errors when specified when a subclass uses a bound method', () => {
       assertError(`
       class A extends B
         a: =>
           1
-    `, 'Cannot automatically convert a subclass that uses bound methods.');
+    `,
+        'Cannot automatically convert a subclass that uses bound methods.',
+        {
+          disallowInvalidConstructors: true,
+        });
     });
 
-    it('errors by default with an existing constructor and bound methods in a subclass', () => {
+    it('errors when specified with an existing constructor and bound methods in a subclass', () => {
       assertError(`
       class A extends B
         a: =>
@@ -230,10 +241,14 @@ describe('classes', () => {
         constructor: ->
           super()
           this.b = 2;
-    `, 'Cannot automatically convert a subclass that uses bound methods.');
+    `,
+        'Cannot automatically convert a subclass that uses bound methods.',
+        {
+          disallowInvalidConstructors: true,
+        });
     });
 
-    it('does not error when specified when using this before super in a constructor', () => {
+    it('disables the babel workaround when using this before super in a constructor', () => {
       check(`
         class A extends B
           constructor: ->
@@ -248,13 +263,12 @@ describe('classes', () => {
         }
       `, {
         options: {
-          allowInvalidConstructors: true,
-          enableBabelConstructorWorkaround: false,
+          disableBabelConstructorWorkaround: true,
         }
       });
     });
 
-    it('does not error when specified when a subclass constructor omits super', () => {
+    it('disables the babel workaround when a subclass constructor omits super', () => {
       check(`
         class A extends B
           constructor: ->
@@ -267,8 +281,7 @@ describe('classes', () => {
         }
       `, {
         options: {
-          allowInvalidConstructors: true,
-          enableBabelConstructorWorkaround: false,
+          disableBabelConstructorWorkaround: true,
         }
       });
     });
@@ -291,8 +304,7 @@ describe('classes', () => {
       }
     `, {
         options: {
-          allowInvalidConstructors: true,
-          enableBabelConstructorWorkaround: false,
+          disableBabelConstructorWorkaround: true,
         }
       });
     });
@@ -320,13 +332,12 @@ describe('classes', () => {
       }
     `, {
         options: {
-          allowInvalidConstructors: true,
-          enableBabelConstructorWorkaround: false,
+          disableBabelConstructorWorkaround: true,
         }
       });
     });
 
-    it('generates workaround code when specified when using this before super in a constructor', () => {
+    it('generates workaround code when using this before super in a constructor', () => {
       check(`
         class A extends B
           constructor: ->
@@ -336,7 +347,7 @@ describe('classes', () => {
         class A extends B {
           constructor() {
             {
-              // Hack: trick babel into allowing this before super.
+              // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
               let thisFn = (() => { this; }).toString();
               let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
@@ -346,14 +357,10 @@ describe('classes', () => {
             super(...arguments);
           }
         }
-      `, {
-        options: {
-          enableBabelConstructorWorkaround: true
-        }
-      });
+      `);
     });
 
-    it('generates workaround code when specified when a subclass constructor omits super', () => {
+    it('generates workaround code when a subclass constructor omits super', () => {
       check(`
         class A extends B
           constructor: ->
@@ -362,7 +369,7 @@ describe('classes', () => {
         class A extends B {
           constructor() {
             {
-              // Hack: trick babel into allowing this before super.
+              // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
               let thisFn = (() => { this; }).toString();
               let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
@@ -371,14 +378,10 @@ describe('classes', () => {
             this.a = 2;
           }
         }
-      `, {
-        options: {
-          enableBabelConstructorWorkaround: true
-        }
-      });
+      `);
     });
 
-    it('generates workaround code when specified when a subclass has a bound method and no constructor', () => {
+    it('generates workaround code when a subclass has a bound method and no constructor', () => {
       check(`
         class A extends B
           foo: =>
@@ -387,7 +390,7 @@ describe('classes', () => {
         class A extends B {
           constructor(...args) {
             {
-              // Hack: trick babel into allowing this before super.
+              // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
               let thisFn = (() => { this; }).toString();
               let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
@@ -401,14 +404,10 @@ describe('classes', () => {
             return null;
           }
         }
-      `, {
-        options: {
-          enableBabelConstructorWorkaround: true
-        }
-      });
+      `);
     });
 
-    it('generates workaround code when specified when a subclass has a bound method and a normal constructor', () => {
+    it('generates workaround code when a subclass has a bound method and a normal constructor', () => {
       check(`
         class A extends B
           constructor: ->
@@ -421,7 +420,7 @@ describe('classes', () => {
         class A extends B {
           constructor() {
             {
-              // Hack: trick babel into allowing this before super.
+              // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
               let thisFn = (() => { this; }).toString();
               let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
@@ -436,14 +435,10 @@ describe('classes', () => {
             return null;
           }
         }
-      `, {
-        options: {
-          enableBabelConstructorWorkaround: true
-        }
-      });
+      `);
     });
 
-    it('generates workaround code when specified when a subclass has a bound method and an empty constructor', () => {
+    it('generates workaround code when a subclass has a bound method and an empty constructor', () => {
       check(`
         class A extends B
           constructor: ->
@@ -454,7 +449,7 @@ describe('classes', () => {
         class A extends B {
           constructor() {
             {
-              // Hack: trick babel into allowing this before super.
+              // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
               let thisFn = (() => { this; }).toString();
               let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
@@ -467,14 +462,10 @@ describe('classes', () => {
             return null;
           }
         }
-      `, {
-        options: {
-          enableBabelConstructorWorkaround: true
-        }
-      });
+      `);
     });
 
-    it('does not generate workaround code when the flag is set but the workaround is unnecessary', () => {
+    it('does not generate workaround code when the workaround is unnecessary', () => {
       check(`
         class A extends B
           constructor: ->
@@ -487,11 +478,7 @@ describe('classes', () => {
             this.x = 3;
           }
         }
-      `, {
-        options: {
-          enableBabelConstructorWorkaround: true
-        }
-      });
+      `);
     });
 
     it('properly generates workaround code when constructors have default parameters', () => {
@@ -504,7 +491,7 @@ describe('classes', () => {
         class A extends B {
           constructor(c) {
             {
-              // Hack: trick babel into allowing this before super.
+              // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
               let thisFn = (() => { this; }).toString();
               let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
@@ -515,11 +502,7 @@ describe('classes', () => {
             super(...arguments);
           }
         }
-      `, {
-        options: {
-          enableBabelConstructorWorkaround: true
-        }
-      });
+      `);
     });
 
     it('chooses variables that do not conflict', () => {
@@ -624,8 +607,7 @@ describe('classes', () => {
       }
     `, {
       options: {
-        allowInvalidConstructors: true,
-        enableBabelConstructorWorkaround: false,
+        disableBabelConstructorWorkaround: true,
       }
     });
   });
@@ -641,8 +623,7 @@ describe('classes', () => {
       }
     `, {
       options: {
-        allowInvalidConstructors: true,
-        enableBabelConstructorWorkaround: false,
+        disableBabelConstructorWorkaround: true,
       }
     });
   });
@@ -1026,8 +1007,7 @@ describe('classes', () => {
       }
     `, {
       options: {
-        allowInvalidConstructors: true,
-        enableBabelConstructorWorkaround: false,
+        disableBabelConstructorWorkaround: true,
       }
     });
   });
@@ -1094,8 +1074,7 @@ describe('classes', () => {
       }
     `, {
       options: {
-        allowInvalidConstructors: true,
-        enableBabelConstructorWorkaround: false,
+        disableBabelConstructorWorkaround: true,
       }
     });
   });

--- a/test/declaration_test.js
+++ b/test/declaration_test.js
@@ -148,10 +148,10 @@ describe('declarations', () => {
     `);
   });
 
-  it('uses const rather than let if specified', () => {
-    check('a = 1', 'const a = 1;', {
+  it('uses let rather than const if specified', () => {
+    check('a = 1', 'let a = 1;', {
       options: {
-        preferConst: true
+        preferLet: true
       }
     });
   });

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -1,7 +1,7 @@
 import check from './support/check';
 
 describe('imports', () => {
-  it('converts commonjs code to JS modules by default', () => {
+  it('converts commonjs code to JS modules with named exports when specified', () => {
     check(`
       x = require('x');
       module.exports.y = 3;
@@ -10,23 +10,20 @@ describe('imports', () => {
       export let y = 3;
     `, {
       options: {
-        keepCommonJS: false,
+        useJSModules: true,
+        looseJSModules: true,
       },
     });
   });
 
-  it('keeps commonjs when the preference is specified', () => {
+  it('keeps commonjs by default', () => {
     check(`
       x = require('x');
       module.exports.y = 3;
     `, `
       const x = require('x');
       module.exports.y = 3;
-    `, {
-      options: {
-        keepCommonJS: true,
-      },
-    });
+    `);
   });
 
   it('properly passes down function identifiers', () => {
@@ -44,13 +41,13 @@ describe('imports', () => {
       const z = require('z');
     `, {
       options: {
-        keepCommonJS: false,
+        useJSModules: true,
         safeImportFunctionIdentifiers: ['foo'],
       },
     });
   });
 
-  it('allows forcing a default export', () => {
+  it('forces a default export by default', () => {
     check(`
       exports.a = b;
       exports.c = d;
@@ -61,8 +58,7 @@ describe('imports', () => {
       export default defaultExport;
     `, {
       options: {
-        keepCommonJS: false,
-        forceDefaultExport: true,
+        useJSModules: true,
       },
     });
   });

--- a/test/suggestions_test.js
+++ b/test/suggestions_test.js
@@ -16,7 +16,7 @@ describe('suggestions', () => {
       class A extends B {
         constructor(...args) {
           {
-            // Hack: trick babel into allowing this before super.
+            // Hack: trick Babel/TypeScript into allowing this before super.
             if (false) { super(); }
             let thisFn = (() => { this; }).toString();
             let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
@@ -32,8 +32,7 @@ describe('suggestions', () => {
       }
     `, {
       options: {
-        enableBabelConstructorWorkaround: true,
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -45,7 +44,7 @@ describe('suggestions', () => {
       const x = 1;
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -67,7 +66,7 @@ describe('suggestions', () => {
       class A extends B {
         constructor(c) {
           {
-            // Hack: trick babel into allowing this before super.
+            // Hack: trick Babel/TypeScript into allowing this before super.
             if (false) { super(); }
             let thisFn = (() => { this; }).toString();
             let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
@@ -80,7 +79,7 @@ describe('suggestions', () => {
       class E extends F {
         constructor(g) {
           {
-            // Hack: trick babel into allowing this before super.
+            // Hack: trick Babel/TypeScript into allowing this before super.
             if (false) { super(); }
             let thisFn = (() => { this; }).toString();
             let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
@@ -92,8 +91,7 @@ describe('suggestions', () => {
       }
     `, {
       options: {
-        disableSuggestions: false,
-        enableBabelConstructorWorkaround: true,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -113,7 +111,7 @@ describe('suggestions', () => {
       }
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -128,7 +126,7 @@ describe('suggestions', () => {
       }
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -145,7 +143,7 @@ describe('suggestions', () => {
       Array.from(b).includes(a);
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -163,7 +161,7 @@ describe('suggestions', () => {
       () => f();
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -179,7 +177,7 @@ describe('suggestions', () => {
       });
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -193,7 +191,7 @@ describe('suggestions', () => {
       values = values.map(val => val + 1);
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -213,7 +211,7 @@ describe('suggestions', () => {
       }
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -232,7 +230,7 @@ describe('suggestions', () => {
       }
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -250,7 +248,7 @@ describe('suggestions', () => {
       accounts[name = getAccountId()] = Math.floor(accounts[name] / splitFactor);
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -262,7 +260,7 @@ describe('suggestions', () => {
       accounts[accountId] = Math.floor(accounts[accountId] / splitFactor);
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -279,7 +277,7 @@ describe('suggestions', () => {
       const array = d.a, b = array[0], c = array[array.length - 1];
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -291,7 +289,7 @@ describe('suggestions', () => {
       const {a: {b: c}} = d;
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -311,7 +309,7 @@ describe('suggestions', () => {
       }
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -326,7 +324,7 @@ describe('suggestions', () => {
       }
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -346,7 +344,7 @@ describe('suggestions', () => {
       }
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -366,7 +364,7 @@ describe('suggestions', () => {
       (needle = a(), Array.from(b()).includes(needle));
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -383,7 +381,7 @@ describe('suggestions', () => {
       Array.from(b).includes(a);
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -407,7 +405,7 @@ describe('suggestions', () => {
       } })();
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -434,7 +432,7 @@ describe('suggestions', () => {
       });
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -457,7 +455,7 @@ describe('suggestions', () => {
       A.initClass();
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -472,7 +470,7 @@ describe('suggestions', () => {
       }
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -491,7 +489,7 @@ describe('suggestions', () => {
       const x = a != null ? a : b;
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -510,7 +508,7 @@ describe('suggestions', () => {
       const b = (a != null);
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -527,7 +525,7 @@ describe('suggestions', () => {
       this;
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -547,7 +545,7 @@ describe('suggestions', () => {
       };
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -562,7 +560,7 @@ describe('suggestions', () => {
       });
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -577,7 +575,7 @@ describe('suggestions', () => {
       }
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -597,7 +595,7 @@ describe('suggestions', () => {
       }
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });
@@ -618,7 +616,7 @@ describe('suggestions', () => {
       }
     `, {
       options: {
-        disableSuggestions: false,
+        disableSuggestionComment: false,
       },
     });
   });

--- a/test/support/check.js
+++ b/test/support/check.js
@@ -9,10 +9,7 @@ export default function check(source, expected, {options={}}={}) {
 
   try {
     let converted = convert(source, Object.assign({
-      preferConst: true,
-      keepCommonJS: true,
-      enableBabelConstructorWorkaround: true,
-      disableSuggestions: true,
+      disableSuggestionComment: true,
     }, options));
     strictEqual(converted.code, expected);
   } catch (err) {

--- a/test/support/validate.js
+++ b/test/support/validate.js
@@ -54,11 +54,7 @@ function runCodeAndExtract(source: string) {
 
 function runValidation(source: string, expectedOutput: ?any) {
   let coffeeES5 = compile(source, { bare: true });
-  let decaffeinateES6 = convert(source, {
-    preferConst: true,
-    keepCommonJS: true,
-    enableBabelConstructorWorkaround: true,
-  }).code;
+  let decaffeinateES6 = convert(source).code;
   let decaffeinateES5 = babel.transform(decaffeinateES6, { presets: ['es2015'] }).code;
 
   let coffeeOutput = runCodeAndExtract(coffeeES5);


### PR DESCRIPTION
Fixes #1107

Implement several defaults changes as described in #1107. This involved updating
the options structure, the CLI code, the docs, and the tests. This also includes
various other little cleanups to the docs and generated code to better match the
new system.

Also rename `disableSuggestions` to `disableSuggestionComment`, since maybe in
the future there will be a different way of displaying suggestions.

BREAKING CHANGE:

JavaScript files produced by decaffeinate now have a comment at the top of the
file with suggestions on cleanup steps. The new `--disable-suggestion-comment`
flag disables this behavior.

decaffeinate now prefers `const` for variables when possible. The
`--prefer-const` option is now a no-op, and a new `--prefer-let` option opts
into the old behavior.

decaffeinate no longer tries to convert code to JS modules by default. There are
three configurations to choose from:
* To keep code as CommonJS (or whatever the original code was using), specify no
  options. Previously, this was the `--keep-commonjs` option.
* To convert code to JS modules in a way that always generates a default export
  for correctness reasons, specify `--use-js-modules`. Previously, this was the
  `--force-default-export` option.
* To convert code to JS modules and use named exports on a best-effort basis,
  specify `--use-js-modules --loose-js-modules`. Previously, this was the
  default option.

decaffeinate now automatically inserts a code snippet at the top of constructors
using `this` before `super`, which allows them to behave as expected, but only
when using Babel or TypeScript under certain configurations. There are three
configurations to choose from:
* To insert the Babel/TypeScript workaround code snippet when necessary, specify
  no options. Previously, this was the `--enable-babel-constructor-workaround`
  option.
* To produce code that uses `this` before `super` (which is well-formed but
  crashes at runtime), specify `--disable-babel-constructor-workaround`.
  Previously, this was the `--allow-invalid-constructors` option.
* To make decaffeinate give an error when code would use `this` before `super`,
  specify `--disallow-invalid-constructors`. Previously, this was the default
  behavior.