### PR TITLE
fix: allow expanding the bounds of parenthesized function bodies

### DIFF
--- a/src/patchers/NodePatcher.ts
+++ b/src/patchers/NodePatcher.ts
@@ -992,6 +992,14 @@ export default class NodePatcher {
    * Also check if these parents are matching, to avoid false positives on things like `(a) && (b)`
    */
   isSurroundedByParentheses(): boolean {
+    // Surrounding parens will extend outer start/end beyond content start/end,
+    // so only consider parens in that case. If we didn't exit early here, we'd
+    // get false positives for nodes that start and end with parens without
+    // actually being surrounded by parens.
+    if (this.contentStart === this.outerStart && this.contentEnd === this.outerEnd) {
+      return false;
+    }
+
     let beforeToken = this.sourceTokenAtIndex(this.outerStartTokenIndex);
     let afterToken = this.sourceTokenAtIndex(this.outerEndTokenIndex);
 

--- a/test/function_test.ts
+++ b/test/function_test.ts
@@ -520,4 +520,16 @@ describe('functions', () => {
       setResult(a)
     `, 1)
   );
+
+  it('handles a default param and a parenthesized body', () =>
+    check(`
+      (a = 1) ->
+        (a)
+    `, `
+      (function(a) {
+        if (a == null) { a = 1; }
+        return (a);
+      });
+    `)
+  );
 });


### PR DESCRIPTION
Fixes #1172

Ultimately, the issue was we had a block like `(a)` where `isSurroundedByParens`
was returning true. This meant that the bounding patcher was itself, even
though the block itself wasn't really surrounded by parens, it just started and
ended with parens. To fix, we can say the node isn't surrounded by parens in
this case, which means we're allowed to insert contents before the start of the
block.