### PR TITLE
fix: move static keyword before async or * in methods

### DIFF
--- a/src/stages/main/patchers/ClassAssignOpPatcher.ts
+++ b/src/stages/main/patchers/ClassAssignOpPatcher.ts
@@ -31,10 +31,13 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
 
   patchAsExpression(): void {
     this.markKeyRepeatableIfNecessary();
+    if (this.isStaticMethod()) {
+      this.insert(this.key.outerStart, 'static ');
+    }
     super.patchAsExpression();
     if (this.isStaticMethod()) {
-      // `this.a: ->` → `static a: ->`
-      //  ^^^^^          ^^^^^^^
+      // `static this.a: ->` → `static a: ->`
+      //         ^^^^^
       let replaceEnd;
       if (this.key instanceof MemberAccessOpPatcher) {
         replaceEnd = this.key.getMemberNameSourceToken().start;
@@ -43,7 +46,7 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
       } else {
         throw this.error('Unexpected static method key type.');
       }
-      this.overwrite(this.key.outerStart, replaceEnd, 'static ');
+      this.remove(this.key.outerStart, replaceEnd);
     }
   }
 

--- a/test/class_test.ts
+++ b/test/class_test.ts
@@ -1907,4 +1907,32 @@ describe('classes', () => {
       
     `, {shouldStripIndent: false});
   });
+
+  it('handles static generator methods', () => {
+    check(`
+      class A
+        @b: ->
+          yield 1
+    `, `
+      class A {
+        static *b() {
+          return yield 1;
+        }
+      }
+    `);
+  });
+
+  it('handles static async methods', () => {
+    checkCS2(`
+      class A
+        @b: ->
+          await 1
+    `, `
+      class A {
+        static async b() {
+          return await 1;
+        }
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #1289