### PR TITLE
fix: update to the latest decaffeinate-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babylon": "7.0.0-beta.16",
     "coffee-lex": "^8.0.0",
     "decaffeinate-coffeescript": "1.10.0-patch26",
-    "decaffeinate-parser": "^18.0.0",
+    "decaffeinate-parser": "^19.0.0",
     "detect-indent": "^4.0.0",
     "esnext": "^3.2.0",
     "lines-and-columns": "^1.1.5",

--- a/src/patchers/NodePatcher.ts
+++ b/src/patchers/NodePatcher.ts
@@ -111,8 +111,8 @@ export default class NodePatcher {
      *   console.log(a + b)
      *               ^    ^
      */
-    this.contentStart = node.range[0];
-    this.contentEnd = node.range[1];
+    this.contentStart = node.start;
+    this.contentEnd = node.end;
 
     if (this.shouldTrimContentRange()) {
       this.trimContentRange();

--- a/src/stages/main/patchers/AssignOpPatcher.ts
+++ b/src/stages/main/patchers/AssignOpPatcher.ts
@@ -225,7 +225,7 @@ export default class AssignOpPatcher extends NodePatcher {
       for (let member of patcher.members) {
         if (member instanceof ObjectInitialiserMemberPatcher) {
           let valueCode = `${ref}${this.accessFieldForObjectDestructure(member.key)}`;
-          assignments.push(...this.generateAssignments(member.expression, valueCode, false));
+          assignments.push(...this.generateAssignments(member.expression || member.key, valueCode, false));
         } else if (member instanceof AssignOpPatcher) {
           // Assignments like {a = b} = c end up as an assign op.
           let valueCode = `${ref}${this.accessFieldForObjectDestructure(member.assignee)}`;

--- a/src/stages/main/patchers/ClassAssignOpPatcher.ts
+++ b/src/stages/main/patchers/ClassAssignOpPatcher.ts
@@ -90,6 +90,9 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
    * @protected
    */
   patchAsProperty(): void {
+    if (!this.expression) {
+      throw this.error('Expected value expression for class assign op.');
+    }
     // `name: null` → `name = null`
     //      ^^             ^^^
     let colonIndex = this.indexOfSourceTokenBetweenPatchersMatching(
@@ -146,6 +149,9 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
   }
 
   isBoundInstanceMethod(): boolean {
+    if (!this.expression) {
+      throw this.error('Expected value expression for class assign op.');
+    }
     return (
       !this.isStaticMethod() &&
       (this.expression.node.type === 'BoundFunction' ||

--- a/src/stages/main/patchers/ObjectInitialiserMemberPatcher.ts
+++ b/src/stages/main/patchers/ObjectInitialiserMemberPatcher.ts
@@ -7,8 +7,17 @@ import ThisPatcher from './ThisPatcher';
  * Handles object properties.
  */
 export default class ObjectInitialiserMemberPatcher extends ObjectBodyMemberPatcher {
+  setAssignee(): void {
+    if (this.expression === null) {
+      this.key.setAssignee();
+    } else {
+      this.expression.setAssignee();
+    }
+    super.setAssignee();
+  }
+
   patchAsProperty(): void {
-    if (this.key.node === this.expression.node) {
+    if (this.expression === null) {
       this.patchAsShorthand({
         expand: this.key.node.type !== 'Identifier'
       });

--- a/src/stages/main/patchers/ObjectInitialiserPatcher.ts
+++ b/src/stages/main/patchers/ObjectInitialiserPatcher.ts
@@ -29,7 +29,7 @@ export default class ObjectInitialiserPatcher extends NodePatcher {
   }
 
   setAssignee(): void {
-    this.members.forEach(member => member.expression.setAssignee());
+    this.members.forEach(member => member.setAssignee());
     super.setAssignee();
   }
 

--- a/src/stages/normalize/patchers/MemberAccessOpPatcher.ts
+++ b/src/stages/normalize/patchers/MemberAccessOpPatcher.ts
@@ -4,7 +4,6 @@ import PassthroughPatcher from '../../../patchers/PassthroughPatcher';
 import { PatcherContext } from '../../../patchers/types';
 import DefaultParamPatcher from './DefaultParamPatcher';
 import IdentifierPatcher from './IdentifierPatcher';
-import ObjectInitialiserMemberPatcher from './ObjectInitialiserMemberPatcher';
 
 export default class MemberAccessOpPatcher extends PassthroughPatcher {
   node: MemberAccessOp;
@@ -41,10 +40,6 @@ export default class MemberAccessOpPatcher extends PassthroughPatcher {
       // destructure (e.g. the logical `a` key in `({@a}) ->`).
       if (patcher.parent instanceof DefaultParamPatcher &&
           patcher.parent.value === patcher) {
-        break;
-      }
-      if (patcher.parent instanceof ObjectInitialiserMemberPatcher &&
-          patcher.parent.key === patcher) {
         break;
       }
       patcher = patcher.parent;

--- a/src/stages/normalize/patchers/ObjectInitialiserMemberPatcher.ts
+++ b/src/stages/normalize/patchers/ObjectInitialiserMemberPatcher.ts
@@ -4,7 +4,7 @@ import { PatcherContext } from '../../../patchers/types';
 
 export default class ObjectInitialiserMemberPatcher extends PassthroughPatcher {
   key: NodePatcher;
-  expression: NodePatcher;
+  expression: NodePatcher | null;
 
   constructor(patcherContext: PatcherContext, key: NodePatcher, expression: NodePatcher) {
     super(patcherContext, key, expression);

--- a/src/utils/blockStartsWithObjectInitialiser.ts
+++ b/src/utils/blockStartsWithObjectInitialiser.ts
@@ -18,7 +18,7 @@ export default function blockStartsWithObjectInitialiser(patcher: NodePatcher): 
       // Already found.
       return false;
     }
-    if (child.type === 'ObjectInitialiser' && child.range[0] === statement.contentStart) {
+    if (child.type === 'ObjectInitialiser' && child.start === statement.contentStart) {
       foundInitialObject = true;
       return false;
     }

--- a/src/utils/canPatchAssigneeToJavaScript.ts
+++ b/src/utils/canPatchAssigneeToJavaScript.ts
@@ -54,7 +54,7 @@ export default function canPatchAssigneeToJavaScript(node: Node, isTopLevel: boo
     return node.members.every(node => canPatchAssigneeToJavaScript(node, false));
   }
   if (node instanceof ObjectInitialiserMember) {
-    return canPatchAssigneeToJavaScript(node.expression, false);
+    return canPatchAssigneeToJavaScript(node.expression || node.key, false);
   }
   return false;
 }

--- a/src/utils/formatDecaffeinateParserAst.ts
+++ b/src/utils/formatDecaffeinateParserAst.ts
@@ -12,7 +12,7 @@ function formatAstNodeLines(node: Node, context: DecaffeinateContext): Array<str
   let propLines = [];
   let childPropNames = childPropertyNames(node);
   let blacklistedProps = childPropNames.concat(
-    ['raw', 'line', 'column', 'type', 'range', 'scope', 'context', 'start', 'end']
+    ['raw', 'line', 'column', 'type', 'parentNode', 'context', 'start', 'end']
   );
   for (let key of Object.keys(node)) {
     if (blacklistedProps.indexOf(key) !== -1) {
@@ -45,7 +45,7 @@ function formatAstNodeLines(node: Node, context: DecaffeinateContext): Array<str
       propLines.push(...childLines);
     }
   }
-  let rangeStr = formatRange(node.range[0], node.range[1], context);
+  let rangeStr = formatRange(node.start, node.end, context);
   return [
     `${node.type} ${rangeStr} {`,
     ...propLines.map(s => '  ' + s),

--- a/src/utils/getAssigneeBindings.ts
+++ b/src/utils/getAssigneeBindings.ts
@@ -20,7 +20,7 @@ export default function getAssigneeBindings(node: Node): Array<string> {
     }
     return bindings;
   } else if (node instanceof ObjectInitialiserMember) {
-    return getAssigneeBindings(node.expression);
+    return getAssigneeBindings(node.expression || node.key);
   } else if (node instanceof AssignOp) {
     return getAssigneeBindings(node.assignee);
   } else if (node instanceof Spread || node instanceof Rest) {

--- a/src/utils/leftHandIdentifiers.ts
+++ b/src/utils/leftHandIdentifiers.ts
@@ -1,4 +1,6 @@
-import { ArrayInitialiser, Identifier, Node, ObjectInitialiser } from 'decaffeinate-parser/dist/nodes';
+import {
+  ArrayInitialiser, Identifier, Node, ObjectInitialiser, ObjectInitialiserMember
+} from 'decaffeinate-parser/dist/nodes';
 import flatMap from './flatMap';
 
 /**
@@ -17,7 +19,13 @@ export default function leftHandIdentifiers(node: Node): Array<Identifier> {
   } else if (node instanceof ArrayInitialiser) {
     return flatMap(node.members, leftHandIdentifiers);
   } else if (node instanceof ObjectInitialiser) {
-    return flatMap(node.members, member => leftHandIdentifiers(member.expression));
+    return flatMap(node.members, member => {
+      if (member instanceof ObjectInitialiserMember) {
+        return leftHandIdentifiers(member.expression || member.key);
+      } else {
+        return leftHandIdentifiers(member.assignee);
+      }
+    });
   } else {
     return [];
   }

--- a/src/utils/normalizeListItem.ts
+++ b/src/utils/normalizeListItem.ts
@@ -89,7 +89,7 @@ function patcherEndsInStatement(patcher: NodePatcher): boolean {
     if (found) {
       return false;
     }
-    if (child.type === 'Block' && child.range[1] === patcher.contentEnd) {
+    if (child.type === 'Block' && child.end === patcher.contentEnd) {
       found = true;
     }
     return true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,7 +66,7 @@
   dependencies:
     "@types/babel-types" "*"
 
-"@types/fs-extra@4.0.0":
+"@types/fs-extra@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-4.0.0.tgz#1dd742ad5c9bce308f7a52d02ebc01421bc9102f"
   dependencies:
@@ -992,9 +992,9 @@ decaffeinate-coffeescript@1.10.0-patch26:
   version "1.10.0-patch26"
   resolved "https://registry.yarnpkg.com/decaffeinate-coffeescript/-/decaffeinate-coffeescript-1.10.0-patch26.tgz#d3f23fcb7e3d574ad38182b44ef6f62c2757fdfe"
 
-decaffeinate-parser@^18.0.0:
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/decaffeinate-parser/-/decaffeinate-parser-18.0.0.tgz#2b99ce0a96c0bc10ec3a2bd18ec2dd8ce7189a16"
+decaffeinate-parser@^19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/decaffeinate-parser/-/decaffeinate-parser-19.0.0.tgz#3ac4b713c995b33b9c052993b48c42b58c64f103"
   dependencies:
     "@types/babylon" "^6.16.1"
     "@types/json-stable-stringify" "^1.0.31"


### PR DESCRIPTION
This fixes various little API changes.

I was hoping to get rid of `traverse` and `childPropertyNames`, but I think I
actually will need the names themselves instead of just the children, which will
require a decaffeinate-parser change.

Also fix a benign bug in `leftHandIdentifiers` on destructuring assignments with
defaults.