### PR TITLE
fix: handle all assignments within IIFEs

### DIFF
--- a/src/stages/main/patchers/ConditionalPatcher.ts
+++ b/src/stages/main/patchers/ConditionalPatcher.ts
@@ -2,6 +2,7 @@ import { SourceType } from 'coffee-lex';
 import SourceTokenListIndex from 'coffee-lex/dist/SourceTokenListIndex';
 import { Conditional } from 'decaffeinate-parser/dist/nodes';
 import { PatcherContext, PatchOptions } from '../../../patchers/types';
+import getEnclosingScopeBlock from '../../../utils/getEnclosingScopeBlock';
 import notNull from '../../../utils/notNull';
 import NodePatcher from './../../../patchers/NodePatcher';
 import BlockPatcher from './BlockPatcher';
@@ -23,6 +24,7 @@ export default class ConditionalPatcher extends NodePatcher {
 
   initialize(): void {
     this.condition.setRequiresExpression();
+    getEnclosingScopeBlock(this).markIIFEPatcherDescendant(this);
   }
 
   /**

--- a/src/stages/main/patchers/ForPatcher.ts
+++ b/src/stages/main/patchers/ForPatcher.ts
@@ -31,6 +31,7 @@ export default abstract class ForPatcher extends LoopPatcher {
   }
 
   initialize(): void {
+    super.initialize();
     if (this.keyAssignee) {
       this.keyAssignee.setAssignee();
       this.keyAssignee.setRequiresExpression();
@@ -43,19 +44,6 @@ export default abstract class ForPatcher extends LoopPatcher {
     if (this.filter) {
       this.filter.setRequiresExpression();
     }
-    this.getEnclosingScopeBlock().markForPatcherDescendant(this);
-  }
-
-  getEnclosingScopeBlock(): BlockPatcher {
-    let patcher: NodePatcher | null = this;
-    while (patcher) {
-      if (patcher instanceof BlockPatcher &&
-          notNull(patcher.parent).node === this.getScope().containerNode) {
-        return patcher;
-      }
-      patcher = patcher.parent;
-    }
-    throw this.error('Expected to find enclosing scope block.');
   }
 
   /**

--- a/src/stages/main/patchers/LoopPatcher.ts
+++ b/src/stages/main/patchers/LoopPatcher.ts
@@ -1,4 +1,5 @@
 import { PatcherContext } from '../../../patchers/types';
+import getEnclosingScopeBlock from '../../../utils/getEnclosingScopeBlock';
 import notNull from '../../../utils/notNull';
 import NodePatcher from './../../../patchers/NodePatcher';
 import BlockPatcher from './BlockPatcher';
@@ -12,6 +13,10 @@ export default class LoopPatcher extends NodePatcher {
   constructor(patcherContext: PatcherContext, body: BlockPatcher) {
     super(patcherContext);
     this.body = body;
+  }
+
+  initialize(): void {
+    getEnclosingScopeBlock(this).markIIFEPatcherDescendant(this);
   }
 
   patchAsExpression(): void {

--- a/src/stages/main/patchers/SwitchPatcher.ts
+++ b/src/stages/main/patchers/SwitchPatcher.ts
@@ -2,6 +2,7 @@ import { SourceType } from 'coffee-lex';
 import SourceToken from 'coffee-lex/dist/SourceToken';
 import NodePatcher from '../../../patchers/NodePatcher';
 import { PatcherContext } from '../../../patchers/types';
+import getEnclosingScopeBlock from '../../../utils/getEnclosingScopeBlock';
 
 export default class SwitchPatcher extends NodePatcher {
   expression: NodePatcher;
@@ -19,6 +20,7 @@ export default class SwitchPatcher extends NodePatcher {
     if (this.expression) {
       this.expression.setRequiresExpression();
     }
+    getEnclosingScopeBlock(this).markIIFEPatcherDescendant(this);
   }
 
   prefersToPatchAsExpression(): boolean {
@@ -95,6 +97,10 @@ export default class SwitchPatcher extends NodePatcher {
       this.patchAsStatement();
       this.insert(this.innerEnd, ' ');
     });
+  }
+
+  willPatchAsIIFE(): boolean {
+    return this.willPatchAsExpression();
   }
 
   canHandleImplicitReturn(): boolean {

--- a/src/stages/main/patchers/TryPatcher.ts
+++ b/src/stages/main/patchers/TryPatcher.ts
@@ -3,6 +3,7 @@ import SourceToken from 'coffee-lex/dist/SourceToken';
 import SourceTokenListIndex from 'coffee-lex/dist/SourceTokenListIndex';
 import NodePatcher from '../../../patchers/NodePatcher';
 import { PatcherContext } from '../../../patchers/types';
+import getEnclosingScopeBlock from '../../../utils/getEnclosingScopeBlock';
 import notNull from '../../../utils/notNull';
 import BlockPatcher from './BlockPatcher';
 
@@ -33,6 +34,7 @@ export default class TryPatcher extends NodePatcher {
       this.catchAssignee.setAssignee();
       this.catchAssignee.setRequiresExpression();
     }
+    getEnclosingScopeBlock(this).markIIFEPatcherDescendant(this);
   }
 
   canPatchAsExpression(): boolean {
@@ -152,6 +154,10 @@ export default class TryPatcher extends NodePatcher {
       this.patchAsStatement();
       this.insert(this.innerEnd, ' ');
     });
+  }
+
+  willPatchAsIIFE(): boolean {
+    return this.willPatchAsExpression();
   }
 
   canHandleImplicitReturn(): boolean {

--- a/src/stages/main/patchers/WhilePatcher.ts
+++ b/src/stages/main/patchers/WhilePatcher.ts
@@ -26,6 +26,7 @@ export default class WhilePatcher extends LoopPatcher {
   }
 
   initialize(): void {
+    super.initialize();
     this.condition.setRequiresExpression();
     if (this.guard !== null) {
       this.guard.setRequiresExpression();

--- a/src/utils/getEnclosingScopeBlock.ts
+++ b/src/utils/getEnclosingScopeBlock.ts
@@ -1,0 +1,18 @@
+import NodePatcher from '../patchers/NodePatcher';
+import BlockPatcher from '../stages/main/patchers/BlockPatcher';
+import notNull from './notNull';
+
+/**
+ * For main stage nodes, find the block corresponding to this node's scope.
+ */
+export default function getEnclosingScopeBlock(patcher: NodePatcher): BlockPatcher {
+  let currentPatcher: NodePatcher | null = patcher;
+  while (currentPatcher) {
+    if (currentPatcher instanceof BlockPatcher &&
+      notNull(currentPatcher.parent).node === patcher.getScope().containerNode) {
+      return currentPatcher;
+    }
+    currentPatcher = currentPatcher.parent;
+  }
+  throw patcher.error('Expected to find enclosing scope block.');
+}

--- a/test/conditional_test.ts
+++ b/test/conditional_test.ts
@@ -835,4 +835,41 @@ describe('conditionals', () => {
         b;
     `);
   });
+
+  it('handles an IIFE conditional with an assigned variable used later', () => {
+    check(`
+      a =
+        if b
+          c = d
+        else if e
+          f
+      c
+    `, `
+      let c;
+      const a =
+        (() => {
+        if (b) {
+          return c = d;
+        } else if (e) {
+          return f;
+        }
+      })();
+      c;
+    `);
+  });
+
+  it('produces the right result with an IIFE conditional with assignment followed by access', () => {
+    validate(`
+      value = 3
+      
+      result =
+        if value == 3
+          x = 1
+        else if value == 4
+          2
+      
+      if value == 3
+        setResult(x)
+    `, 1);
+  });
 });

--- a/test/for_test.ts
+++ b/test/for_test.ts
@@ -1810,4 +1810,46 @@ describe('for loops', () => {
       [1, 2]
     );
   });
+
+  it('handles an IIFE for-in with an assignment followed by access', () => {
+    check(`
+      a =
+        for b in c
+          d = e
+          break
+      d
+    `, `
+      let d;
+      const a =
+        (() => {
+        const result = [];
+        for (let b of Array.from(c)) {
+          d = e;
+          break;
+        }
+        return result;
+      })();
+      d;
+    `);
+  });
+
+  it('handles an IIFE for-of with an assignment followed by access', () => {
+    check(`
+      a =
+        for b of c
+          d = e
+      d
+    `, `
+      let d;
+      const a =
+        (() => {
+        const result = [];
+        for (let b in c) {
+          result.push(d = e);
+        }
+        return result;
+      })();
+      d;
+    `);
+  });
 });

--- a/test/switch_test.ts
+++ b/test/switch_test.ts
@@ -599,4 +599,22 @@ describe('switch', () => {
       setResult('' + f())
     `, 'undefined');
   });
