### PR TITLE
fix: don't convert complex object rest assignments to JS

### DIFF
--- a/src/utils/canPatchAssigneeToJavaScript.ts
+++ b/src/utils/canPatchAssigneeToJavaScript.ts
@@ -53,9 +53,11 @@ export default function canPatchAssigneeToJavaScript(node: Node, isTopLevel: boo
     }
     return node.members.every((member, i) => {
       let isInFinalPosition = i === node.members.length - 1;
-      if (isInFinalPosition &&
+      if (
+        isInFinalPosition &&
         (member instanceof Spread || member instanceof Rest) &&
-        canPatchAssigneeToJavaScript(member.expression)) {
+        member.expression instanceof Identifier
+      ) {
         return true;
       }
       return canPatchAssigneeToJavaScript(member, false);

--- a/test/expansion_test.ts
+++ b/test/expansion_test.ts
@@ -454,4 +454,19 @@ describe('expansion', () => {
       [a, , b] = Array.from([1, , 3]);
     `);
   });
+
+  it('does not convert nested object rest operations to JS', () => {
+    checkCS2(`
+      {...{...a}} = b
+    `, `
+      const {...a} = __objectWithoutKeys__(b, []);
+      function __objectWithoutKeys__(object, keys) {
+        const result = {...object};
+        for (const k of keys) {
+          delete result[keys];
+        }
+        return result;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
JS object rest appears to only allow assigning to identifiers, but CS allows
complex expressions, so fall back to ugly code if it's anything other than an
identifier.