### PR TITLE
test(ci): replace node v7.x.x with node v9.x.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,14 @@ cache:
 notifications:
   email: false
 before_install:
-  # TODO: Switch this back to yarn when greenkeeperio/greenkeeper-lockfile#98 is fixed.
-  # https://github.com/greenkeeperio/greenkeeper-lockfile/issues/98
-  - npm install --global greenkeeper-lockfile@1
+  - yarn global add greenkeeper-lockfile@1
 before_script:
   - greenkeeper-lockfile-update
 after_script:
   - greenkeeper-lockfile-upload
 node_js:
+  - '9'
   - '8'
-  - '7'
   - '6'
   - '4'
 after_success:


### PR DESCRIPTION
We only want to test against the latest non-stable version. Also, greenkeeperio/greenkeeper-lockfile#98 is fixed so we can revert the switch to npm.