### PR TITLE
fix: change continuation patching to happen before program patching

### DIFF
--- a/src/stages/main/patchers/ProgramPatcher.ts
+++ b/src/stages/main/patchers/ProgramPatcher.ts
@@ -13,10 +13,10 @@ export default class ProgramPatcher extends SharedProgramPatcher {
 
   patchAsStatement(): void {
     this.patchComments();
+    this.patchContinuations();
     if (this.body) {
       this.body.patch({ leftBrace: false, rightBrace: false });
     }
-    this.patchContinuations();
     this.patchHelpers();
   }
 
@@ -28,14 +28,7 @@ export default class ProgramPatcher extends SharedProgramPatcher {
   patchContinuations(): void {
     this.getProgramSourceTokens().forEach(token => {
       if (token.type === SourceType.CONTINUATION) {
-        try {
-          this.remove(token.start, token.end);
-        } catch (e) {
-          this.log(
-            'Warning: Ignoring a continuation token because it could not be ' +
-            'removed. Most likely, this is because its range has already ' +
-            'been overwritten.');
-        }
+        this.remove(token.start, token.end);
       }
     });
   }

--- a/test/conditional_test.ts
+++ b/test/conditional_test.ts
@@ -872,4 +872,15 @@ describe('conditionals', () => {
         setResult(x)
     `, 1);
   });
+
+  it('handles multiline inline conditionals with an existential operator condition (#1230)', () => {
+    check(`
+      test  = if \\
+        cond? \\
+        then 'true' else 'no'
+    `, `
+      const test  = (typeof cond !== 'undefined' && cond !== null) 
+        ? 'true' : 'no';
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #1230

Generally with magic-string it's best to patch in order, and to remove before
you add. In this case, we were removing continuation tokens after the fact
across the whole program, which was causing an open-paren to be incorrectly
removed since it was in the range being removed. Removing continuations first
seems to avoid this problem, and also avoid the need to wrap the remove in a
try/catch.