### PR TITLE
feat: update repl-related code to support new repl changes

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,12 +96,7 @@ function parseArguments(args: Array<string>): CLIOptions {
         break;
 
       case '--loose':
-        baseOptions.looseDefaultParams = true;
-        baseOptions.looseForExpressions = true;
-        baseOptions.looseForOf = true;
-        baseOptions.looseIncludes = true;
-        baseOptions.looseComparisonNegation = true;
-        baseOptions.looseJSModules = true;
+        baseOptions.loose = true;
         break;
 
       case '--loose-default-params':

--- a/src/options.ts
+++ b/src/options.ts
@@ -10,6 +10,7 @@ export type Options = {
   looseJSModules?: boolean,
   safeImportFunctionIdentifiers?: Array<string>,
   preferLet?: boolean,
+  loose?: boolean,
   looseDefaultParams?: boolean,
   looseForExpressions?: boolean,
   looseForOf?: boolean,
@@ -31,6 +32,7 @@ export const DEFAULT_OPTIONS: Options = {
   looseJSModules: false,
   safeImportFunctionIdentifiers: [],
   preferLet: false,
+  loose: false,
   looseDefaultParams: false,
   looseForExpressions: false,
   looseForOf: false,
@@ -39,3 +41,18 @@ export const DEFAULT_OPTIONS: Options = {
   disableBabelConstructorWorkaround: false,
   disallowInvalidConstructors: false,
 };
+
+export function resolveOptions(options: Options): Options {
+  if (options.loose) {
+    options = {
+      ...options,
+      looseDefaultParams: true,
+      looseForExpressions: true,
+      looseForOf: true,
+      looseIncludes: true,
+      looseComparisonNegation: true,
+      looseJSModules: true,
+    };
+  }
+  return {...DEFAULT_OPTIONS, ...options};
+}

--- a/src/utils/formatCoffeeScriptAst.ts
+++ b/src/utils/formatCoffeeScriptAst.ts
@@ -1,13 +1,14 @@
-import { Base } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
+import { Base as CS1Base } from 'decaffeinate-coffeescript/lib/coffee-script/nodes';
+import { Base as CS2Base } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes';
 import CodeContext from './CodeContext';
 import formatCoffeeScriptLocationData from './formatCoffeeScriptLocationData';
 
-export default function formatCoffeeScriptAst(program: Base, context: CodeContext): string {
+export default function formatCoffeeScriptAst(program: CS1Base | CS2Base, context: CodeContext): string {
   let resultLines = formatAstNodeLines(program, context);
   return resultLines.map(line => line + '\n').join('');
 }
 
-function formatAstNodeLines(node: Base, context: CodeContext): Array<string> {
+function formatAstNodeLines(node: CS1Base | CS2Base, context: CodeContext): Array<string> {
   let propLines = [];
   let blacklistedProps = ['locationData'];
   // Show the non-node children first.
@@ -66,5 +67,5 @@ function shouldTraverse(value: any): boolean {
   if (Array.isArray(value)) {
     return value.length === 0 || shouldTraverse(value[0]);
   }
-  return value instanceof Base;
+  return value instanceof CS1Base || value instanceof CS2Base;
 }

--- a/test/utils/formatCoffeeScriptAst_test.ts
+++ b/test/utils/formatCoffeeScriptAst_test.ts
@@ -1,5 +1,6 @@
 import { strictEqual } from 'assert';
-import {nodes} from 'decaffeinate-coffeescript2';
+import {nodes as cs1Nodes} from 'decaffeinate-coffeescript';
+import {nodes as cs2Nodes} from 'decaffeinate-coffeescript2';
 import CodeContext from '../../src/utils/CodeContext';
 import formatCoffeeScriptAst from '../../src/utils/formatCoffeeScriptAst';
 import stripSharedIndent from '../../src/utils/stripSharedIndent';
@@ -9,7 +10,7 @@ describe('formatCoffeeScriptAst', () => {
     let source = stripSharedIndent(`
       x = a()
     `);
-    let formattedTokens = formatCoffeeScriptAst(nodes(source), new CodeContext(source));
+    let formattedTokens = formatCoffeeScriptAst(cs2Nodes(source), new CodeContext(source));
     strictEqual(formattedTokens, stripSharedIndent(`
       Block [1:1(0)-1:8(7)] {
         expressions: [
@@ -57,7 +58,7 @@ describe('formatCoffeeScriptAst', () => {
         when 1
           2
     `);
-    let formattedTokens = formatCoffeeScriptAst(nodes(source), new CodeContext(source));
+    let formattedTokens = formatCoffeeScriptAst(cs2Nodes(source), new CodeContext(source));
     strictEqual(formattedTokens, stripSharedIndent(`
       Block [1:1(0)-3:6(21)] {
         expressions: [
@@ -86,6 +87,38 @@ describe('formatCoffeeScriptAst', () => {
                 }
               ]
             ]
+          }
+        ]
+      }
+    `) + '\n');
+  });
+
+  it('properly formats CS1 code', () => {
+    let source = stripSharedIndent(`
+      x = 1
+    `);
+    let formattedTokens = formatCoffeeScriptAst(cs1Nodes(source), new CodeContext(source));
+    strictEqual(formattedTokens, stripSharedIndent(`
+      Block [1:1(0)-1:6(5)] {
+        expressions: [
+          Assign [1:1(0)-1:6(5)] {
+            context: undefined
+            param: undefined
+            subpattern: undefined
+            operatorToken: undefined
+            moduleDeclaration: undefined
+            variable: Value [1:1(0)-1:2(1)] {
+              base: IdentifierLiteral [1:1(0)-1:2(1)] {
+                value: "x"
+              }
+              properties: []
+            }
+            value: Value [1:5(4)-1:6(5)] {
+              base: NumberLiteral [1:5(4)-1:6(5)] {
+                value: "1"
+              }
+              properties: []
+            }
           }
         ]
       }


### PR DESCRIPTION
* Add support for a `loose` option passed programmatically instead of just
  through the CLI.
* Make all intermediate steps specify cs1 or cs2.