+
+  it('handles an IIFE switch with an assignment followed by access', () => {
+    check(`
+      a =
+        switch b
+          when c
+            d = e
+      d
+    `, `
+      let d;
+      const a =
+        (() => { switch (b) {
+          case c:
+            return d = e;
+        } })();
+      d;
+    `);
+  });
 });

--- a/test/try_test.ts
+++ b/test/try_test.ts
@@ -414,4 +414,21 @@ describe('try', () => {
       } catch (b) {} 
     `);
   });
+
+  it('handles an IIFE try/catch with an assignment followed by access', () => {
+    check(`
+      a =
+        try
+          b = c
+        catch
+      b
+    `, `
+      let b;
+      const a =
+        (() => { try {
+          return b = c;
+        } catch (error) {} })();
+      b;
+    `);
+  });
 });

--- a/test/while_test.ts
+++ b/test/while_test.ts
@@ -455,4 +455,24 @@ describe('while', () => {
       while (true) {} 
     `);
   });
+
+  it('handles an IIFE while with an assignment followed by access', () => {
+    check(`
+      a =
+        while b
+          c = d
+      c
+    `, `
+      let c;
+      const a =
+        (() => {
+        const result = [];
+        while (b) {
+          result.push(c = d);
+        }
+        return result;
+      })();
+      c;
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #1205

Previously, the block code had a special case for loop assignees, but we actually
need to hoist all assigned variables when turning a node into an IIFE. We
accomplish this by having all IIFE-capable nodes add themselves to the parent
BlockPatcher, and the BlockPatcher figures out the variable assignees used
outside of the IIFE and explicitly hoists those variables.