### PR TITLE
test: increase string integration test timeout

### DIFF
--- a/test/string_integration_test.ts
+++ b/test/string_integration_test.ts
@@ -37,7 +37,7 @@ setResult(runTest())`);
 }
 
 describe('string integration', function(): void {
-  this.timeout(60000);
+  this.timeout(180000);
   let strings = ['', '   ', 'word', '   leading indent', 'trailing indent   ',
                  '    leading and trailing indent    '];
   let quotes = [


### PR DESCRIPTION
These still run fairly fast on my machine, but seem to be super-slow on CI
recently, so just increase the timeout so the builds pass. Hopefully just a
travis issue that will fix itself.