### PR TITLE
feat: upgrade decaffeinate-parser to use the CS2 AST format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ node_js:
   - '9'
   - '8'
   - '6'
-  - '4'
 after_success:
   - 'curl -Lo travis_after_all.py https://git.io/travis_after_all'
   - python travis_after_all.py

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "babylon": "7.0.0-beta.34",
     "coffee-lex": "^8.1.1",
     "decaffeinate-coffeescript": "1.12.7-patch.2",
-    "decaffeinate-parser": "^20.2.2",
+    "decaffeinate-coffeescript2": "2.2.1-patch.1",
+    "decaffeinate-parser": "^21.0.1",
     "detect-indent": "^4.0.0",
     "esnext": "^3.2.0",
     "lines-and-columns": "^1.1.5",
@@ -52,7 +53,7 @@
     "tslib": "^1.7.1"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "files": [
     "bin",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import lex from 'coffee-lex';
-import { nodes as getCoffeeNodes, tokens as getCoffeeTokens } from 'decaffeinate-coffeescript';
+import { nodes as getCoffeeNodes, tokens as getCoffeeTokens } from 'decaffeinate-coffeescript2';
 import {parse as decaffeinateParse} from 'decaffeinate-parser';
 import AddVariableDeclarationsStage from './stages/add-variable-declarations/index';
 import EsnextStage from './stages/esnext/index';

--- a/src/utils/DecaffeinateContext.ts
+++ b/src/utils/DecaffeinateContext.ts
@@ -1,5 +1,5 @@
 import SourceTokenList from 'coffee-lex/dist/SourceTokenList';
-import { Block } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Block } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import { parse as decaffeinateParse, traverse } from 'decaffeinate-parser';
 import { Node, Program } from 'decaffeinate-parser/dist/nodes';
 import LinesAndColumns from 'lines-and-columns';

--- a/src/utils/formatCoffeeScriptAst.ts
+++ b/src/utils/formatCoffeeScriptAst.ts
@@ -1,4 +1,4 @@
-import { Base } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Base } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import CodeContext from './CodeContext';
 import formatCoffeeScriptLocationData from './formatCoffeeScriptLocationData';
 

--- a/src/utils/formatCoffeeScriptLexerTokens.ts
+++ b/src/utils/formatCoffeeScriptLexerTokens.ts
@@ -1,4 +1,4 @@
-import { Token } from 'decaffeinate-coffeescript/lib/coffee-script/lexer';
+import { Token } from 'decaffeinate-coffeescript2/lib/coffeescript/lexer';
 import CodeContext from './CodeContext';
 import formatCoffeeScriptLocationData from './formatCoffeeScriptLocationData';
 

--- a/src/utils/formatCoffeeScriptLocationData.ts
+++ b/src/utils/formatCoffeeScriptLocationData.ts
@@ -1,4 +1,4 @@
-import { LocationData } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { LocationData } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import CodeContext from './CodeContext';
 
 export default function formatCoffeeScriptLocationData(locationData: LocationData, context: CodeContext): string {

--- a/test/conditional_test.ts
+++ b/test/conditional_test.ts
@@ -619,11 +619,10 @@ describe('conditionals', () => {
       (function() {
         if (false) {
           // comment
-        } else if (true) {
+        } else if (true) {} 
           /*
           block comment
           */
-        }
         else {}
       });
     `);
@@ -637,8 +636,8 @@ describe('conditionals', () => {
       )
     `, `
       const x = (true ?
-        undefined/* a */
-       : undefined
+        /* a */
+      undefined : undefined
       );
     `);
   });
@@ -817,8 +816,8 @@ describe('conditionals', () => {
       x = if a
         ;
     `, `
-      const x = a ?
-        undefined : undefined;
+      const x = a ? undefined : undefined
+        ;
     `);
   });
 
@@ -830,8 +829,8 @@ describe('conditionals', () => {
         b
     `, `
       const x = a ?
-        undefined
-      :
+        
+      undefined :
         b;
     `);
   });

