### PR TITLE
fix: properly remove `then` token from anonymous classes

### DIFF
--- a/src/stages/normalize/patchers/ClassPatcher.ts
+++ b/src/stages/normalize/patchers/ClassPatcher.ts
@@ -153,7 +153,7 @@ export default class ClassPatcher extends NodePatcher {
     } else if (this.nameAssignee) {
       searchStart = this.nameAssignee.outerEnd;
     } else {
-      searchStart = this.contentStart;
+      searchStart = this.firstToken().end;
     }
     let searchEnd;
     if (this.body) {

--- a/test/class_test.ts
+++ b/test/class_test.ts
@@ -1935,4 +1935,21 @@ describe('classes', () => {
       }
     `);
   });
+
+  it('handles anonymous classes with inline bodies', () => {
+    check(`
+      class then a = 1
+    `, `
+      (function() {
+        let a = undefined;
+        const Cls = class {
+          static initClass() {
+            a = 1;
+          }
+        };
+        Cls.initClass();
+        return Cls;
+      })();
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #1298

The code was deleting from the start of the class declaration, when it should
have been from the end of the `class` token.