### PR TITLE
fix: handle double commas in arg lists by removing the first

### DIFF
--- a/src/utils/normalizeListItem.ts
+++ b/src/utils/normalizeListItem.ts
@@ -50,8 +50,10 @@ export default function normalizeListItem(
     }
 
     // In some rare cases (when the LHS is an implicit object initializer), the
-    // parser allows two commas, so get rid of the second.
-    for (let extraneousComma of commaTokens.slice(1)) {
+    // parser allows two commas. The first one is an unnecessary object
+    // initializer delimiter, and the second may be a needed arg delimiter, so
+    // get rid of the first in these situations.
+    for (let extraneousComma of commaTokens.slice(0, -1)) {
       patcher.remove(extraneousComma.start, extraneousComma.end);
     }
   }

--- a/test/function_call_test.ts
+++ b/test/function_call_test.ts
@@ -643,8 +643,8 @@ describe('function calls', () => {
       , d
     `, `
       a(
-        {b: c},
-       d);
+        {b: c}
+      , d);
     `);
   });
 

--- a/test/object_test.ts
+++ b/test/object_test.ts
@@ -536,4 +536,25 @@ describe('objects', () => {
         b: c});
     `);
   });
+
+  it('correctly handles comma-separated implicit object args', () => {
+    check(`
+      somefunc 
+        hey: 1,
+        yo: 2,
+      ,
+        sup: 2,
+        friend: 3
+    `, `
+      somefunc({ 
+        hey: 1,
+        yo: 2
+      }
+      , {
+        sup: 2,
+        friend: 3
+      }
+      );
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #1182

An implicit object literal followed by an arg separator can sometimes result in
two commas in a row between arguments. The previous strategy was to just remove
the second, but in some cases, that could cause indentation issues that change
the parsing so there's no more argument separator. Removing the first one
instead should fix this problem.

Another fix may be to fix the location data of implicit object literals to
include the trailing comma, but this fix should work for now.