### PR TITLE
fix: properly downgrade unicode code point escapes in regexes

### DIFF
--- a/src/stages/main/patchers/HeregexPatcher.ts
+++ b/src/stages/main/patchers/HeregexPatcher.ts
@@ -1,8 +1,11 @@
+import {Heregex} from 'decaffeinate-parser/dist/nodes';
 import InterpolatedPatcher from './InterpolatedPatcher';
 
 const CLOSE_TOKEN_BASE_LENGTH = 3;
 
 export default class HeregexPatcher extends InterpolatedPatcher {
+  node: Heregex;
+
   patchAsExpression(): void {
     let openToken = this.firstToken();
     let closeToken = this.lastToken();
@@ -24,5 +27,9 @@ export default class HeregexPatcher extends InterpolatedPatcher {
 
   shouldExcapeZeroChars(): boolean {
     return true;
+  }
+
+  shouldDowngradeUnicodeCodePointEscapes(): boolean {
+    return !this.node.flags.unicode;
   }
 }

--- a/src/stages/main/patchers/InterpolatedPatcher.ts
+++ b/src/stages/main/patchers/InterpolatedPatcher.ts
@@ -2,6 +2,8 @@ import { SourceType } from 'coffee-lex';
 
 import SourceToken from 'coffee-lex/dist/SourceToken';
 import { PatcherContext } from '../../../patchers/types';
+import downgradeUnicodeCodePointEscapesInRange
+  from '../../../utils/downgradeUnicodeCodePointEscapesInRange';
 import escape from '../../../utils/escape';
 import escapeSpecialWhitespaceInRange from '../../../utils/escapeSpecialWhitespaceInRange';
 import escapeZeroCharsInRange from '../../../utils/escapeZeroCharsInRange';
@@ -85,12 +87,19 @@ export default class InterpolatedPatcher extends NodePatcher {
           if (this.shouldExcapeZeroChars()) {
             escapeZeroCharsInRange(token.start, token.end, this);
           }
+          if (this.shouldDowngradeUnicodeCodePointEscapes()) {
+            downgradeUnicodeCodePointEscapesInRange(token.start, token.end, this, {needsExtraEscape: true});
+          }
         }
       }
     }
   }
 
   shouldExcapeZeroChars(): boolean {
+    return false;
+  }
+
+  shouldDowngradeUnicodeCodePointEscapes(): boolean {
     return false;
   }
 

--- a/src/stages/main/patchers/RegexPatcher.ts
+++ b/src/stages/main/patchers/RegexPatcher.ts
@@ -1,8 +1,16 @@
+import {Regex} from 'decaffeinate-parser/dist/nodes';
 import NodePatcher from '../../../patchers/NodePatcher';
+import downgradeUnicodeCodePointEscapesInRange
+  from '../../../utils/downgradeUnicodeCodePointEscapesInRange';
 import escapeSpecialWhitespaceInRange from '../../../utils/escapeSpecialWhitespaceInRange';
 
 export default class RegexPatcher extends NodePatcher {
+  node: Regex;
+
   patchAsExpression(): void {
     escapeSpecialWhitespaceInRange(this.contentStart + 1, this.contentEnd - 1, this);
+    if (!this.node.flags.unicode) {
+      downgradeUnicodeCodePointEscapesInRange(this.contentStart + 1, this.contentEnd - 1, this);
+    }
   }
 }

