### PR TITLE
fix: remove parens surrounding inline JS expressions

### DIFF
--- a/src/stages/main/patchers/JavaScriptPatcher.ts
+++ b/src/stages/main/patchers/JavaScriptPatcher.ts
@@ -1,4 +1,5 @@
 import NodePatcher from './../../../patchers/NodePatcher';
+import FunctionApplicationPatcher from './FunctionApplicationPatcher';
 
 /**
  * Handles embedded JavaScript.
@@ -8,11 +9,23 @@ export default class JavaScriptPatcher extends NodePatcher {
    * All we have to do is strip off the backticks.
    */
   patchAsExpression(): void {
+    // For any normal surrounding parens, CoffeeScript's rule is to remove them,
+    // which allows things like comment-only inline JS. Function call parens
+    // should not be removed, though.
+    let shouldRemoveSurroundingParens =
+      !(this.parent instanceof FunctionApplicationPatcher && this === this.parent.args[0]);
+
+    if (shouldRemoveSurroundingParens) {
+      this.remove(this.outerStart, this.contentStart);
+    }
     // '`void 0`' → 'void 0`'
     //  ^
     this.remove(this.contentStart, this.contentStart + '`'.length);
     // 'void 0`' → 'void 0'
     //        ^
     this.remove(this.contentEnd - '`'.length, this.contentEnd);
+    if (shouldRemoveSurroundingParens) {
+      this.remove(this.contentEnd, this.outerEnd);
+    }
   }
 }

--- a/test/javascript_test.ts
+++ b/test/javascript_test.ts
@@ -1,4 +1,5 @@
 import check from './support/check';
+import validate from './support/validate';
 
 describe('embedded JavaScript', () => {
   it('strips the backticks off in a statement context', () => {
@@ -11,5 +12,17 @@ describe('embedded JavaScript', () => {
 
   it('allows passing JSX through', () => {
     check('-> `<MyComponent />`', '() => <MyComponent />;');
+  });
+
+  it('handles comment-only inline JS surrounded by parens', () => {
+    check('a = (`/** comment */`) b', 'const a = /** comment */(b);');
+  });
+
+  it('treats comment-only inline JS as an expression', () => {
+    check('f `/*foo*/`', 'f(/*foo*/);');
+  });
+
+  it('removes parens around inline JS even when it would cause precedence issues', () => {
+    validate('setResult(10 - (`5 + 3`))', 8);
   });
 });


### PR DESCRIPTION
Fixes #1176

It looks like CoffeeScript handles embedded JS comments by removing all parens
around inline JS, even if it causes unintuitive behavior, so we copy that
behavior.