### PR TITLE
fix: simplify normalizeListItem, add regression tests

### DIFF
--- a/src/utils/normalizeListItem.ts
+++ b/src/utils/normalizeListItem.ts
@@ -48,12 +48,6 @@ export default function normalizeListItem(
         commaTokens.length === 0) {
       patcher.insert(listItemPatcher.outerEnd, ',');
     }
-
-    // In some rare cases (when the LHS is an implicit object initializer), the
-    // parser allows two commas, so get rid of the second.
-    for (let extraneousComma of commaTokens.slice(1)) {
-      patcher.remove(extraneousComma.start, extraneousComma.end);
-    }
   }
 }
 

--- a/test/function_call_test.ts
+++ b/test/function_call_test.ts
@@ -643,8 +643,8 @@ describe('function calls', () => {
       , d
     `, `
       a(
-        {b: c},
-       d);
+        {b: c}
+      , d);
     `);
   });
 

--- a/test/object_test.ts
+++ b/test/object_test.ts
@@ -527,13 +527,34 @@ describe('objects', () => {
     `);
   });
 
-  it.skip('handles an implicit object arg ending in a comma', () => {
+  it('handles an implicit object arg ending in a comma', () => {
     check(`
       a
         b: c,
     `, `
       a({
         b: c});
+    `);
+  });
+
+  it('correctly handles comma-separated implicit object args', () => {
+    check(`
+      somefunc 
+        hey: 1,
+        yo: 2,
+      ,
+        sup: 2,
+        friend: 3
+    `, `
+      somefunc({ 
+        hey: 1,
+        yo: 2
+      }
+      , {
+        sup: 2,
+        friend: 3
+      }
+      );
     `);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1198,8 +1198,8 @@ decaffeinate-coffeescript@1.10.0-patch26:
   resolved "https://registry.yarnpkg.com/decaffeinate-coffeescript/-/decaffeinate-coffeescript-1.10.0-patch26.tgz#d3f23fcb7e3d574ad38182b44ef6f62c2757fdfe"
 
 decaffeinate-parser@^19.1.0:
-  version "19.1.2"
-  resolved "https://registry.yarnpkg.com/decaffeinate-parser/-/decaffeinate-parser-19.1.2.tgz#a5e694ef001f493dbd85219b93d546ad5bf763e5"
+  version "19.1.3"
+  resolved "https://registry.yarnpkg.com/decaffeinate-parser/-/decaffeinate-parser-19.1.3.tgz#6127d0508ac2f9a760ccfee136f4226706ded4f0"
   dependencies:
     "@types/babylon" "^6.16.1"
     "@types/json-stable-stringify" "^1.0.31"


### PR DESCRIPTION
Follow up from https://github.com/decaffeinate/decaffeinate-parser/pull/273

Adds tests for #1182 and #1191.

Now that implicit object literals have the proper location data, we no longer
need a special case for handling two commas in a row between args, since the
earlier comma is now part of the object literal.