### PR TITLE
fix: Changed the constructor hack to be more explicit for minifiers

### DIFF
--- a/src/utils/babelConstructorWorkaroundLines.ts
+++ b/src/utils/babelConstructorWorkaroundLines.ts
@@ -23,8 +23,8 @@ export default [
   '{',
   '  // Hack: trick Babel/TypeScript into allowing this before super.',
   '  if (false) { super(); }',
-  '  let thisFn = (() => { this }).toString();',
-  "  let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();",
+  '  let thisFn = (() => { return this; }).toString();',
+  "  let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();",
   '  eval(`${thisName} = this;`);',
   '}',
 ];

--- a/test/class_test.ts
+++ b/test/class_test.ts
@@ -361,8 +361,8 @@ describe('classes', () => {
             {
               // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
-              let thisFn = (() => { this; }).toString();
-              let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
+              let thisFn = (() => { return this; }).toString();
+              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
               eval(\`\${thisName} = this;\`);
             }
             this.a = 2;
@@ -383,8 +383,8 @@ describe('classes', () => {
             {
               // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
-              let thisFn = (() => { this; }).toString();
-              let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
+              let thisFn = (() => { return this; }).toString();
+              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
               eval(\`\${thisName} = this;\`);
             }
             this.a = 2;
@@ -404,8 +404,8 @@ describe('classes', () => {
             {
               // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
-              let thisFn = (() => { this; }).toString();
-              let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
+              let thisFn = (() => { return this; }).toString();
+              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
               eval(\`\${thisName} = this;\`);
             }
             this.foo = this.foo.bind(this);
@@ -434,8 +434,8 @@ describe('classes', () => {
             {
               // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
-              let thisFn = (() => { this; }).toString();
-              let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
+              let thisFn = (() => { return this; }).toString();
+              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
               eval(\`\${thisName} = this;\`);
             }
             this.foo = this.foo.bind(this);
@@ -463,8 +463,8 @@ describe('classes', () => {
             {
               // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
-              let thisFn = (() => { this; }).toString();
-              let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
+              let thisFn = (() => { return this; }).toString();
+              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
               eval(\`\${thisName} = this;\`);
             }
             this.foo = this.foo.bind(this);
@@ -505,8 +505,8 @@ describe('classes', () => {
             {
               // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
-              let thisFn = (() => { this; }).toString();
-              let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
+              let thisFn = (() => { return this; }).toString();
+              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
               eval(\`\${thisName} = this;\`);
             }
             if (c == null) { c = {}; }
@@ -1951,5 +1951,21 @@ describe('classes', () => {
         return Cls;
       })();
     `);
+  });
+
+  it('produce a proper hack to trick Babel and into TypeScript that would be OK with UglifyJS -- and continues to produce results as would be expected', () => {
+      validateCS1(`
+      class A
+        constructor: ->
+          @value ?= 1
+          @value += 1
+      
+      class B extends A
+        constructor: ->
+          @value = 3
+          super
+      b = new B()
+      setResult(b.value)
+    `, 4, {options: {disableBabelConstructorWorkaround: false}, skipNodeCheck: true});
   });
 });

--- a/test/class_test.ts
+++ b/test/class_test.ts
@@ -1953,19 +1953,19 @@ describe('classes', () => {
     `);
   });
 
-  it('produce a proper hack to trick Babel and into TypeScript that would be OK with UglifyJS -- and continues to produce results as would be expected', () => {
-      validateCS1(`
-      class A
-        constructor: ->
-          @value ?= 1
-          @value += 1
-      
-      class B extends A
-        constructor: ->
-          @value = 3
-          super
-      b = new B()
-      setResult(b.value)
-    `, 4, {options: {disableBabelConstructorWorkaround: false}, skipNodeCheck: true});
+  it('it produces a Babel/TS constructor hack that allows this before super in a constructor and produces correct values', () => {
+    validateCS1(`
+    class A
+      constructor: ->
+        @value ?= 1
+        @value += 1
+    
+    class B extends A
+      constructor: ->
+        @value = 3
+        super
+    b = new B()
+    setResult(b.value)
+  `, 4, {options: {}, skipNodeCheck: true});
   });
 });

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -260,8 +260,8 @@ describe('decaffeinate CLI', () => {
           {
             // Hack: trick Babel/TypeScript into allowing this before super.
             if (false) { super(); }
-            let thisFn = (() => { this; }).toString();
-            let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
+            let thisFn = (() => { return this; }).toString();
+            let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
             eval(\`$\{thisName} = this;\`);
           }
           this.a = 1;
@@ -288,8 +288,8 @@ describe('decaffeinate CLI', () => {
           {
             // Hack: trick Babel/TypeScript into allowing this before super.
             if (false) { super(); }
-            let thisFn = (() => { this; }).toString();
-            let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
+            let thisFn = (() => { return this; }).toString();
+            let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
             eval(\`$\{thisName} = this;\`);
           }
           this.a = 1;

--- a/test/suggestions_test.ts
+++ b/test/suggestions_test.ts
@@ -18,8 +18,8 @@ describe('suggestions', () => {
           {
             // Hack: trick Babel/TypeScript into allowing this before super.
             if (false) { super(); }
-            let thisFn = (() => { this; }).toString();
-            let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
+            let thisFn = (() => { return this; }).toString();
+            let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
             eval(\`$\{thisName} = this;\`);
           }
           this.c = this.c.bind(this);
@@ -68,8 +68,8 @@ describe('suggestions', () => {
           {
             // Hack: trick Babel/TypeScript into allowing this before super.
             if (false) { super(); }
-            let thisFn = (() => { this; }).toString();
-            let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
+            let thisFn = (() => { return this; }).toString();
+            let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
             eval(\`$\{thisName} = this;\`);
           }
           this.c = c;
@@ -81,8 +81,8 @@ describe('suggestions', () => {
           {
             // Hack: trick Babel/TypeScript into allowing this before super.
             if (false) { super(); }
-            let thisFn = (() => { this; }).toString();
-            let thisName = thisFn.slice(thisFn.indexOf('{') + 1, thisFn.indexOf(';')).trim();
+            let thisFn = (() => { return this; }).toString();
+            let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
             eval(\`$\{thisName} = this;\`);
           }
           this.g = g;


### PR DESCRIPTION
This is a fix for: https://github.com/decaffeinate/decaffeinate/issues/1303

I need to test on UglifyJS still and going to do that soon but wanted to get the feedback rolling. I took your suggestion with the validate and adding a test that would exercise the behavior but wasn't sure if you wanted to validate the actual constructor function itself. 

I regexp'd all the other tests to match the new lines as well, since there were a few. 

Queries:

1. Is this what you were thinking?
2. Otherwise, if you were not, did you expect to call `setResult` and verify the result of `thisName` somewhere? If so, how to verify that it ends up in the sandbox? I tried it but ending up getting `thisName` is undefined. 