### PR TITLE
fix: convert comma statement terminators to semicolons in more places

### DIFF
--- a/test/object_test.ts
+++ b/test/object_test.ts
@@ -526,4 +526,14 @@ describe('objects', () => {
       };
     `);
   });
+
+  it('handles an implicit object arg ending in a comma', () => {
+    check(`
+      a
+        b: c,
+    `, `
+      a({
+        b: c});
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #1191

Previously, we only changed commas to semicolons between statements, but we
actually want to do it after the last statement in a block as well, which avoids
some problems involving trailing commas at the end of a file.