### PR TITLE
fix: don't convert loops to filter and map when the filter has a side-effect

### DIFF
--- a/src/stages/main/patchers/ForInPatcher.ts
+++ b/src/stages/main/patchers/ForInPatcher.ts
@@ -162,6 +162,9 @@ export default class ForInPatcher extends ForPatcher {
     if (this.filter !== null && this.keyAssignee !== null) {
       return false;
     }
+    if (this.filter !== null && !this.filter.isPure()) {
+      return false;
+    }
     if (this.body.containsYield() || (this.filter && this.filter.containsYield())) {
       return false;
     }

--- a/test/for_test.ts
+++ b/test/for_test.ts
@@ -1784,4 +1784,30 @@ describe('for loops', () => {
       })(); 
     `);
   });
+
+  it('does not convert to filter and map when the condition might have a side-effect', () => {
+    check(`
+      x = for a in [1, 2, 3] when b = a - 1
+        b
+    `, `
+      const x = (() => {
+        const result = [];
+        for (let a of [1, 2, 3]) {
+          var b;
+          if ((b = a - 1)) {
+            result.push(b);
+          }
+        }
+        return result;
+      })();
+    `);
+  });
+
+  it('behaves correctly on side-effects', () => {
+    validate(`
+      setResult(for a in [1, 2, 3] when b = a - 1 then b)
+    `,
+      [1, 2]
+    );
+  });
 });


### PR DESCRIPTION
Fixes #1170

The filter and map approach runs all filter calls first and then all map calls,
so if the filter has any side-effects, we can't use filter and map, so just fall
back to the normal expression loop case.