--- a/test/for_test.ts
+++ b/test/for_test.ts
@@ -1742,8 +1742,12 @@ describe('for loops', () => {
       x = for a in b
         ;
     `, `
-      const x = Array.from(b).map((a) =>
-        undefined);
+      const x = (() => {
+        const result = [];
+        for (let a of Array.from(b)) {
+        }
+        return result;
+      })();
     `);
   });
 

--- a/test/function_call_test.ts
+++ b/test/function_call_test.ts
@@ -753,8 +753,7 @@ describe('function calls', () => {
     `, `
       fn1(done =>
         fn2('string', function(object) {
-          
-        }
+          }
         , function(err, data) {
           const p = data;
           return done(err);

--- a/test/utils/formatCoffeeScriptAst_test.ts
+++ b/test/utils/formatCoffeeScriptAst_test.ts
@@ -1,5 +1,5 @@
 import { strictEqual } from 'assert';
-import {nodes} from 'decaffeinate-coffeescript';
+import {nodes} from 'decaffeinate-coffeescript2';
 import CodeContext from '../../src/utils/CodeContext';
 import formatCoffeeScriptAst from '../../src/utils/formatCoffeeScriptAst';
 import stripSharedIndent from '../../src/utils/stripSharedIndent';
@@ -20,25 +20,34 @@ describe('formatCoffeeScriptAst', () => {
             operatorToken: undefined
             moduleDeclaration: undefined
             variable: Value [1:1(0)-1:2(1)] {
+              isDefaultValue: false
               base: IdentifierLiteral [1:1(0)-1:2(1)] {
                 value: "x"
               }
               properties: []
             }
-            value: Call [1:5(4)-1:8(7)] {
-              soak: false
-              isNew: false
-              variable: Value [1:5(4)-1:6(5)] {
-                base: IdentifierLiteral [1:5(4)-1:6(5)] {
-                  value: "a"
+            value: Value [1:5(4)-1:8(7)] {
+              isDefaultValue: false
+              base: Call [1:5(4)-1:8(7)] {
+                soak: false
+                token: undefined
+                isNew: false
+                csx: false
+                variable: Value [1:5(4)-1:6(5)] {
+                  isDefaultValue: false
+                  base: IdentifierLiteral [1:5(4)-1:6(5)] {
+                    value: "a"
+                  }
+                  properties: []
                 }
-                properties: []
+                args: []
               }
-              args: []
+              properties: []
             }
           }
         ]
       }
+
     `) + '\n');
   });
 
@@ -58,6 +67,7 @@ describe('formatCoffeeScriptAst', () => {
             cases: [
               [
                 Value [2:8(14)-2:9(15)] {
+                  isDefaultValue: false
                   base: NumberLiteral [2:8(14)-2:9(15)] {
                     value: "1"
                   }
@@ -66,6 +76,7 @@ describe('formatCoffeeScriptAst', () => {
                 Block [3:5(20)-3:6(21)] {
                   expressions: [
                     Value [3:5(20)-3:6(21)] {
+                      isDefaultValue: false
                       base: NumberLiteral [3:5(20)-3:6(21)] {
                         value: "2"
                       }

--- a/test/utils/formatCoffeeScriptLexerTokens_test.ts
+++ b/test/utils/formatCoffeeScriptLexerTokens_test.ts
@@ -1,5 +1,5 @@
 import { strictEqual } from 'assert';
-import { tokens } from 'decaffeinate-coffeescript';
+import { tokens } from 'decaffeinate-coffeescript2';
 import CodeContext from '../../src/utils/CodeContext';
 import formatCoffeeScriptLexerTokens from '../../src/utils/formatCoffeeScriptLexerTokens';
 import stripSharedIndent from '../../src/utils/stripSharedIndent';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1257,17 +1257,22 @@ debug@3.1.0, debug@^3.0.1:
   dependencies:
     ms "2.0.0"
 
+decaffeinate-coffeescript2@2.2.1-patch.1:
+  version "2.2.1-patch.1"
+  resolved "https://registry.yarnpkg.com/decaffeinate-coffeescript2/-/decaffeinate-coffeescript2-2.2.1-patch.1.tgz#e63a33cfb5870534107b82cb2604f1e4ff126684"
+
 decaffeinate-coffeescript@1.12.7-patch.2:
   version "1.12.7-patch.2"
   resolved "https://registry.yarnpkg.com/decaffeinate-coffeescript/-/decaffeinate-coffeescript-1.12.7-patch.2.tgz#c0a453395e0194bcf0dce8d81dbf7170c5a1d578"
 
-decaffeinate-parser@^20.2.2:
-  version "20.2.2"
-  resolved "https://registry.yarnpkg.com/decaffeinate-parser/-/decaffeinate-parser-20.2.2.tgz#589d00e6694327b707c74b29dea17c9732aa696c"
+decaffeinate-parser@^21.0.1:
+  version "21.0.1"
+  resolved "https://registry.yarnpkg.com/decaffeinate-parser/-/decaffeinate-parser-21.0.1.tgz#86f4c43a8a3819e64e2ce467cc00f058b4c7f33e"
   dependencies:
     babylon "^6.18.0"
     coffee-lex "^8.1.1"
     decaffeinate-coffeescript "1.12.7-patch.2"
+    decaffeinate-coffeescript2 "2.2.1-patch.1"
     json-stable-stringify "^1.0.1"
     lines-and-columns "^1.1.6"
 


### PR DESCRIPTION
This does not yet enable any CS2 features, but sets things up to enable a CS2
mode. There were some minor changes around empty blocks, but that should only
affect formatting.

BREAKING CHANGE: Node 4 is no longer supported.