### PR TITLE
fix: add do expression close parens at innerEnd instead of contentEnd

### DIFF
--- a/src/stages/main/patchers/DoOpPatcher.ts
+++ b/src/stages/main/patchers/DoOpPatcher.ts
@@ -34,7 +34,7 @@ export default class DoOpPatcher extends NodePatcher {
     this.expression.patch();
 
     if (addParens) {
-      this.insert(this.contentEnd, ')');
+      this.insert(this.innerEnd, ')');
     }
 
     let args: Array<string> = [];
@@ -50,7 +50,7 @@ export default class DoOpPatcher extends NodePatcher {
         }
       });
     }
-    this.insert(this.contentEnd, `(${args.join(', ')})`);
+    this.insert(this.innerEnd, `(${args.join(', ')})`);
   }
 
   /**

--- a/test/class_test.ts
+++ b/test/class_test.ts
@@ -1870,4 +1870,29 @@ describe('classes', () => {
       setResult(B.a())
     `, 3);
   });
+
+  it('handles complex class expressions with trailing whitespace', () => {
+    check(`
+      A = class B
+        c: d
+        e: ->
+          f 
+      
+    `, `
+      let B;
+      const A = (B = (function() {
+        B = class B {
+          static initClass() {
+            this.prototype.c = d;
+          }
+          e() {
+            return f;
+          }
+        };
+        B.initClass();
+        return B; 
+      })());
+      
+    `, {shouldStripIndent: false});
+  });
 });

--- a/test/do_test.ts
+++ b/test/do_test.ts
@@ -113,4 +113,15 @@ describe('`do`', () => {
       setResult(arr)
     `, [0, 1, 2, 3, 4]);
   });
+
+  it('handles a do expression with trailing whitespace', () => {
+    check(`
+      do ->
+        return b 
+      
+    `, `
+      (() => b)();
+      
+    `, {shouldStripIndent: false});
+  });
 });

--- a/test/support/check.ts
+++ b/test/support/check.ts
@@ -6,12 +6,19 @@ import stripSharedIndent from '../../src/utils/stripSharedIndent';
 
 export type Extra = {
   options?: Options;
+  shouldStripIndent?: boolean;
 };
 
 export default function check(
-    source: string, expected: string, {options={}}: Extra = {}): void {
-  if (source[0] === '\n') { source = stripSharedIndent(source); }
-  if (expected[0] === '\n') { expected = stripSharedIndent(expected); }
+    source: string, expected: string, {options={}, shouldStripIndent=true}: Extra = {}): void {
+  if (shouldStripIndent) {
+    if (source[0] === '\n') {
+      source = stripSharedIndent(source);
+    }
+    if (expected[0] === '\n') {
+      expected = stripSharedIndent(expected);
+    }
+  }
 
   try {
     let converted = convert(source, {


### PR DESCRIPTION
Fixes #1193

We were sometimes competing with other code that inserted at innerEnd, so
contentEnd wouldn't work.