### PR TITLE
fix: don't skip over semantic tokens when inserting new lines

### DIFF
--- a/src/patchers/NodePatcher.ts
+++ b/src/patchers/NodePatcher.ts
@@ -1240,10 +1240,12 @@ export default class NodePatcher {
   appendLineAfter(content: string, indentOffset: number=0): void {
     let boundingPatcher = this.getBoundingPatcher();
     let endOfLine = this.getEndOfLine();
-    this.insert(
-      Math.min(endOfLine, boundingPatcher.innerEnd),
-      `\n${this.getIndent(indentOffset)}${content}`
-    );
+    let nextToken = this.nextSemanticToken();
+    let insertPoint = Math.min(Math.min(endOfLine, boundingPatcher.innerEnd));
+    if (nextToken) {
+      insertPoint = Math.min(insertPoint, nextToken.start);
+    }
+    this.insert(insertPoint, `\n${this.getIndent(indentOffset)}${content}`);
   }
 
   /**

--- a/test/object_test.ts
+++ b/test/object_test.ts
@@ -513,4 +513,17 @@ describe('objects', () => {
       });
     `);
   });
+
+  it('handles an object literal ending in a semicolon', () => {
+    check(`
+      o = 
+        a: 1
+        b: 2;
+    `, `
+      const o = { 
+        a: 1,
+        b: 2
+      };
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #1178

In some cases, we would insert a close-curly-brace for an object literal ending
in a semicolon, and the curly brace would go after the semicolon, which it
should go before.