### PR TITLE
docs(issues): use the new Github multiple issue templates feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/crash.md
+++ b/.github/ISSUE_TEMPLATE/crash.md
@@ -1,0 +1,23 @@
+<!--
+
+☕️ 𝓭𝓮𝓬𝓪𝓯𝓯𝓮𝓲𝓷𝓪𝓽𝓮
+
+Thanks for creating an issue! You can paste your code into http://decaffeinate-project.org/repl/ and then copy the URL to get a shareable link to your code. Pasting that URL into the issue as a markdown link is helpful, like so:
+
+    [(repl)](http://decaffeinate-project.org/repl/#?evaluate=true&code=a%20b)
+
+-->
+
+decaffeinate is crashing on my CoffeeScript input:
+
+```coffee
+<FILL THIS IN>
+```
+
+<LINK TO REPL>
+
+I get this error:
+
+```
+<FILL THIS IN>
+```

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,3 @@
+I have a feature request.
+
+<FILL THIS IN WITH DETAILS OF YOUR FEATURE REQUEST>

--- a/.github/ISSUE_TEMPLATE/wrong.md
+++ b/.github/ISSUE_TEMPLATE/wrong.md
@@ -1,0 +1,29 @@
+<!--
+
+☕️ 𝓭𝓮𝓬𝓪𝓯𝓯𝓮𝓲𝓷𝓪𝓽𝓮
+
+Thanks for creating an issue! You can paste your code into http://decaffeinate-project.org/repl/ and then copy the URL to get a shareable link to your code. Pasting that URL into the issue as a markdown link is helpful, like so:
+
+    [(repl)](http://decaffeinate-project.org/repl/#?evaluate=true&code=a%20b)
+
+-->
+
+decaffeinate is producing the wrong JavaScript based on my CoffeeScript input:
+
+```coffee
+<FILL THIS IN>
+```
+
+<LINK TO REPL>
+
+I get this output:
+
+```js
+<FILL THIS IN>
+```
+
+Here's what I expect it to be instead:
+
+```js
+<FILL THIS IN>
+```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ cleaning up the converted JavaScript code and other things to keep in mind.
 ## Questions and support
 
 Feel free to join the [gitter chat room](https://gitter.im/decaffeinate/Lobby)
-to ask questions, or you can file an issue on the [issues] page.
+to ask questions, or you can file an issue on the [issues] page:
+- [report a crash][crash-issue]
+- [report incorrect output][wrong-issue]
+- [request a feature][feature-issue]
 
 ## Status
 
@@ -161,6 +164,9 @@ For more usage details, see the output of `decaffeinate --help`.
 [repl]: http://decaffeinate-project.org/repl/
 [bulk-decaffeinate]: https://github.com/decaffeinate/bulk-decaffeinate
 [issues]: https://github.com/decaffeinate/decaffeinate/issues
+[crash-issue]: https://github.com/decaffeinate/decaffeinate/issues/new?template=crash.md
+[wrong-issue]: https://github.com/decaffeinate/decaffeinate/issues/new?template=wrong.md
+[feature-issue]: https://github.com/decaffeinate/decaffeinate/issues/new?template=feature.md
 [conversion-guide]: https://github.com/decaffeinate/decaffeinate/blob/master/docs/conversion-guide.md
 [suggestions]: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
 [correctness-issues]: https://github.com/decaffeinate/decaffeinate/blob/master/docs/correctness-issues.md


### PR DESCRIPTION
We retain the default one for someone who just stumbles onto the issues page, but if you come from the README we can be a little more targeted.

https://github.com/blog/2495-multiple-issue-and-pull-request-templates