### PR TITLE
fix: don't skip parens around do expressions surrounded by parens

### DIFF
--- a/src/stages/main/patchers/DoOpPatcher.ts
+++ b/src/stages/main/patchers/DoOpPatcher.ts
@@ -26,18 +26,15 @@ export default class DoOpPatcher extends NodePatcher {
     let nextToken = notNull(this.sourceTokenAtIndex(notNull(doTokenIndex.next())));
     this.remove(doToken.start, nextToken.start);
 
-    let addParens = !this.isSurroundedByParentheses() && !(
-        this.expression instanceof IdentifierPatcher
-      );
-
+    let addParens = !(this.expression instanceof IdentifierPatcher);
     if (addParens) {
-      this.insert(this.outerStart, '(');
+      this.insert(this.contentStart, '(');
     }
 
     this.expression.patch();
 
     if (addParens) {
-      this.insert(this.outerEnd, ')');
+      this.insert(this.contentEnd, ')');
     }
 
     let args: Array<string> = [];
@@ -53,7 +50,7 @@ export default class DoOpPatcher extends NodePatcher {
         }
       });
     }
-    this.insert(this.innerEnd, `(${args.join(', ')})`);
+    this.insert(this.contentEnd, `(${args.join(', ')})`);
   }
 
   /**

--- a/test/do_test.ts
+++ b/test/do_test.ts
@@ -1,4 +1,5 @@
 import check from './support/check';
+import validate from './support/validate';
 
 describe('`do`', () => {
   it('becomes a normal call expression when not given a function expression', () => {
@@ -48,11 +49,11 @@ describe('`do`', () => {
         a = 1
         b = a) + 1
     `, `
-      (function() {
+      ((function() {
         let b;
         const a = 1;
         return b = a;
-      }()) + 1;
+      })()) + 1;
     `);
   });
 
@@ -93,5 +94,23 @@ describe('`do`', () => {
     `, `
       (!a)();
     `);
+  });
+
+  it('places the function call properly for parenthesized do expressions', () => {
+    check(`
+      (do => 1)
+    `, `
+      (() => 1)();
+    `);
+  });
+
+  it('properly handles a complex nested do use case (#1189)', () => {
+    validate(`
+      setTimeout = (f, n) -> f()
+      arr = []
+      for i in [0...5]
+        setTimeout((do (i) => => arr.push(i)), 0);
+      setResult(arr)
+    `, [0, 1, 2, 3, 4]);
   });
 });


### PR DESCRIPTION
Fixes #1189

We often can skip surrounding parens when we're already surrounded by parens,
but the parens around the do expression can't actually be skipped in that case,
since then the arguments might be applied with the wrong precedence.