### PR TITLE
feat: add basic support for array elisions

### DIFF
--- a/src/stages/main/index.ts
+++ b/src/stages/main/index.ts
@@ -20,6 +20,7 @@ import ContinuePatcher from './patchers/ContinuePatcher';
 import DefaultParamPatcher from './patchers/DefaultParamPatcher';
 import DoOpPatcher from './patchers/DoOpPatcher';
 import DynamicMemberAccessOpPatcher from './patchers/DynamicMemberAccessOpPatcher';
+import ElisionPatcher from './patchers/ElisionPatcher';
 import EqualityPatcher from './patchers/EqualityPatcher';
 import ExistsOpCompoundAssignOpPatcher from './patchers/ExistsOpCompoundAssignOpPatcher';
 import ExistsOpPatcher from './patchers/ExistsOpPatcher';
@@ -272,6 +273,9 @@ export default class MainStage extends TransformCoffeeScriptStage {
 
       case 'Expansion':
         return ExpansionPatcher;
+
+      case 'Elision':
+        return ElisionPatcher;
 
       case 'Rest':
         return RestPatcher;

--- a/src/stages/main/patchers/ArrayInitialiserPatcher.ts
+++ b/src/stages/main/patchers/ArrayInitialiserPatcher.ts
@@ -1,6 +1,7 @@
 import { SourceType } from 'coffee-lex';
 import { PatcherContext } from '../../../patchers/types';
 import NodePatcher from './../../../patchers/NodePatcher';
+import ElisionPatcher from './ElisionPatcher';
 import ExpansionPatcher from './ExpansionPatcher';
 
 export default class ArrayInitialiserPatcher extends NodePatcher {
@@ -30,7 +31,9 @@ export default class ArrayInitialiserPatcher extends NodePatcher {
         return;
       }
 
-      let needsComma = !isLast && !member.hasSourceTokenAfter(SourceType.COMMA);
+      let needsComma = !isLast &&
+        !member.hasSourceTokenAfter(SourceType.COMMA) &&
+        !(member instanceof ElisionPatcher);
       member.patch();
       if (needsComma) {
         this.insert(member.outerEnd, ',');

--- a/src/stages/main/patchers/AssignOpPatcher.ts
+++ b/src/stages/main/patchers/AssignOpPatcher.ts
@@ -13,6 +13,7 @@ import ArrayInitialiserPatcher from './ArrayInitialiserPatcher';
 import ConditionalPatcher from './ConditionalPatcher';
 import DoOpPatcher from './DoOpPatcher';
 import DynamicMemberAccessOpPatcher from './DynamicMemberAccessOpPatcher';
+import ElisionPatcher from './ElisionPatcher';
 import ExpansionPatcher from './ExpansionPatcher';
 import FunctionApplicationPatcher from './FunctionApplicationPatcher';
 import FunctionPatcher from './FunctionPatcher';
@@ -185,6 +186,9 @@ export default class AssignOpPatcher extends NodePatcher {
       }
     } else if (patcher instanceof ExpansionPatcher) {
       // Expansions don't produce assignments.
+      return [];
+    } else if (patcher instanceof ElisionPatcher) {
+      // Elisions don't produce assignments.
       return [];
     } else if (patcher instanceof SpreadPatcher) {
       // Calling code seeing a spread patcher should provide an expression for

--- a/src/stages/main/patchers/ElisionPatcher.ts
+++ b/src/stages/main/patchers/ElisionPatcher.ts
@@ -1,0 +1,9 @@
+import NodePatcher from './../../../patchers/NodePatcher';
+
+export default class ElisionPatcher extends NodePatcher {
+  _elisionPatcherBrand: never;
+
+  patchAsExpression(): void {
+    // Nothing to patch.
+  }
+}

--- a/src/utils/canPatchAssigneeToJavaScript.ts
+++ b/src/utils/canPatchAssigneeToJavaScript.ts
@@ -8,7 +8,7 @@
  * JS falls back to the default if the value only if the value is undefined.
  */
 import {
-  ArrayInitialiser, DynamicMemberAccessOp, Expansion, Identifier,
+  ArrayInitialiser, DynamicMemberAccessOp, Elision, Expansion, Identifier,
   MemberAccessOp, Node, ObjectInitialiser, ObjectInitialiserMember,
   ProtoMemberAccessOp, Rest, SoakedDynamicMemberAccessOp, SoakedMemberAccessOp,
   SoakedProtoMemberAccessOp, Spread
@@ -18,7 +18,7 @@ export default function canPatchAssigneeToJavaScript(node: Node, isTopLevel: boo
   if (node instanceof Identifier || node instanceof MemberAccessOp ||
       node instanceof SoakedMemberAccessOp || node instanceof ProtoMemberAccessOp ||
       node instanceof DynamicMemberAccessOp || node instanceof SoakedDynamicMemberAccessOp ||
-      node instanceof SoakedProtoMemberAccessOp) {
+      node instanceof SoakedProtoMemberAccessOp || node instanceof Elision) {
     return true;
   }
   if (node instanceof ArrayInitialiser) {

--- a/src/utils/normalizeListItem.ts
+++ b/src/utils/normalizeListItem.ts
@@ -4,7 +4,7 @@
  * syntax in the normalize stage.
  */
 import { SourceType } from 'coffee-lex';
-import { Block } from 'decaffeinate-parser/dist/nodes';
+import {Block, Elision} from 'decaffeinate-parser/dist/nodes';
 import NodePatcher from '../patchers/NodePatcher';
 import containsDescendant from './containsDescendant';
 import notNull from './notNull';
@@ -17,7 +17,7 @@ export default function normalizeListItem(
   // when combined with other normalize stage transformations. So just
   // remove the redundant comma.
   let lastToken = listItemPatcher.lastToken();
-  if (lastToken.type === SourceType.COMMA) {
+  if (lastToken.type === SourceType.COMMA && !(listItemPatcher.node instanceof Elision)) {
     patcher.remove(lastToken.start, lastToken.end);
   }
   // CoffeeScript allows semicolon-separated lists, so just change them to

--- a/test/expansion_test.ts
+++ b/test/expansion_test.ts
@@ -445,4 +445,13 @@ describe('expansion', () => {
       const {a, ...r} = arr[arr.length - 1];
     `);
   });
+
+  it('allows array elisions', () => {
+    checkCS2(`
+      [a, , b] = [1, , 3]
+    `, `
+      let a, b;
+      [a, , b] = Array.from([1, , 3]);
+    `);
+  });
 });


### PR DESCRIPTION
It looks like add-variable-declarations isn't yet smart enough to place the
`var` in the best place, and we still unnecessarily use `Array.from` in CS2,
but this should be correct.