### PR TITLE
fix: remove parens from the inside of a block instead of the outside

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "coffee-lex": "^9.1.0",
     "decaffeinate-coffeescript": "1.12.7-patch.2",
     "decaffeinate-coffeescript2": "2.2.1-patch.3",
-    "decaffeinate-parser": "^22.3.1",
+    "decaffeinate-parser": "^22.4.2",
     "detect-indent": "^4.0.0",
     "esnext": "^3.2.0",
     "lines-and-columns": "^1.1.5",

--- a/test/function_call_test.ts
+++ b/test/function_call_test.ts
@@ -761,4 +761,12 @@ describe('function calls', () => {
       );
     `);
   });
+
+  it('properly handles empty function expressions surrounded by parens', () => {
+    check(`
+      middleware.execute {}, (->), (->)
+    `, `
+      middleware.execute({}, (function() {}), (function() {}));
+    `);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -798,9 +798,9 @@ decaffeinate-coffeescript@1.12.7-patch.2:
   version "1.12.7-patch.2"
   resolved "https://registry.yarnpkg.com/decaffeinate-coffeescript/-/decaffeinate-coffeescript-1.12.7-patch.2.tgz#c0a453395e0194bcf0dce8d81dbf7170c5a1d578"
 
-decaffeinate-parser@^22.3.1:
-  version "22.3.1"
-  resolved "https://registry.yarnpkg.com/decaffeinate-parser/-/decaffeinate-parser-22.3.1.tgz#bbe6a57563750173d45eac1657a1e87c68cba208"
+decaffeinate-parser@^22.4.2:
+  version "22.4.2"
+  resolved "https://registry.yarnpkg.com/decaffeinate-parser/-/decaffeinate-parser-22.4.2.tgz#b789f04bdcfb17abecca7f0e2b803a35d77ba05d"
   dependencies:
     babylon "^6.18.0"
     coffee-lex "^9.1.0"


### PR DESCRIPTION
The parser details for blocks surrounded by parens have been tweaked so that the
block bounds include the parens. That means we can't just remove parens
surrounding the block; we need to find interior parens not attached to a child
and remove those. This fixes a test regression from a decaffeinate-parser
change.