### PR TITLE
feat: add support for object rest in CS2

### DIFF
--- a/src/stages/main/patchers/ObjectInitialiserPatcher.ts
+++ b/src/stages/main/patchers/ObjectInitialiserPatcher.ts
@@ -6,6 +6,7 @@ import { isSemanticToken } from '../../../utils/types';
 import NodePatcher from './../../../patchers/NodePatcher';
 import AssignOpPatcher from './AssignOpPatcher';
 import ObjectInitialiserMemberPatcher from './ObjectInitialiserMemberPatcher';
+import SpreadPatcher from './SpreadPatcher';
 
 export type OpenCurlyInfo = {
   curlyBraceInsertionPosition: number,
@@ -17,7 +18,7 @@ export type OpenCurlyInfo = {
  * Handles object literals.
  */
 export default class ObjectInitialiserPatcher extends NodePatcher {
-  members: Array<ObjectInitialiserMemberPatcher | AssignOpPatcher>;
+  members: Array<ObjectInitialiserMemberPatcher | AssignOpPatcher | SpreadPatcher>;
 
   constructor(patcherContext: PatcherContext, members: Array<ObjectInitialiserMemberPatcher | AssignOpPatcher>) {
     super(patcherContext);

--- a/src/utils/canPatchAssigneeToJavaScript.ts
+++ b/src/utils/canPatchAssigneeToJavaScript.ts
@@ -51,7 +51,15 @@ export default function canPatchAssigneeToJavaScript(node: Node, isTopLevel: boo
     if (node.members.length === 0) {
       return false;
     }
-    return node.members.every(node => canPatchAssigneeToJavaScript(node, false));
+    return node.members.every((member, i) => {
+      let isInFinalPosition = i === node.members.length - 1;
+      if (isInFinalPosition &&
+        (member instanceof Spread || member instanceof Rest) &&
+        canPatchAssigneeToJavaScript(member.expression)) {
+        return true;
+      }
+      return canPatchAssigneeToJavaScript(member, false);
+    });
   }
   if (node instanceof ObjectInitialiserMember) {
     return canPatchAssigneeToJavaScript(node.expression || node.key, false);

--- a/src/utils/getObjectAssigneeKeys.ts
+++ b/src/utils/getObjectAssigneeKeys.ts
@@ -1,0 +1,21 @@
+/**
+ * Determine the keys explicitly removed from this object assignment, so that we know which keys to
+ * omit when processing a rest operation.
+ */
+import AssignOpPatcher from '../stages/main/patchers/AssignOpPatcher';
+import IdentifierPatcher from '../stages/main/patchers/IdentifierPatcher';
+import ObjectInitialiserMemberPatcher from '../stages/main/patchers/ObjectInitialiserMemberPatcher';
+import ObjectInitialiserPatcher from '../stages/main/patchers/ObjectInitialiserPatcher';
+
+export default function getObjectAssigneeKeys(node: ObjectInitialiserPatcher): Array<string> {
+  let results: Array<string> = [];
+  for (let member of node.members) {
+    // We ignore non-identifier keys, since CoffeeScript doesn't seem to handle them properly.
+    if (member instanceof ObjectInitialiserMemberPatcher && member.key instanceof IdentifierPatcher) {
+      results.push(member.key.node.data);
+    } else if (member instanceof AssignOpPatcher && member.assignee instanceof IdentifierPatcher) {
+      results.push(member.assignee.node.data);
+    }
+  }
+  return results;
+}

--- a/test/expansion_test.ts
+++ b/test/expansion_test.ts
@@ -1,4 +1,4 @@
-import check from './support/check';
+import check, {checkCS2} from './support/check';
 import validate from './support/validate';
 
 describe('expansion', () => {
@@ -417,5 +417,32 @@ describe('expansion', () => {
       [a, b..., c, d] = [1, 2]
       setResult([a, b, c, d])
     `, [1, [], 2, undefined]);
+  });
+
+  it('handles nested rest after an array expansion ', () => {
+    checkCS2(`
+      [...,{a, r..., b = c}] = arr
+    `, `
+      const obj = arr[arr.length - 1],
+        { a } = obj,
+        r = __objectWithoutKeys__(obj, ['a', 'b']),
+        val = obj.b,
+        b = val != null ? val : c;
+      function __objectWithoutKeys__(object, keys) {
+        const result = {...object};
+        for (const k of keys) {
+          delete result[keys];
+        }
+        return result;
+      }
+    `);
+  });
+
+  it('emits JS object rest when possible ', () => {
+    checkCS2(`
+      [...,{a, r...}] = arr
+    `, `
+      const {a, ...r} = arr[arr.length - 1];
+    `);
   });
 });


### PR DESCRIPTION
When the object rest is simple and at the end of the object assignment, we can
emit a normal JS object rest. In other situations, we need to emit a helper and
call that helper.