### PR TITLE
fix: don't generate blockless arrow functions that contain assignments

### DIFF
--- a/test/function_test.ts
+++ b/test/function_test.ts
@@ -543,4 +543,45 @@ describe('functions', () => {
       , c);
     `)
   );
+
+  it('applies proper variable scopes with sibling arrow functions (#1201)', () =>
+    check(`
+      () =>
+        a = 1
+        return
+      
+      () =>
+        a = 2
+        return
+    `, `
+      () => {
+        const a = 1;
+      };
+      
+      () => {
+        const a = 2;
+      };
+    `)
+  );
+
+  it('applies proper variable scopes with sibling blockless arrow functions (#1202)', () =>
+    check(`
+      () => a = 1
+      () => a = 2
+    `, `
+      () => { let a;
+      return a = 1; };
+      () => { let a;
+      return a = 2; };
+    `)
+  );
+
+  it('correctly handles scoping for an assignment in an inline arrow function', () =>
+    validate(`
+      f = => a = 1
+      a = 2
+      f()
+      setResult(a)
+    `, 2)
+  );
 });

--- a/test/soaked_test.ts
+++ b/test/soaked_test.ts
@@ -799,8 +799,8 @@ describe('soaked expressions', () => {
     checkSoak(`
       a()?[b()] ?= d
     `, `
-      let base;
       let name;
+      let base;
       __guard__((base = a()), x => x[name = b()] != null ? base[name] : (base[name] = d));
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
@@ -830,8 +830,8 @@ describe('soaked expressions', () => {
     checkSoak(`
       a()?[b()] and= d
     `, `
-      let base;
       let name;
+      let base;
       __guard__((base = a()), x => x[name = b()] && (base[name] = d));
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,12 +114,12 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
 
 add-variable-declarations@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/add-variable-declarations/-/add-variable-declarations-3.1.0.tgz#bc7d783ea348b84cf15c1af7ef50c65fcab38993"
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/add-variable-declarations/-/add-variable-declarations-3.1.2.tgz#183902497fb7df0f8da23ebc0971dfce6f33ecfd"
   dependencies:
     babel-traverse "7.0.0-alpha.15"
     babel-types "7.0.0-alpha.15"
-    babylon "7.0.0-beta.16"
+    babylon "7.0.0-beta.31"
     magic-string "^0.22.2"
 
 agent-base@2:
@@ -767,6 +767,10 @@ babylon@7.0.0-beta.16, babylon@^7.0.0-beta.16:
 babylon@7.0.0-beta.27:
   version "7.0.0-beta.27"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.27.tgz#b6edd30ef30619e2f630eb52585fdda84e6542cd"
+
+babylon@7.0.0-beta.31:
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.31.tgz#7ec10f81e0e456fd0f855ad60fa30c2ac454283f"
 
 babylon@^6.14.1, babylon@^6.17.2:
   version "6.17.4"


### PR DESCRIPTION
Fixes #1202

add-variable-declarations won't have a place to add a declaration if the
function doesn't have a block body, so if there's any assignment in an arrow
function, we always give it a block body.

The formatting after decaffeinate and add-variable-declarations looks really
bad, I think because add-variable-declarations doesn't attempt to handle inline
functions, but this case is rare enough that I'm not too worried about
formatting.

Also update add-variable-declarations and add a regression test for #1201.