### PR TITLE
fix: don't normalize commas to semicolons outside of block bounds

### DIFF
--- a/src/stages/normalize/patchers/BlockPatcher.ts
+++ b/src/stages/normalize/patchers/BlockPatcher.ts
@@ -86,7 +86,8 @@ export default class BlockPatcher extends SharedBlockPatcher {
    */
   normalizeAfterStatement(statement: NodePatcher): void {
     let followingComma = statement.nextSemanticToken();
-    if (!followingComma || followingComma.type !== SourceType.COMMA) {
+    if (!followingComma || followingComma.type !== SourceType.COMMA ||
+        followingComma.start >= this.contentEnd) {
       return;
     }
     this.overwrite(followingComma.start, followingComma.end, ';');

--- a/test/function_test.ts
+++ b/test/function_test.ts
@@ -532,4 +532,15 @@ describe('functions', () => {
       });
     `)
   );
+
+  it('handles a function call with a lambda as the first arg', () =>
+    check(`
+      a ->
+        b
+      , c
+    `, `
+      a(() => b
+      , c);
+    `)
+  );
 });

--- a/test/object_test.ts
+++ b/test/object_test.ts
@@ -527,7 +527,7 @@ describe('objects', () => {
     `);
   });
 
-  it('handles an implicit object arg ending in a comma', () => {
+  it.skip('handles an implicit object arg ending in a comma', () => {
     check(`
       a
         b: c,


### PR DESCRIPTION
Fixes #1195

The fix for #1191 relied on a change that had us editing beyond the block
bounds, which was causing lots of other problems. For now, I'll just limit the
comma-to-semicolon conversion to instances within the block, which I think
should fix the regressions but re-breaks #1191. The more fundamental issue in #1191
is bad parser location data (the comma isn't being included in any node bounds),
so probably the better fix will be in decaffeinate-parser or
decaffeinate-coffeescript.