--- a/src/utils/downgradeUnicodeCodePointEscapesInRange.ts
+++ b/src/utils/downgradeUnicodeCodePointEscapesInRange.ts
@@ -1,0 +1,54 @@
+import NodePatcher from '../patchers/NodePatcher';
+
+/**
+ * Normal JS regular expressions don't support unicode code point escapes (e.g. /\u{1a}/), so
+ * CoffeeScript compiles them to normal unicode escapes /\u001a/. Note that regexes now support the
+ * "u" flag that makes them support unicode code point escapes and changes a few other aspects of
+ * their behavior, but CoffeeScript still keeps the old behavior and just compiles the code point to
+ * normal unicode escapes when the "u" flag is missing.
+ *
+ * needsExtraEscape is for heregexes where we'll need two backslashes before each 'u'. The first one
+ * will be handled automatically by later code, but the second one we need to insert here.
+ */
+export default function downgradeUnicodeCodePointEscapesInRange(
+  start: number,
+  end: number,
+  patcher: NodePatcher,
+  {needsExtraEscape}: {needsExtraEscape?: boolean} = {}
+): void {
+  const source = patcher.context.source;
+  let numBackslashes = 0;
+  for (let i = start; i < end - 2; i++) {
+    if (source[i] === '\\') {
+      numBackslashes++;
+    } else {
+      numBackslashes = 0;
+    }
+    if (numBackslashes % 2 === 1 && source.slice(i, i + 3) === '\\u{') {
+      let codePointEnd = i + 3;
+      while (codePointEnd < source.length && source[codePointEnd] !== '}') {
+        codePointEnd++;
+      }
+      // Logic taken from unicodeCodePointToUnicodeEscapes in CoffeeScript's lexer.coffee.
+      let codePointText = source.slice(i + 3, codePointEnd);
+      let codePoint = parseInt(codePointText, 16);
+      if (codePoint < 0x10000) {
+        patcher.overwrite(i, codePointEnd + 1, toUnicodeEscape(codePoint));
+      } else {
+        let high = Math.floor((codePoint - 0x10000) / 0x400) + 0xD800;
+        let low = (codePoint - 0x10000) % 0x400 + 0xDC00;
+        patcher.overwrite(
+          i,
+          codePointEnd + 1,
+          `${toUnicodeEscape(high)}${needsExtraEscape ? '\\' : ''}${toUnicodeEscape(low)}`
+        );
+      }
+      i = codePointEnd;
+    }
+  }
+}
+
+function toUnicodeEscape(val: number): string {
+  let str = val.toString(16);
+  return `\\u${'0'.repeat(4 - str.length)}${str}`;
+}

--- a/src/utils/getCompareOperator.ts
+++ b/src/utils/getCompareOperator.ts
@@ -21,8 +21,6 @@ export default function getCompareOperator(operator: string, negated: boolean): 
       return negated ? '<' : '>=';
 
     default:
-      throw this.error(
-        `unsupported equality/inequality type: ${operator}`
-      );
+      throw new Error(`unsupported equality/inequality type: ${operator}`);
   }
 }

--- a/test/regular_expression_test.ts
+++ b/test/regular_expression_test.ts
@@ -151,4 +151,60 @@ describe('regular expressions', () => {
       new RegExp(\`\\\\\\\\[\\\\\\\\]\`);
     `);
   });
+
+  it('replaces unicode code point escapes with regular unicode escapes in regexes', () => {
+    check(`
+      /\\u{a}/
+      `, `
+      /\\u000a/;
+    `);
+  });
+
+  it('replaces non-BMP unicode code point escapes with regular unicode escapes in regexes', () => {
+    check(`
+      /\\u{10000}/
+      `, `
+      /\\ud800\\udc00/;
+    `);
+  });
+
+  it('replaces heregex unicode code point escapes with regular unicode escapes', () => {
+    check(`
+      ///\\u{a}///
+      `, `
+      new RegExp(\`\\\\u000a\`);
+    `);
+  });
+
+  it('replaces heregex non-BMP unicode code point escapes with regular unicode escapes', () => {
+    check(`
+      ///\\u{10000}///
+      `, `
+      new RegExp(\`\\\\ud800\\\\udc00\`);
+    `);
+  });
+
+  it('does not downgrade unicode code point escapes when the "u" flag is specified', () => {
+    check(`
+      /\\u{a}/u
+      `, `
+      /\\u{a}/u;
+    `);
+  });
+
+  it('does not downgrade heregex unicode code point escapes when the "u" flag is specified', () => {
+    check(`
+      ///\\u{a}///u
+      `, `
+      new RegExp(\`\\\\u{a}\`, 'u');
+    `);
+  });
+
+  it('does not replace unicode when u is preceded by two backslashes', () => {
+    check(`
+      /\\\\u{a}/
+      `, `
+      /\\\\u{a}/;
+    `);
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "lib": ["es2015"],
     "experimentalDecorators": true,
     "noImplicitAny": true,
+    "noImplicitThis": true,
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
This fixes the last CoffeeScript test failure after upgrading to 1.12.7.

CoffeeScript specifically handles unicode code point escapes in regexes without
the "u" flag specified, e.g. `/\u{a}/`, whereas JavaScript requires the "u" flag
for it to be interpreted as a code point escape. Unfortunately, it's incorrect
to just add the "u" flag, since that introduces various other semantics. To fix,
we just copy CoffeeScript's behavior and downgrade to old-style unicode escapes
in the BMP case and emit old-style unicode escapes for the surrogate pair in the
non-BMP case. When the "u" flag is specified, we skip this behavior.