### PR TITLE
fix: properly handle escaped backslashes in inline JS

### DIFF
--- a/src/stages/main/patchers/JavaScriptPatcher.ts
+++ b/src/stages/main/patchers/JavaScriptPatcher.ts
@@ -33,9 +33,25 @@ export default class JavaScriptPatcher extends NodePatcher {
     //  ^
     this.remove(this.contentStart, this.contentStart + tokenLength);
 
+    // We want to allow escaped backticks, and escaped backslashes immediately before escaped
+    // backticks.
     for (let i = this.contentStart + tokenLength; i < this.contentEnd - tokenLength - 1; i++) {
       if (this.slice(i, i + 2) === '\\`') {
-        this.remove(i, i + 1);
+        let startBackslash = i;
+        while (this.context.source[startBackslash] === '\\') {
+          startBackslash--;
+        }
+        startBackslash++;
+        // The range [startBackslash, i + 2) is now a string like "\\\\\`". One backslash is used
+        // for the escape and two for each backslash to include, so 1 backslash should become 0,
+        // 3 backslashes should become 1, 5 should become 2, etc. In normal (single-backtick) inline
+        // JS, there will always be an odd number of backslashes (since otherwise the backtick would
+        // be the end of the JS node), but in triple-backtick inline JS there could be an even
+        // number. CoffeeScript has the same special escaping behavior there as well, so replicate
+        // that: 2 backslashes become 1, 4 become 2, etc. In all case, this behavior only happens
+        // for a sequence of backslashes followed by a backtick.
+        let numBackslashesToKeep = Math.floor((i + 1 - startBackslash) / 2);
+        this.remove(startBackslash, i + 1 - numBackslashesToKeep);
       }
     }
 

--- a/test/javascript_test.ts
+++ b/test/javascript_test.ts
@@ -33,4 +33,13 @@ describe('embedded JavaScript', () => {
   it('handles escaped backticks in inline JS', () => {
     check('`s + \\`hello\\`;`', 's + `hello`;');
   });
+
+  it('handles escaped backslashes before escaped backticks in inline JS', () => {
+    // Five backslashes produces JS "\\`", which is a single backslash followed by a backtick.
+    validate('setResult(`"\\\\\\\\\\`"`);', '\\`');
+  });
+
+  it('does not handle escaped backslashes when not followed by a backtick', () => {
+    validate('setResult(`"\\\\\\\\"`);', '\\\\');
+  });
 });


### PR DESCRIPTION
Previously I thought escaped backslashes weren't handled at all, but actually
they're only handled just before escaped backticks. That means we need to walk
left whenever we see an escaped backtick, count how many backslashes there are,
and remove the appropriate number to account for escaping.