### PR TITLE
Fixes: Updated constructor hack to be more specific

### DIFF
--- a/src/utils/babelConstructorWorkaroundLines.ts
+++ b/src/utils/babelConstructorWorkaroundLines.ts
@@ -24,7 +24,7 @@ export default [
   '  // Hack: trick Babel/TypeScript into allowing this before super.',
   '  if (false) { super(); }',
   '  let thisFn = (() => { return this; }).toString();',
-  "  let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();",
+  "  let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.lastIndexOf(';')).trim();",
   '  eval(`${thisName} = this;`);',
   '}'
 ];

--- a/test/class_test.ts
+++ b/test/class_test.ts
@@ -428,7 +428,7 @@ describe('classes', () => {
               // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
               let thisFn = (() => { return this; }).toString();
-              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
+              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.lastIndexOf(';')).trim();
               eval(\`\${thisName} = this;\`);
             }
             this.a = 2;
@@ -453,7 +453,7 @@ describe('classes', () => {
               // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
               let thisFn = (() => { return this; }).toString();
-              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
+              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.lastIndexOf(';')).trim();
               eval(\`\${thisName} = this;\`);
             }
             this.a = 2;
@@ -477,7 +477,7 @@ describe('classes', () => {
               // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
               let thisFn = (() => { return this; }).toString();
-              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
+              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.lastIndexOf(';')).trim();
               eval(\`\${thisName} = this;\`);
             }
             this.foo = this.foo.bind(this);
@@ -510,7 +510,7 @@ describe('classes', () => {
               // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
               let thisFn = (() => { return this; }).toString();
-              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
+              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.lastIndexOf(';')).trim();
               eval(\`\${thisName} = this;\`);
             }
             this.foo = this.foo.bind(this);
@@ -542,7 +542,7 @@ describe('classes', () => {
               // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
               let thisFn = (() => { return this; }).toString();
-              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
+              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.lastIndexOf(';')).trim();
               eval(\`\${thisName} = this;\`);
             }
             this.foo = this.foo.bind(this);
@@ -590,7 +590,7 @@ describe('classes', () => {
               // Hack: trick Babel/TypeScript into allowing this before super.
               if (false) { super(); }
               let thisFn = (() => { return this; }).toString();
-              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
+              let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.lastIndexOf(';')).trim();
               eval(\`\${thisName} = this;\`);
             }
             if (c == null) { c = {}; }

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -19,7 +19,11 @@ function runCli(argStr: string, stdin: string, expectedStdout: string): void {
   equal(stdout.trim(), expectedStdout.trim());
 }
 
-function runCliExpectError(argStr: string, stdin: string, expectedStderr: string): void {
+function runCliExpectError(
+  argStr: string,
+  stdin: string,
+  expectedStderr: string
+): void {
   if (stdin[0] === '\n') {
     stdin = stripSharedIndent(stdin);
   }
@@ -340,7 +344,7 @@ describe('decaffeinate CLI', () => {
             // Hack: trick Babel/TypeScript into allowing this before super.
             if (false) { super(); }
             let thisFn = (() => { return this; }).toString();
-            let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
+            let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.lastIndexOf(';')).trim();
             eval(\`$\{thisName} = this;\`);
           }
           this.a = 1;
@@ -372,7 +376,7 @@ describe('decaffeinate CLI', () => {
             // Hack: trick Babel/TypeScript into allowing this before super.
             if (false) { super(); }
             let thisFn = (() => { return this; }).toString();
-            let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
+            let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.lastIndexOf(';')).trim();
             eval(\`$\{thisName} = this;\`);
           }
           this.a = 1;

--- a/test/suggestions_test.ts
+++ b/test/suggestions_test.ts
@@ -21,7 +21,7 @@ describe('suggestions', () => {
             // Hack: trick Babel/TypeScript into allowing this before super.
             if (false) { super(); }
             let thisFn = (() => { return this; }).toString();
-            let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
+            let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.lastIndexOf(';')).trim();
             eval(\`$\{thisName} = this;\`);
           }
           this.c = this.c.bind(this);
@@ -79,7 +79,7 @@ describe('suggestions', () => {
             // Hack: trick Babel/TypeScript into allowing this before super.
             if (false) { super(); }
             let thisFn = (() => { return this; }).toString();
-            let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
+            let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.lastIndexOf(';')).trim();
             eval(\`$\{thisName} = this;\`);
           }
           this.c = c;
@@ -92,7 +92,7 @@ describe('suggestions', () => {
             // Hack: trick Babel/TypeScript into allowing this before super.
             if (false) { super(); }
             let thisFn = (() => { return this; }).toString();
-            let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();
+            let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.lastIndexOf(';')).trim();
             eval(\`$\{thisName} = this;\`);
           }
           this.g = g;


### PR DESCRIPTION
Firefox 45 (LTS) produces the following code, something like this:

```
use strict;
return _this;
```

Since the `use strict`; is there, it throws the hack off. With this patch / fork, we have successfully deployed to QA servers and ran against every major browser (all the way down to IE7) You can technically ship a product with this hack in place on every major browser now + old ones. 

We're currently in the process of removing all the hacks but it's good to be able get something out of the box that you can iterate on + run all your tests again in all the different browsers as you slowly chip away. 