### PR TITLE
feat: add a `--use-cs2` option and implement LHS array spread

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ decaffeinate could be improved, feel free to file an issue on the [issues] page.
 
 ## Options
 
+* `--use-cs2`: Treat the input as CoffeeScript 2 code. CoffeeScript 2 has some
+  small breaking changes and differences in behavior compared with CS1, so
+  decaffeinate assumes CS1 by default and allows CS2 via this flag.
 * `--modernize-js`: Treat the input as JavaScript and only run the
   JavaScript-to-JavaScript transforms, modifying the file(s) in-place.
 * `--literate`: Treat the input file as Literate CoffeeScript.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,10 @@ function parseArguments(args: Array<string>): CLIOptions {
         process.exit(0);
         break;
 
+      case '--use-cs2':
+        baseOptions.useCS2 = true;
+        break;
+
       case '--modernize-js':
         modernizeJS = true;
         break;
@@ -246,6 +250,10 @@ function usage(): void {
   console.log('OPTIONS');
   console.log();
   console.log('  -h, --help               Display this help message.');
+  console.log('  --use-cs2                Treat the input as CoffeeScript 2 code. CoffeeScript 2 has');
+  console.log('                           some small breaking changes and differences in behavior');
+  console.log('                           compared with CS1, so decaffeinate assumes CS1 by default');
+  console.log('                           and allows CS2 via this flag.');
   console.log('  --modernize-js           Treat the input as JavaScript and only run the');
   console.log('                           JavaScript-to-JavaScript transforms, modifying the file(s)');
   console.log('                           in-place.');

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -53,6 +53,14 @@ describe('decaffeinate CLI', () => {
     `);
   });
 
+  it('respects the --use-cs2 flag', () => {
+    runCli('--use-cs2', `
+      a = [...b, c]
+    `, `
+      const a = [...b, c];
+    `);
+  });
+
   it('respects the --literate flag', () => {
     runCli('--literate', `
       This is a literate file.

--- a/test/spread_test.ts
+++ b/test/spread_test.ts
@@ -1,20 +1,36 @@
-import check from './support/check';
+import {checkCS1, checkCS2} from './support/check';
 import validate from './support/validate';
 
 describe('spread', () => {
   it('handles simple function calls', () => {
-    check(`
+    checkCS1(`
       a(b...)
     `, `
       a(...Array.from(b || []));
     `);
   });
 
+  it('handles simple function calls in CS2', () => {
+    checkCS2(`
+      a(b...)
+    `, `
+      a(...b);
+    `);
+  });
+
   it('handles advanced function calls', () => {
-    check(`
+    checkCS1(`
       a(1, 2, makeArray(arguments...)...)
     `, `
       a(1, 2, ...Array.from(makeArray(...arguments)));
+    `);
+  });
+
+  it('handles advanced function calls in CS2', () => {
+    checkCS2(`
+      a(1, 2, makeArray(arguments...)...)
+    `, `
+      a(1, 2, ...makeArray(...arguments));
     `);
   });
 
@@ -34,18 +50,34 @@ describe('spread', () => {
   });
 
   it('handles simple array literals', () => {
-    check(`
+    checkCS1(`
       [b...]
     `, `
       [...Array.from(b)];
     `);
   });
 
+  it('handles simple array literals in CS2', () => {
+    checkCS2(`
+      [b...]
+    `, `
+      [...b];
+    `);
+  });
+
   it('handles advanced array literals', () => {
-    check(`
+    checkCS1(`
       [1, 2, makeArray(arguments...)...]
     `, `
       [1, 2, ...Array.from(makeArray(...arguments))];
+    `);
+  });
+
+  it('handles advanced array literals in CS2', () => {
+    checkCS2(`
+      [1, 2, makeArray(arguments...)...]
+    `, `
+      [1, 2, ...makeArray(...arguments)];
     `);
   });
 
@@ -54,5 +86,13 @@ describe('spread', () => {
       obj = {length: 2, 0: 'a', 1: 'b'}
       setResult([1, 2, obj...])
     `, [1, 2, 'a', 'b']);
+  });
+
+  it('handles array spread with the operator on the LHS', () => {
+    checkCS2(`
+      a = [...b, c]
+    `, `
+      const a = [...b, c];
+    `);
   });
 });


### PR DESCRIPTION
Progress toward https://github.com/decaffeinate/decaffeinate/issues/427

There's still new syntax and semantics to support, but this gets the beginnings
of a CS2 mode.

For array spread on the left-hand side, we now detect where the ellipsis is and
don't change it if it's already on the left. We also skip Array.from in CS2
mode.