### PR TITLE
chore: run update-website as part of the release step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ jobs:
       deploy:
         provider: script
         skip_cleanup: true
-        script: 'yarn install && yarn build && npx semantic-release'
+        script: 'yarn install && yarn build && npx semantic-release && yarn update-website'
         on:
           branch: master


### PR DESCRIPTION
Looks like this got dropped when moving to build stages.