### PR TITLE
chore: skip isPrimaryInstance check when updating website

### DIFF
--- a/script/update-website.ts
+++ b/script/update-website.ts
@@ -67,22 +67,6 @@ async function hasChanges(): Promise<boolean> {
   }
 }
 
-/**
- * Travis jobs numbers have the build number, then a period, then the job number
- * within that build. So if the build number is "4", the job number might be
- * "4.1". If we have a job number then we're the primary instance if we are the
- * first job of our build.
- */
-function isPrimaryInstance(): boolean {
-  let jobNumber = process.env['TRAVIS_JOB_NUMBER'];
-
-  if (!jobNumber) {
-    return true;
-  }
-
-  return jobNumber.endsWith('.1');
-}
-
 async function updateWebsite(): Promise<void> {
   await configureGithubRemote('website', 'decaffeinate/decaffeinate-project.org');
 
@@ -131,12 +115,8 @@ async function updateWebsite(): Promise<void> {
   await run('git', ['reset', '--hard', currentRef]);
 }
 
-if (isPrimaryInstance()) {
-  updateWebsite()
-    .catch(err => {
-      console.error(err.stack);
-      process.exit(1);
-    });
-} else {
-  console.log('Skipping website update since this is not the primary instance.');
-}
+updateWebsite()
+  .catch(err => {
+    console.error(err.stack);
+    process.exit(1);
+  });


### PR DESCRIPTION
Looks like this was causing the website to not be updated. With build stages, we
now don't need to do this check.