### PR TITLE
fix: implement various semantics differences between CS1 and CS2

### DIFF
--- a/src/stages/normalize/patchers/ForPatcher.ts
+++ b/src/stages/normalize/patchers/ForPatcher.ts
@@ -84,7 +84,7 @@ export default class ForPatcher extends NodePatcher {
     if (!this.valAssignee) {
       throw this.error('Expected to find a valAssignee.');
     }
-    if (canPatchAssigneeToJavaScript(this.valAssignee.node)) {
+    if (canPatchAssigneeToJavaScript(this.valAssignee.node, this.options)) {
       this.valAssignee.patch();
       return null;
     } else {

--- a/src/stages/normalize/patchers/FunctionPatcher.ts
+++ b/src/stages/normalize/patchers/FunctionPatcher.ts
@@ -214,7 +214,7 @@ export default class FunctionPatcher extends NodePatcher {
       // We have separate code to handle relatively simple default params that
       // results in better code, so use that.
       if (parameter instanceof DefaultParamPatcher &&
-          canPatchAssigneeToJavaScript(parameter.param.node)) {
+          canPatchAssigneeToJavaScript(parameter.param.node, this.options)) {
         continue;
       }
 
@@ -226,8 +226,8 @@ export default class FunctionPatcher extends NodePatcher {
         continue;
       }
 
-      if (parameter instanceof ArrayInitialiserPatcher ||
-          !canPatchAssigneeToJavaScript(parameter.node)) {
+      if ((!this.options.useCS2 && parameter instanceof ArrayInitialiserPatcher) ||
+          !canPatchAssigneeToJavaScript(parameter.node, this.options)) {
         return i;
       }
     }

--- a/src/utils/canPatchAssigneeToJavaScript.ts
+++ b/src/utils/canPatchAssigneeToJavaScript.ts
@@ -8,13 +8,16 @@
  * JS falls back to the default if the value only if the value is undefined.
  */
 import {
-  ArrayInitialiser, DynamicMemberAccessOp, Elision, Expansion, Identifier,
+  ArrayInitialiser, AssignOp, DynamicMemberAccessOp, Elision, Expansion, Identifier,
   MemberAccessOp, Node, ObjectInitialiser, ObjectInitialiserMember,
   ProtoMemberAccessOp, Rest, SoakedDynamicMemberAccessOp, SoakedMemberAccessOp,
   SoakedProtoMemberAccessOp, Spread
 } from 'decaffeinate-parser/dist/nodes';
+import {Options} from '../options';
 
-export default function canPatchAssigneeToJavaScript(node: Node, isTopLevel: boolean = true): boolean {
+export default function canPatchAssigneeToJavaScript(
+  node: Node, options: Options, isTopLevel: boolean = true
+): boolean {
   if (node instanceof Identifier || node instanceof MemberAccessOp ||
       node instanceof SoakedMemberAccessOp || node instanceof ProtoMemberAccessOp ||
       node instanceof DynamicMemberAccessOp || node instanceof SoakedDynamicMemberAccessOp ||
@@ -24,7 +27,7 @@ export default function canPatchAssigneeToJavaScript(node: Node, isTopLevel: boo
   if (node instanceof ArrayInitialiser) {
     // Nested array destructures can't convert cleanly because we need to wrap
     // them in Array.from.
-    if (!isTopLevel) {
+    if (!options.useCS2 && !isTopLevel) {
       return false;
     }
     // Empty destructure operations need to result in zero assignments, and thus
@@ -39,16 +42,18 @@ export default function canPatchAssigneeToJavaScript(node: Node, isTopLevel: boo
       }
       if (isInFinalPosition &&
           (member instanceof Spread || member instanceof Rest) &&
-          canPatchAssigneeToJavaScript(member.expression)) {
+          !(member.expression instanceof ObjectInitialiser) &&
+          canPatchAssigneeToJavaScript(member.expression, options, false)) {
         return true;
       }
-      return canPatchAssigneeToJavaScript(member, false);
+      return canPatchAssigneeToJavaScript(member, options, false);
     });
   }
   if (node instanceof ObjectInitialiser) {
     // JS empty destructure crashes if the RHS is undefined or null, so more
-    // precisely copy the behavior for empty destructures.
-    if (node.members.length === 0) {
+    // precisely copy the behavior for empty destructures. CS2 does not have this
+    // behavior.
+    if (!options.useCS2 && node.members.length === 0) {
       return false;
     }
     return node.members.every((member, i) => {
@@ -60,11 +65,15 @@ export default function canPatchAssigneeToJavaScript(node: Node, isTopLevel: boo
       ) {
         return true;
       }
-      return canPatchAssigneeToJavaScript(member, false);
+      return canPatchAssigneeToJavaScript(member, options, false);
     });
   }
   if (node instanceof ObjectInitialiserMember) {
-    return canPatchAssigneeToJavaScript(node.expression || node.key, false);
+    return canPatchAssigneeToJavaScript(node.expression || node.key, options, false);
+  }
+  // Defaults work in CS2, but top-level assignments are never defaults.
+  if (options.useCS2 && node instanceof AssignOp && !isTopLevel) {
+    return canPatchAssigneeToJavaScript(node.assignee, options, false);
   }
   return false;
 }

--- a/test/class_test.ts
+++ b/test/class_test.ts
@@ -1,6 +1,6 @@
 import assertError from './support/assertError';
-import check, {checkCS1} from './support/check';
-import validate from './support/validate';
+import check, {checkCS1, checkCS2} from './support/check';
+import validate, {validateCS1} from './support/validate';
 
 describe('classes', () => {
   it('converts named classes without bodies', () => {
@@ -115,7 +115,7 @@ describe('classes', () => {
 
   describe('assign properties from method parameters', () => {
     it('constructor without function body', () => {
-      check(`
+      checkCS1(`
         class A
           constructor: ([@a = 1], {test: @b = 2}, @c) ->
       `, `
@@ -129,6 +129,18 @@ describe('classes', () => {
               val1 = obj.test,
               this.b = val1 != null ? val1 : 2,
               this.c = args[2];
+          }
+        }
+      `);
+      checkCS2(`
+        class A
+          constructor: ([@a = 1], {test: @b = 2}, @c) ->
+      `, `
+        class A {
+          constructor([a = 1], {test: b = 2}, c) {
+            this.a = a;
+            this.b = b;
+            this.c = c;
           }
         }
       `);
@@ -1193,7 +1205,7 @@ describe('classes', () => {
   });
 
   it('has correct behavior with a standalone prototype super call', () => {
-    validate(`
+    validateCS1(`
       class A
         c: -> 3
       class B extends A
@@ -1204,7 +1216,7 @@ describe('classes', () => {
   });
 
   it('forwards function arguments on empty super, even if the arguments are for an inner function', () => {
-    validate(`
+    validateCS1(`
       class A
         c: (x) -> x + 5
       class B extends A
@@ -1717,7 +1729,7 @@ describe('classes', () => {
   });
 
   it('behaves correctly for dynamic prototype method assignments', () => {
-    validate(`
+    validateCS1(`
       class Base
         f: -> 1
         g: -> 2
@@ -1849,7 +1861,7 @@ describe('classes', () => {
   });
 
   it('behaves properly with conditionally assigned static methods with super', () => {
-    validate(`
+    validateCS1(`
       class A
         @a = -> 3
       class B extends A
@@ -1860,7 +1872,7 @@ describe('classes', () => {
   });
 
   it('behaves properly with conditionally assigned static methods with a dynamic name with super', () => {
-    validate(`
+    validateCS1(`
       class A
         @a = -> 3
       m = 'a'

--- a/test/declaration_test.ts
+++ b/test/declaration_test.ts
@@ -1,4 +1,4 @@
-import check from './support/check';
+import check, {checkCS1, checkCS2} from './support/check';
 
 describe('declarations', () => {
   it('adds inline declarations for assignments as statements', () => {
@@ -87,7 +87,8 @@ describe('declarations', () => {
   });
 
   it('adds variable declarations for destructuring array assignment', () => {
-    check(`[a] = b`, `const [a] = Array.from(b);`);
+    checkCS1(`[a] = b`, `const [a] = Array.from(b);`);
+    checkCS2(`[a] = b`, `const [a] = b;`);
   });
 
   it('adds variable declarations for destructuring object assignment', () => {
@@ -95,12 +96,19 @@ describe('declarations', () => {
   });
 
   it('does not add variable declarations for destructuring array assignment with previously declared bindings', () => {
-    check(`
+    checkCS1(`
       a = 1
       [a] = b
     `, `
       let a = 1;
       [a] = Array.from(b);
+    `);
+    checkCS2(`
+      a = 1
+      [a] = b
+    `, `
+      let a = 1;
+      [a] = b;
     `);
   });
 
@@ -115,13 +123,21 @@ describe('declarations', () => {
   });
 
   it('does not add inline variable declarations when the destructuring is mixed', () => {
-    check(`
+    checkCS1(`
       a = 1
       [a, b] = c
     `, `
       let b;
       let a = 1;
       [a, b] = Array.from(c);
+    `);
+    checkCS2(`
+      a = 1
+      [a, b] = c
+    `, `
+      let b;
+      let a = 1;
+      [a, b] = c;
     `);
   });
 

--- a/test/for_test.ts
+++ b/test/for_test.ts
@@ -1,4 +1,4 @@
-import check from './support/check';
+import check, {checkCS1, checkCS2} from './support/check';
 import validate from './support/validate';
 
 describe('for loops', () => {
@@ -1273,12 +1273,22 @@ describe('for loops', () => {
   });
 
   it('handles a complex assignee in a postfix loop', () => {
-    check(`
+    checkCS1(`
       x = (a for [a = 1] in b)
     `, `
       const x = ((() => {
         const result = [];
         for (let value of Array.from(b)) {     const val = value[0], a = val != null ? val : 1; result.push(a);
+        }
+        return result;
+      })());
+    `);
+    checkCS2(`
+      x = (a for [a = 1] in b)
+    `, `
+      const x = ((() => {
+        const result = [];
+        for ([a = 1] of Array.from(b)) {     result.push(a);
         }
         return result;
       })());

--- a/test/function_call_test.ts
+++ b/test/function_call_test.ts
@@ -1,4 +1,4 @@
-import check, {checkCS1} from './support/check';
+import check, {checkCS1, checkCS2} from './support/check';
 
 describe('function calls', () => {
   it('inserts commas after arguments if they are not there', () => {
@@ -722,12 +722,18 @@ describe('function calls', () => {
     `);
   });
 
-  it('wraps parens around comma-separated simple in an argument position', () => {
-    check(`
+  it('wraps parens around comma-separated simple assignments in an argument position', () => {
+    checkCS1(`
       a([b] = c)
     `, `
       let b;
       a(([b] = Array.from(c), c));
+    `);
+    checkCS2(`
+      a([b] = c)
+    `, `
+      let b;
+      a(([b] = c));
     `);
   });
 

--- a/test/in_test.ts
+++ b/test/in_test.ts
@@ -208,7 +208,7 @@ describe('in operator', () => {
       arr = []
       arr.push('first') in [arr.push('second')]
       setResult(arr)
-    `, ['first', 'second'], { requireNode6: true });
+    `, ['first', 'second']);
   });
 
   it('handles an impure soak LHS', () => {

--- a/test/spread_test.ts
+++ b/test/spread_test.ts
@@ -1,5 +1,5 @@
 import {checkCS1, checkCS2} from './support/check';
-import validate from './support/validate';
+import validate, {validateCS1} from './support/validate';
 
 describe('spread', () => {
   it('handles simple function calls', () => {
@@ -37,12 +37,17 @@ describe('spread', () => {
   it('has the correct runtime behavior when spreading null in a function call', () => {
     validate(`
       f = -> arguments.length
-      setResult(f(null...))
-    `, 0);
+      try
+        # Works in CS1
+        setResult(f(null...))
+      catch
+        setResult('Fails in CS2')
+    `, {cs1: 0, cs2: 'Fails in CS2'});
   });
 
   it('has the correct runtime behavior when spreading a fake array in a function call', () => {
-    validate(`
+    // Ignore CS2 checking since Babel handles this case wrong and doesn't crash.
+    validateCS1(`
       f = -> arguments.length
       obj = {length: 2, 0: 'a', 1: 'b'}
       setResult(f(1, 2, obj...))
@@ -82,7 +87,8 @@ describe('spread', () => {
   });
 
   it('has the correct runtime behavior when spreading a fake array in an array literal', () => {
-    validate(`
+    // Ignore CS2 checking since Babel handles this case wrong and doesn't crash.
+    validateCS1(`
       obj = {length: 2, 0: 'a', 1: 'b'}
       setResult([1, 2, obj...])
     `, [1, 2, 'a', 'b']);


### PR DESCRIPTION
This isn't complete yet, but it gets closer. We now have separate validate
functions for CS1 and CS2 and are able to verify different results for each.
Generally, CS2 shouldn't emit `Array.from` and doesn't need to fall back to
expanded destructures as much.

Some details:
* We now need to be able to patch things like `{@a = 1} = b`, so implement the
  patcher for that.
* When patching default values, we may not surround the assignment in parens, so
  skip that case.
* When patching default values the expanded way, we need to do `!== undefined`
  as the check instead of `!= null`.
* Any `Array.from` in assignment expansion is no longer necessary.
* There are now various differences around what assignment operations we're
  willing to patch directly to JS vs expanding.