### PR TITLE
chore: set up prettier and run it on all files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  parser: 'typescript-eslint-parser',
+  parserOptions: {
+    sourceType: 'module'
+  },
+  plugins: ['prettier'],
+  rules: {
+    'prettier/prettier': ['error']
+  }
+};

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "printWidth": 120
+}

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "decaffeinate": "./bin/decaffeinate"
   },
   "scripts": {
-    "lint": "tslint --config tslint.json --project tsconfig.json --type-check",
-    "lint-fix": "tslint --config tslint.json --project tsconfig.json --type-check --fix",
+    "lint": "eslint --ext .ts src test && tslint --config tslint.json --project tsconfig.json --type-check",
+    "lint-fix": "eslint --fix --ext .ts src test && tslint --config tslint.json --project tsconfig.json --type-check --fix",
     "pretest": "yarn run build",
     "test": "mocha 'test/**/*.ts'",
     "prebuild": "rimraf dist && mkdirp dist && npm run lint",
@@ -51,7 +51,7 @@
     "lines-and-columns": "^1.1.5",
     "magic-string": "^0.22.1",
     "mz": "^2.7.0",
-    "tslib": "^1.7.1"
+    "tslib": "^1.9.0"
   },
   "engines": {
     "node": ">=6"
@@ -68,14 +68,18 @@
     "@types/mz": "^0.0.32",
     "@types/node": "^10.0.3",
     "babel-core": "^7.0.0-beta.3",
+    "eslint": "^4.19.1",
+    "eslint-plugin-prettier": "^2.6.0",
     "fs-extra": "^6.0.0",
     "mkdirp": "^0.5.1",
     "mocha": "^5.0.0",
     "mversion": "^1.10.1",
+    "prettier": "^1.12.1",
     "rimraf": "^2.5.4",
-    "ts-node": "^6.0.0",
+    "ts-node": "^6.0.3",
     "tslint": "^5.5.0",
-    "typescript": "^2.4.1"
+    "typescript": "^2.8.3",
+    "typescript-eslint-parser": "^15.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -196,7 +196,7 @@ async function runWithPaths(paths: Array<string>, options: CLIOptions): Promise<
 async function runWithStdio(options: CLIOptions): Promise<void> {
   return new Promise<void>(resolve => {
     let data = '';
-    process.stdin.on('data', chunk => data += chunk);
+    process.stdin.on('data', chunk => (data += chunk));
     process.stdin.on('end', () => {
       let resultCode = runWithCode('stdin', data, options);
       process.stdout.write(resultCode);
@@ -209,7 +209,7 @@ async function runWithStdio(options: CLIOptions): Promise<void> {
  * Run decaffeinate on the given code string and return the resulting code.
  */
 function runWithCode(name: string, code: string, options: CLIOptions): string {
-  let baseOptions = Object.assign({filename: name}, options.baseOptions);
+  let baseOptions = Object.assign({ filename: name }, options.baseOptions);
   try {
     if (options.modernizeJS) {
       return modernizeJS(code, baseOptions).code;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,17 +26,17 @@ import notNull from './utils/notNull';
 export { PatchError };
 
 export type ConversionResult = {
-  code: string,
+  code: string;
 };
 
 export type StageResult = {
-  code: string,
-  suggestions: Array<Suggestion>,
+  code: string;
+  suggestions: Array<Suggestion>;
 };
 
 type Stage = {
-  name: string,
-  run: (content: string, options: Options) => StageResult,
+  name: string;
+  run: (content: string, options: Options) => StageResult;
 };
 
 /**
@@ -49,7 +49,8 @@ export function convert(source: string, options: Options = {}): ConversionResult
   let originalNewlineStr = detectNewlineStr(source);
   source = convertNewlines(source, '\n');
 
-  let literate = options.literate ||
+  let literate =
+    options.literate ||
     notNull(options.filename).endsWith('.litcoffee') ||
     notNull(options.filename).endsWith('.coffee.md');
   let stages = [
@@ -75,7 +76,7 @@ export function convert(source: string, options: Options = {}): ConversionResult
   }
   result.code = convertNewlines(result.code, originalNewlineStr);
   return {
-    code: result.code,
+    code: result.code
   };
 }
 
@@ -84,13 +85,11 @@ export function modernizeJS(source: string, options: Options = {}): ConversionRe
   options = resolveOptions(options);
   let originalNewlineStr = detectNewlineStr(source);
   source = convertNewlines(source, '\n');
-  let stages = [
-    EsnextStage
-  ];
+  let stages = [EsnextStage];
   let result = runStages(source, options, stages);
   result.code = convertNewlines(result.code, originalNewlineStr);
   return {
-    code: result.code,
+    code: result.code
   };
 }
 
@@ -122,20 +121,20 @@ function convertCustomStage(source: string, stageName: string, useCS2: boolean):
   if (stageName === 'coffeescript-lexer') {
     let tokens = useCS2 ? getCoffee2Tokens(source) : getCoffee1Tokens(source);
     return {
-      code: formatCoffeeScriptLexerTokens(tokens, context),
+      code: formatCoffeeScriptLexerTokens(tokens, context)
     };
   } else if (stageName === 'coffeescript-parser') {
     let nodes = useCS2 ? getCoffee2Nodes(source) : getCoffee1Nodes(source);
     return {
-      code: formatCoffeeScriptAst(nodes, context),
+      code: formatCoffeeScriptAst(nodes, context)
     };
   } else if (stageName === 'coffee-lex') {
     return {
-      code: formatCoffeeLexTokens(lex(source, {useCS2}), context),
+      code: formatCoffeeLexTokens(lex(source, { useCS2 }), context)
     };
   } else if (stageName === 'decaffeinate-parser') {
     return {
-      code: formatDecaffeinateParserAst(decaffeinateParse(source, {useCS2}), context),
+      code: formatDecaffeinateParserAst(decaffeinateParse(source, { useCS2 }), context)
     };
   } else {
     throw new Error(`Unrecognized stage name: ${stageName}`);

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,23 +1,23 @@
 export type Options = {
-  filename?: string,
-  useCS2?: boolean,
-  runToStage?: string | null,
-  literate?: boolean,
-  disableSuggestionComment?: boolean,
-  useOptionalChaining?: boolean,
-  noArrayIncludes?: boolean,
-  useJSModules?: boolean,
-  looseJSModules?: boolean,
-  safeImportFunctionIdentifiers?: Array<string>,
-  preferLet?: boolean,
-  loose?: boolean,
-  looseDefaultParams?: boolean,
-  looseForExpressions?: boolean,
-  looseForOf?: boolean,
-  looseIncludes?: boolean,
-  looseComparisonNegation?: boolean,
-  disableBabelConstructorWorkaround?: boolean,
-  disallowInvalidConstructors?: boolean,
+  filename?: string;
+  useCS2?: boolean;
+  runToStage?: string | null;
+  literate?: boolean;
+  disableSuggestionComment?: boolean;
+  useOptionalChaining?: boolean;
+  noArrayIncludes?: boolean;
+  useJSModules?: boolean;
+  looseJSModules?: boolean;
+  safeImportFunctionIdentifiers?: Array<string>;
+  preferLet?: boolean;
+  loose?: boolean;
+  looseDefaultParams?: boolean;
+  looseForExpressions?: boolean;
+  looseForOf?: boolean;
+  looseIncludes?: boolean;
+  looseComparisonNegation?: boolean;
+  disableBabelConstructorWorkaround?: boolean;
+  disallowInvalidConstructors?: boolean;
 };
 
 export const DEFAULT_OPTIONS: Options = {
@@ -39,7 +39,7 @@ export const DEFAULT_OPTIONS: Options = {
   looseIncludes: false,
   looseComparisonNegation: false,
   disableBabelConstructorWorkaround: false,
-  disallowInvalidConstructors: false,
+  disallowInvalidConstructors: false
 };
 
 export function resolveOptions(options: Options): Options {
@@ -51,8 +51,8 @@ export function resolveOptions(options: Options): Options {
       looseForOf: true,
       looseIncludes: true,
       looseComparisonNegation: true,
-      looseJSModules: true,
+      looseJSModules: true
     };
   }
-  return {...DEFAULT_OPTIONS, ...options};
+  return { ...DEFAULT_OPTIONS, ...options };
 }

--- a/src/patchers/NodePatcher.ts
+++ b/src/patchers/NodePatcher.ts
@@ -2,16 +2,10 @@ import { SourceType } from 'coffee-lex';
 import SourceToken from 'coffee-lex/dist/SourceToken';
 import SourceTokenList from 'coffee-lex/dist/SourceTokenList';
 import SourceTokenListIndex from 'coffee-lex/dist/SourceTokenListIndex';
-import {
-  FunctionApplication, NewOp, Node, SoakedFunctionApplication
-} from 'decaffeinate-parser/dist/nodes';
+import { FunctionApplication, NewOp, Node, SoakedFunctionApplication } from 'decaffeinate-parser/dist/nodes';
 import MagicString from 'magic-string';
 import { Options } from '../options';
-import {
-  AVOID_IIFES,
-  AVOID_INLINE_ASSIGNMENTS,
-  CLEAN_UP_IMPLICIT_RETURNS, Suggestion
-} from '../suggestions';
+import { AVOID_IIFES, AVOID_INLINE_ASSIGNMENTS, CLEAN_UP_IMPLICIT_RETURNS, Suggestion } from '../suggestions';
 import adjustIndent from '../utils/adjustIndent';
 import { logger } from '../utils/debug';
 import DecaffeinateContext from '../utils/DecaffeinateContext';
@@ -29,7 +23,7 @@ export interface PatcherClass {
   // The "children" arg is some number of NodePatchers, but there doesn't seem
   // to be an easy way to have TypeScript understand that.
   // tslint:disable-next-line:no-any
-  new(context: PatcherContext, ...children: Array<any>): NodePatcher;
+  new (context: PatcherContext, ...children: Array<any>): NodePatcher;
   patcherClassForChildNode(node: Node, property: string): PatcherClass | null;
   patcherClassOverrideForNode(node: Node): PatcherClass | null;
 }
@@ -72,7 +66,7 @@ export default class NodePatcher {
   addThisAssignmentAtScopeHeader: AddThisAssignmentCallback | null = null;
   addDefaultParamAssignmentAtScopeHeader: AddDefaultParamCallback | null = null;
 
-  constructor({node, context, editor, options, addSuggestion}: PatcherContext) {
+  constructor({ node, context, editor, options, addSuggestion }: PatcherContext) {
     this.log = logger(this.constructor.name);
 
     this.node = node;
@@ -94,7 +88,8 @@ export default class NodePatcher {
   /**
    * Allow patcher classes that would patch a node to chose a different class.
    */
-  static patcherClassOverrideForNode(_node: Node): PatcherClass | null { // eslint-disable-line no-unused-vars
+  static patcherClassOverrideForNode(_node: Node): PatcherClass | null {
+    // eslint-disable-line no-unused-vars
     return null;
   }
 
@@ -146,10 +141,7 @@ export default class NodePatcher {
         isSemanticToken,
         outerStartTokenIndex.previous()
       );
-      let nextSurroundingTokenIndex = tokens.indexOfTokenMatchingPredicate(
-        isSemanticToken,
-        outerEndTokenIndex.next()
-      );
+      let nextSurroundingTokenIndex = tokens.indexOfTokenMatchingPredicate(isSemanticToken, outerEndTokenIndex.next());
 
       if (!previousSurroundingTokenIndex || !nextSurroundingTokenIndex) {
         break;
@@ -158,11 +150,17 @@ export default class NodePatcher {
       let previousSurroundingToken = tokens.tokenAtIndex(previousSurroundingTokenIndex);
       let nextSurroundingToken = tokens.tokenAtIndex(nextSurroundingTokenIndex);
 
-      if (!previousSurroundingToken || (previousSurroundingToken.type !== SourceType.LPAREN && previousSurroundingToken.type !== SourceType.CALL_START)) {
+      if (
+        !previousSurroundingToken ||
+        (previousSurroundingToken.type !== SourceType.LPAREN && previousSurroundingToken.type !== SourceType.CALL_START)
+      ) {
         break;
       }
 
-      if (!nextSurroundingToken || (nextSurroundingToken.type !== SourceType.RPAREN && nextSurroundingToken.type !== SourceType.CALL_END)) {
+      if (
+        !nextSurroundingToken ||
+        (nextSurroundingToken.type !== SourceType.RPAREN && nextSurroundingToken.type !== SourceType.CALL_END)
+      ) {
         break;
       }
 
@@ -265,8 +263,7 @@ export default class NodePatcher {
   patch(options: PatchOptions = {}): void {
     this.withPrettyErrors(() => {
       if (this._repeatableOptions !== null) {
-        this._repeatCode = this.patchAsRepeatableExpression(
-          this._repeatableOptions, options);
+        this._repeatCode = this.patchAsRepeatableExpression(this._repeatableOptions, options);
       } else if (this.forcedToPatchAsExpression()) {
         this.patchAsForcedExpression(options);
         this.commitDeferredSuffix();
@@ -319,7 +316,7 @@ export default class NodePatcher {
     while (beforeCode === null) {
       try {
         beforeCode = this.slice(sliceStart, this.contentStart);
-      } catch(e) {
+      } catch (e) {
         // Assume that this is because the index is an invalid start. It looks
         // like there isn't a robust way to detect this case exactly, so just
         // try a lower start for any error.
@@ -332,9 +329,7 @@ export default class NodePatcher {
     patchFn();
     let code = this.slice(sliceStart, this.contentEnd);
     let startIndex = 0;
-    while (startIndex < beforeCode.length &&
-        startIndex < code.length &&
-        beforeCode[startIndex] === code[startIndex]) {
+    while (startIndex < beforeCode.length && startIndex < code.length && beforeCode[startIndex] === code[startIndex]) {
       startIndex++;
     }
     return code.substr(startIndex);
@@ -348,12 +343,7 @@ export default class NodePatcher {
       body();
     } catch (err) {
       if (!PatcherError.detect(err)) {
-        throw this.error(
-          err.message,
-          this.contentStart,
-          this.contentEnd,
-          err
-        );
+        throw this.error(err.message, this.contentStart, this.contentEnd, err);
       } else {
         throw err;
       }
@@ -376,8 +366,7 @@ export default class NodePatcher {
    *
    * @protected
    */
-  patchAsRepeatableExpression(
-      repeatableOptions: RepeatableOptions = {}, patchOptions: PatchOptions = {}): string {
+  patchAsRepeatableExpression(repeatableOptions: RepeatableOptions = {}, patchOptions: PatchOptions = {}): string {
     if (this.isRepeatable() && !repeatableOptions.forceRepeat) {
       return this.captureCodeForPatchOperation(() => {
         this.patchAsForcedExpression(patchOptions);
@@ -436,9 +425,7 @@ export default class NodePatcher {
    */
   insert(index: number, content: string): void {
     if (typeof index !== 'number') {
-      throw new Error(
-        `cannot insert ${JSON.stringify(content)} at non-numeric index ${index}`
-      );
+      throw new Error(`cannot insert ${JSON.stringify(content)} at non-numeric index ${index}`);
     }
     this.log(
       'INSERT',
@@ -463,9 +450,7 @@ export default class NodePatcher {
    */
   prependLeft(index: number, content: string): void {
     if (typeof index !== 'number') {
-      throw new Error(
-        `cannot insert ${JSON.stringify(content)} at non-numeric index ${index}`
-      );
+      throw new Error(`cannot insert ${JSON.stringify(content)} at non-numeric index ${index}`);
     }
     this.log(
       'PREPEND LEFT',
@@ -492,9 +477,11 @@ export default class NodePatcher {
     // determine our bounds (we're allowed to patch from the previous
     // comma/paren to the next comma/paren), so loosen the restriction to the
     // entire function.
-    if (boundingPatcher.parent &&
-        (this.isNodeFunctionApplication(boundingPatcher.parent.node) ||
-        boundingPatcher.parent.node.type === 'ArrayInitialiser')) {
+    if (
+      boundingPatcher.parent &&
+      (this.isNodeFunctionApplication(boundingPatcher.parent.node) ||
+        boundingPatcher.parent.node.type === 'ArrayInitialiser')
+    ) {
       boundingPatcher = boundingPatcher.parent;
     }
     if (this.allowPatchingOuterBounds()) {
@@ -508,7 +495,7 @@ export default class NodePatcher {
    * @protected
    */
   isIndexEditable(index: number): boolean {
-    let [ start, end ] = this.getEditingBounds();
+    let [start, end] = this.getEditingBounds();
     return index >= start && index <= end;
   }
 
@@ -517,7 +504,7 @@ export default class NodePatcher {
    */
   assertEditableIndex(index: number): void {
     if (!this.isIndexEditable(index)) {
-      let [ start, end ] = this.getEditingBounds();
+      let [start, end] = this.getEditingBounds();
       throw this.error(
         `cannot edit index ${index} because it is not editable (i.e. outside [${start}, ${end}))`,
         start,
@@ -564,15 +551,14 @@ export default class NodePatcher {
    */
   overwrite(start: number, end: number, content: string): void {
     if (typeof start !== 'number' || typeof end !== 'number') {
-      throw new Error(
-        `cannot overwrite non-numeric range [${start}, ${end}) ` +
-        `with ${JSON.stringify(content)}`
-      );
+      throw new Error(`cannot overwrite non-numeric range [${start}, ${end}) ` + `with ${JSON.stringify(content)}`);
     }
     this.log(
-      'OVERWRITE', `[${start}, ${end})`,
+      'OVERWRITE',
+      `[${start}, ${end})`,
       JSON.stringify(this.context.source.slice(start, end)),
-      '→', JSON.stringify(content)
+      '→',
+      JSON.stringify(content)
     );
     this.editor.overwrite(start, end, content);
   }
@@ -582,14 +568,9 @@ export default class NodePatcher {
    */
   remove(start: number, end: number): void {
     if (typeof start !== 'number' || typeof end !== 'number') {
-      throw new Error(
-        `cannot remove non-numeric range [${start}, ${end})`
-      );
+      throw new Error(`cannot remove non-numeric range [${start}, ${end})`);
     }
-    this.log(
-      'REMOVE', `[${start}, ${end})`,
-      JSON.stringify(this.context.source.slice(start, end))
-    );
+    this.log('REMOVE', `[${start}, ${end})`, JSON.stringify(this.context.source.slice(start, end)));
     this.editor.remove(start, end);
   }
 
@@ -598,19 +579,17 @@ export default class NodePatcher {
    */
   move(start: number, end: number, index: number): void {
     if (typeof start !== 'number' || typeof end !== 'number') {
-      throw this.error(
-        `cannot remove non-numeric range [${start}, ${end})`
-      );
+      throw this.error(`cannot remove non-numeric range [${start}, ${end})`);
     }
     if (typeof index !== 'number') {
-      throw this.error(
-        `cannot move to non-numeric index: ${index}`
-      );
+      throw this.error(`cannot move to non-numeric index: ${index}`);
     }
     this.log(
-      'MOVE', `[${start}, ${end}) → ${index}`,
+      'MOVE',
+      `[${start}, ${end}) → ${index}`,
       JSON.stringify(this.context.source.slice(start, end)),
-      'BEFORE', JSON.stringify(this.context.source.slice(index, index + 8))
+      'BEFORE',
+      JSON.stringify(this.context.source.slice(index, index + 8))
     );
     this.editor.move(start, end, index);
   }
@@ -787,7 +766,8 @@ export default class NodePatcher {
   /**
    * Patch the end of an implicitly-returned descendant.
    */
-  patchImplicitReturnEnd(_patcher: NodePatcher): void { // eslint-disable-line no-unused-vars
+  patchImplicitReturnEnd(_patcher: NodePatcher): void {
+    // eslint-disable-line no-unused-vars
     // Nothing to do.
   }
 
@@ -876,7 +856,11 @@ export default class NodePatcher {
    * Gets the index of the token between left and right patchers that matches
    * a predicate function.
    */
-  indexOfSourceTokenBetweenPatchersMatching(left: NodePatcher, right: NodePatcher, predicate: (token: SourceToken) => boolean): SourceTokenListIndex | null {
+  indexOfSourceTokenBetweenPatchersMatching(
+    left: NodePatcher,
+    right: NodePatcher,
+    predicate: (token: SourceToken) => boolean
+  ): SourceTokenListIndex | null {
     return this.indexOfSourceTokenBetweenSourceIndicesMatching(left.outerEnd, right.outerStart, predicate);
   }
 
@@ -884,21 +868,20 @@ export default class NodePatcher {
    * Gets the index of the token between source locations that matches a
    * predicate function.
    */
-  indexOfSourceTokenBetweenSourceIndicesMatching(left: number, right: number, predicate: (token: SourceToken) => boolean): SourceTokenListIndex | null {
+  indexOfSourceTokenBetweenSourceIndicesMatching(
+    left: number,
+    right: number,
+    predicate: (token: SourceToken) => boolean
+  ): SourceTokenListIndex | null {
     let tokenList = this.getProgramSourceTokens();
     return tokenList.indexOfTokenMatchingPredicate(
       token => {
-        return (
-          token.start >= left &&
-          token.start <= right &&
-          predicate(token)
-        );
+        return token.start >= left && token.start <= right && predicate(token);
       },
       tokenList.indexOfTokenNearSourceIndex(left),
       tokenList.indexOfTokenNearSourceIndex(right).next()
     );
   }
-
 
   /**
    * Gets the token at a particular index.
@@ -968,9 +951,12 @@ export default class NodePatcher {
    * Gets the index of a token after `contentStart` with the matching type, ignoring
    * non-semantic types by default.
    */
-  indexOfSourceTokenAfterSourceTokenIndex(start: SourceTokenListIndex, type: SourceType, predicate: (token: SourceToken) => boolean=isSemanticToken): SourceTokenListIndex | null {
-    let index = this.getProgramSourceTokens()
-      .indexOfTokenMatchingPredicate(predicate, start.next());
+  indexOfSourceTokenAfterSourceTokenIndex(
+    start: SourceTokenListIndex,
+    type: SourceType,
+    predicate: (token: SourceToken) => boolean = isSemanticToken
+  ): SourceTokenListIndex | null {
+    let index = this.getProgramSourceTokens().indexOfTokenMatchingPredicate(predicate, start.next());
     if (!index) {
       return null;
     }
@@ -984,7 +970,7 @@ export default class NodePatcher {
   /**
    * Determines whether this patcher's node is followed by a particular token.
    */
-  hasSourceTokenAfter(type: SourceType, predicate: (token: SourceToken) => boolean=isSemanticToken): boolean {
+  hasSourceTokenAfter(type: SourceType, predicate: (token: SourceToken) => boolean = isSemanticToken): boolean {
     return this.indexOfSourceTokenAfterSourceTokenIndex(this.outerEndTokenIndex, type, predicate) !== null;
   }
 
@@ -1020,12 +1006,11 @@ export default class NodePatcher {
       return false;
     }
 
-    let parenRange = this.getProgramSourceTokens()
-      .rangeOfMatchingTokensContainingTokenIndex(
-        leftTokenType,
-        rightTokenType,
-        this.outerStartTokenIndex
-      );
+    let parenRange = this.getProgramSourceTokens().rangeOfMatchingTokensContainingTokenIndex(
+      leftTokenType,
+      rightTokenType,
+      this.outerStartTokenIndex
+    );
     if (!parenRange) {
       return false;
     }
@@ -1045,8 +1030,10 @@ export default class NodePatcher {
     if (this.isSurroundedByParentheses()) {
       return this;
     } else if (this.parent) {
-      if (this.isNodeFunctionApplication(this.parent.node) &&
-          this.parent.node.arguments.some(arg => arg === this.node)) {
+      if (
+        this.isNodeFunctionApplication(this.parent.node) &&
+        this.parent.node.arguments.some(arg => arg === this.node)
+      ) {
         return this;
       } else if (this.parent.node.type === 'ArrayInitialiser') {
         return this;
@@ -1060,9 +1047,7 @@ export default class NodePatcher {
   }
 
   isNodeFunctionApplication(node: Node): node is FunctionApplication | SoakedFunctionApplication | NewOp {
-    return node instanceof FunctionApplication ||
-      node instanceof SoakedFunctionApplication ||
-      node instanceof NewOp;
+    return node instanceof FunctionApplication || node instanceof SoakedFunctionApplication || node instanceof NewOp;
   }
 
   /**
@@ -1106,12 +1091,8 @@ export default class NodePatcher {
   /**
    * Gets the indent string for the line that starts this patcher's node.
    */
-  getIndent(offset: number=0): string {
-    return adjustIndent(
-      this.context.source,
-      this.contentStart,
-      this.getAdjustedIndentLevel() + offset
-    );
+  getIndent(offset: number = 0): string {
+    return adjustIndent(this.context.source, this.contentStart, this.getAdjustedIndentLevel() + offset);
   }
 
   /**
@@ -1131,10 +1112,7 @@ export default class NodePatcher {
    * Get the amount the adjusted indent level differs from the original level.
    */
   getAdjustedIndentLevel(): number {
-    return (
-      this.adjustedIndentLevel +
-      (this.parent ? this.parent.getAdjustedIndentLevel() : 0)
-    );
+    return this.adjustedIndentLevel + (this.parent ? this.parent.getAdjustedIndentLevel() : 0);
   }
 
   /**
@@ -1153,7 +1131,7 @@ export default class NodePatcher {
    * that strings inserted before child nodes appear after the indent, not
    * before.
    */
-  indent(offset: number=1, {skipFirstLine=false}: {skipFirstLine?: boolean}={}): void {
+  indent(offset: number = 1, { skipFirstLine = false }: { skipFirstLine?: boolean } = {}): void {
     if (offset === 0) {
       return;
     }
@@ -1201,7 +1179,8 @@ export default class NodePatcher {
               // indentation wrong means ugly JS code that's still correct.
               this.log(
                 'Warning: Ignoring an unindent operation because the line ' +
-                'did not start with the proper indentation.');
+                  'did not start with the proper indentation.'
+              );
             }
             hasIndentedThisLine = true;
           }
@@ -1238,7 +1217,7 @@ export default class NodePatcher {
   /**
    * Appends the given content on a new line after the end of the current line.
    */
-  appendLineAfter(content: string, indentOffset: number=0): void {
+  appendLineAfter(content: string, indentOffset: number = 0): void {
     let boundingPatcher = this.getBoundingPatcher();
     let endOfLine = this.getEndOfLine();
     let nextToken = this.nextSemanticToken();
@@ -1252,9 +1231,16 @@ export default class NodePatcher {
   /**
    * Generate an error referring to a particular section of the source.
    */
-  error(message: string, start: number = this.contentStart, end: number = this.contentEnd, error: Error | null = null): PatcherError {
+  error(
+    message: string,
+    start: number = this.contentStart,
+    end: number = this.contentEnd,
+    error: Error | null = null
+  ): PatcherError {
     let patcherError = new PatcherError(message, this.context.source, start, end);
-    if (error) { patcherError.stack = error.stack; }
+    if (error) {
+      patcherError.stack = error.stack;
+    }
     return patcherError;
   }
 
@@ -1341,7 +1327,10 @@ export default class NodePatcher {
   /**
    * Gets the first "interesting token" in the indexed range (default range is `this` + parent)
    */
-  getFirstSemanticToken(from: number=this.contentStart, to: number = notNull(this.parent).contentEnd): SourceToken | null {
+  getFirstSemanticToken(
+    from: number = this.contentStart,
+    to: number = notNull(this.parent).contentEnd
+  ): SourceToken | null {
     let nextSemanticIdx = this.indexOfSourceTokenBetweenSourceIndicesMatching(from, to, isSemanticToken);
     return nextSemanticIdx && this.sourceTokenAtIndex(nextSemanticIdx);
   }

--- a/src/patchers/PassthroughPatcher.ts
+++ b/src/patchers/PassthroughPatcher.ts
@@ -3,7 +3,7 @@ import { PatcherContext } from './types';
 
 export default class PassthroughPatcher extends NodePatcher {
   children: Array<NodePatcher | Array<NodePatcher> | null>;
-  
+
   constructor(patcherContext: PatcherContext, ...children: Array<NodePatcher | Array<NodePatcher> | null>) {
     super(patcherContext);
     this.children = children;

--- a/src/patchers/SharedBlockPatcher.ts
+++ b/src/patchers/SharedBlockPatcher.ts
@@ -26,9 +26,9 @@ export default class SharedBlockPatcher extends NodePatcher {
         token => token.type === SourceType.NEWLINE || token.type === SourceType.SEMICOLON,
         lastStatement.outerEndTokenIndex
       );
-      let insertionPoint = terminatorTokenIndex ?
-        notNull(this.sourceTokenAtIndex(terminatorTokenIndex)).start :
-        lastStatement.outerEnd;
+      let insertionPoint = terminatorTokenIndex
+        ? notNull(this.sourceTokenAtIndex(terminatorTokenIndex)).start
+        : lastStatement.outerEnd;
       insertionPoint = Math.min(insertionPoint, this.getBoundingPatcher().innerEnd);
       let indent = lastStatement.getIndent();
       statements.forEach(line => {

--- a/src/patchers/types.ts
+++ b/src/patchers/types.ts
@@ -13,18 +13,18 @@ export type PatcherContext = {
 };
 
 export type RepeatableOptions = {
-  parens?: boolean,
-  ref?: string,
-  isForAssignment?: boolean,
-  forceRepeat?: boolean,
+  parens?: boolean;
+  ref?: string;
+  isForAssignment?: boolean;
+  forceRepeat?: boolean;
 };
 
 export type PatchOptions = {
-  needsParens?: boolean,
-  fnNeedsParens?: boolean,
-  skipParens?: boolean,
-  leftBrace?: boolean,
-  rightBrace?: boolean,
-  method?: boolean,
-  forceTemplateLiteral?: boolean,
+  needsParens?: boolean;
+  fnNeedsParens?: boolean;
+  skipParens?: boolean;
+  leftBrace?: boolean;
+  rightBrace?: boolean;
+  method?: boolean;
+  forceTemplateLiteral?: boolean;
 };

--- a/src/stages/TransformCoffeeScriptStage.ts
+++ b/src/stages/TransformCoffeeScriptStage.ts
@@ -23,7 +23,7 @@ export default class TransformCoffeeScriptStage {
     patcher.patch();
     return {
       code: editor.toString(),
-      suggestions: stage.suggestions,
+      suggestions: stage.suggestions
     };
   }
 
@@ -32,16 +32,17 @@ export default class TransformCoffeeScriptStage {
   suggestions: Array<Suggestion> = [];
 
   constructor(
-      readonly ast: Node,
-      readonly context: DecaffeinateContext,
-      readonly editor: MagicString,
-      readonly options: Options) {
-  }
+    readonly ast: Node,
+    readonly context: DecaffeinateContext,
+    readonly editor: MagicString,
+    readonly options: Options
+  ) {}
 
   /**
    * This should be overridden in subclasses.
    */
-  patcherConstructorForNode(_node: Node): PatcherClass | null { // eslint-disable-line no-unused-vars
+  patcherConstructorForNode(_node: Node): PatcherClass | null {
+    // eslint-disable-line no-unused-vars
     return null;
   }
 
@@ -67,9 +68,7 @@ export default class TransformCoffeeScriptStage {
       if (!child) {
         return null;
       } else if (Array.isArray(child)) {
-        return child.map(item =>
-          item ? this.patcherForNode(item, constructor, name) : null
-        );
+        return child.map(item => (item ? this.patcherForNode(item, constructor, name) : null));
       } else {
         return this.patcherForNode(child, constructor, name);
       }
@@ -80,7 +79,9 @@ export default class TransformCoffeeScriptStage {
       context: this.context,
       editor: this.editor,
       options: this.options,
-      addSuggestion: (suggestion: Suggestion) => { this.suggestions.push(suggestion); },
+      addSuggestion: (suggestion: Suggestion) => {
+        this.suggestions.push(suggestion);
+      }
     };
     let patcher = new constructor(patcherContext, ...children);
     this.patchers.push(patcher);
@@ -103,8 +104,7 @@ export default class TransformCoffeeScriptStage {
     if (constructor === null) {
       let props = node.getChildNames();
       throw new PatchError(
-        `no patcher available for node type: ${node.type}` +
-        `${props.length ? ` (props: ${props.join(', ')})` : ''}`,
+        `no patcher available for node type: ${node.type}` + `${props.length ? ` (props: ${props.join(', ')})` : ''}`,
         this.context.source,
         node.start,
         node.end

--- a/src/stages/add-variable-declarations/index.ts
+++ b/src/stages/add-variable-declarations/index.ts
@@ -12,7 +12,7 @@ export default class AddVariableDeclarationsStage {
     addVariableDeclarations(content, editor);
     return {
       code: editor.toString(),
-      suggestions: [],
+      suggestions: []
     };
   }
 }

--- a/src/stages/esnext/index.ts
+++ b/src/stages/esnext/index.ts
@@ -17,11 +17,11 @@ export default class EsnextStage {
     let { code } = convert(content, {
       plugins,
       'declarations.block-scope': {
-        disableConst({node, parent}: NodePath<VariableDeclaration>): boolean {
+        disableConst({ node, parent }: NodePath<VariableDeclaration>): boolean {
           if (options.preferLet) {
             return (
               // Only use `const` for top-level variables…
-              parent && parent.type !== 'Program' ||
+              (parent && parent.type !== 'Program') ||
               // … as the only variable in its declaration …
               node.declarations.length !== 1 ||
               // … without any sort of destructuring …
@@ -32,16 +32,16 @@ export default class EsnextStage {
           } else {
             return false;
           }
-        },
+        }
       },
       'modules.commonjs': {
         forceDefaultExport: !options.looseJSModules,
-        safeFunctionIdentifiers: options.safeImportFunctionIdentifiers,
-      },
+        safeFunctionIdentifiers: options.safeImportFunctionIdentifiers
+      }
     });
     return {
       code,
-      suggestions: [],
+      suggestions: []
     };
   }
 }

--- a/src/stages/literate/index.ts
+++ b/src/stages/literate/index.ts
@@ -9,7 +9,7 @@ export default class LiterateStage {
   static run(content: string): StageResult {
     return {
       code: convertCodeFromLiterate(content),
-      suggestions: [],
+      suggestions: []
     };
   }
 }
@@ -40,8 +40,7 @@ function convertCodeFromLiterate(code: string): string {
     } else {
       // Remain a comment on an empty line, an unindented line, or if the last
       // line was nonempty.
-      if (lineIsEmpty(line) || !lineIsIndented(line) ||
-          (i > 0 && !lineIsEmpty(lines[i - 1]))) {
+      if (lineIsEmpty(line) || !lineIsIndented(line) || (i > 0 && !lineIsEmpty(lines[i - 1]))) {
         commentLines.push(line);
       } else {
         resultLines.push(...convertCommentLines(commentLines));

--- a/src/stages/main/patchers/ArrayInitialiserPatcher.ts
+++ b/src/stages/main/patchers/ArrayInitialiserPatcher.ts
@@ -31,9 +31,7 @@ export default class ArrayInitialiserPatcher extends NodePatcher {
         return;
       }
 
-      let needsComma = !isLast &&
-        !member.hasSourceTokenAfter(SourceType.COMMA) &&
-        !(member instanceof ElisionPatcher);
+      let needsComma = !isLast && !member.hasSourceTokenAfter(SourceType.COMMA) && !(member instanceof ElisionPatcher);
       member.patch();
       if (needsComma) {
         this.insert(member.outerEnd, ',');

--- a/src/stages/main/patchers/AsyncFunctionPatcher.ts
+++ b/src/stages/main/patchers/AsyncFunctionPatcher.ts
@@ -1,13 +1,13 @@
 import FunctionPatcher from './FunctionPatcher';
 
 export default class AsyncFunctionPatcher extends FunctionPatcher {
-  patchFunctionStart({method=false}: {method: boolean}): void {
+  patchFunctionStart({ method = false }: { method: boolean }): void {
     let arrow = this.getArrowToken();
 
     if (!method) {
       this.insert(this.contentStart, 'async function');
     }
-    
+
     if (!this.hasParamStart()) {
       this.insert(this.contentStart, '() ');
     }

--- a/src/stages/main/patchers/AwaitPatcher.ts
+++ b/src/stages/main/patchers/AwaitPatcher.ts
@@ -1,4 +1,4 @@
-import {PatcherContext, PatchOptions} from '../../../patchers/types';
+import { PatcherContext, PatchOptions } from '../../../patchers/types';
 import NodePatcher from './../../../patchers/NodePatcher';
 
 export default class AwaitPatcher extends NodePatcher {
@@ -14,7 +14,7 @@ export default class AwaitPatcher extends NodePatcher {
     this.expression.setRequiresExpression();
   }
 
-  patchAsExpression({needsParens = true}: PatchOptions = {}): void {
+  patchAsExpression({ needsParens = true }: PatchOptions = {}): void {
     this.expression.patch({ needsParens });
   }
 }

--- a/src/stages/main/patchers/BinaryOpPatcher.ts
+++ b/src/stages/main/patchers/BinaryOpPatcher.ts
@@ -42,9 +42,8 @@ export default class BinaryOpPatcher extends NodePatcher {
   /**
    * LEFT OP RIGHT
    */
-  patchAsExpression({needsParens = false}: PatchOptions = {}): void {
-    let addParens =
-      (needsParens && !this.isSurroundedByParentheses()) || this.binaryOpNegated;
+  patchAsExpression({ needsParens = false }: PatchOptions = {}): void {
+    let addParens = (needsParens && !this.isSurroundedByParentheses()) || this.binaryOpNegated;
     if (this.binaryOpNegated) {
       this.insert(this.innerStart, '!');
     }

--- a/src/stages/main/patchers/BoundFunctionPatcher.ts
+++ b/src/stages/main/patchers/BoundFunctionPatcher.ts
@@ -43,7 +43,7 @@ export default class BoundFunctionPatcher extends FunctionPatcher {
     if (!this.hasParamStart()) {
       this.insert(this.contentStart, '() ');
     } else if (!this.parameterListNeedsParentheses()) {
-      let [ param ] = this.parameters;
+      let [param] = this.parameters;
       if (param.isSurroundedByParentheses()) {
         this.remove(param.outerStart, param.contentStart);
         this.remove(param.contentEnd, param.outerEnd);
@@ -62,7 +62,7 @@ export default class BoundFunctionPatcher extends FunctionPatcher {
       return true;
     }
 
-    let [ param ] = parameters;
+    let [param] = parameters;
     return !(param instanceof IdentifierPatcher);
   }
 
@@ -76,8 +76,7 @@ export default class BoundFunctionPatcher extends FunctionPatcher {
           this.body.patch({ leftBrace: false });
         }
       } else {
-        let needsParens = blockStartsWithObjectInitialiser(this.body) &&
-          !this.body.isSurroundedByParentheses();
+        let needsParens = blockStartsWithObjectInitialiser(this.body) && !this.body.isSurroundedByParentheses();
         if (needsParens) {
           this.insert(this.body.innerStart, '(');
         }

--- a/src/stages/main/patchers/BoundGeneratorFunctionPatcher.ts
+++ b/src/stages/main/patchers/BoundGeneratorFunctionPatcher.ts
@@ -2,7 +2,7 @@ import { PatchOptions } from '../../../patchers/types';
 import ManuallyBoundFunctionPatcher from './ManuallyBoundFunctionPatcher';
 
 export default class BoundGeneratorFunctionPatcher extends ManuallyBoundFunctionPatcher {
-  patchFunctionStart({method = false}: PatchOptions = {}): void {
+  patchFunctionStart({ method = false }: PatchOptions = {}): void {
     let arrow = this.getArrowToken();
 
     if (!method) {

--- a/src/stages/main/patchers/CSXElementPatcher.ts
+++ b/src/stages/main/patchers/CSXElementPatcher.ts
@@ -1,6 +1,6 @@
 import SourceType from 'coffee-lex/dist/SourceType';
 import NodePatcher from '../../../patchers/NodePatcher';
-import {PatcherContext} from '../../../patchers/types';
+import { PatcherContext } from '../../../patchers/types';
 import StringPatcher from './StringPatcher';
 
 export default class CSXElementPatcher extends NodePatcher {

--- a/src/stages/main/patchers/ChainedComparisonOpPatcher.ts
+++ b/src/stages/main/patchers/ChainedComparisonOpPatcher.ts
@@ -26,10 +26,9 @@ export default class ChainedComparisonOpPatcher extends NodePatcher {
     }
   }
 
-  patchAsExpression({needsParens = false}: PatchOptions = {}): void {
+  patchAsExpression({ needsParens = false }: PatchOptions = {}): void {
     let negateEntireExpression = this.shouldNegateEntireExpression();
-    let addParens = negateEntireExpression ||
-      (needsParens && !this.isSurroundedByParentheses());
+    let addParens = negateEntireExpression || (needsParens && !this.isSurroundedByParentheses());
     if (negateEntireExpression) {
       this.insert(this.contentStart, '!');
     }
@@ -62,10 +61,7 @@ export default class ChainedComparisonOpPatcher extends NodePatcher {
     for (let operand of middle) {
       // `a < b < c` → `a < b && b < c`
       //                     ^^^^^
-      this.insert(
-        operand.outerEnd,
-        ` ${logicalOperator} ${operand.getRepeatCode()}`
-      );
+      this.insert(operand.outerEnd, ` ${logicalOperator} ${operand.getRepeatCode()}`);
     }
 
     if (addParens) {
@@ -79,9 +75,11 @@ export default class ChainedComparisonOpPatcher extends NodePatcher {
    * intelligently negate the subexpressions accounting for unsafe negations.
    */
   shouldNegateEntireExpression(): boolean {
-    return this.negated &&
+    return (
+      this.negated &&
       this.node.operators.some(operator => isCompareOpNegationUnsafe(operator.operator)) &&
-      !this.options.looseComparisonNegation;
+      !this.options.looseComparisonNegation
+    );
   }
 
   /**

--- a/src/stages/main/patchers/ClassAssignOpPatcher.ts
+++ b/src/stages/main/patchers/ClassAssignOpPatcher.ts
@@ -55,13 +55,12 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
    * that we do, so mark it as repeatable now.
    */
   markKeyRepeatableIfNecessary(): void {
-    if (this.expression instanceof FunctionPatcher &&
-      containsSuperCall(this.expression.node)) {
+    if (this.expression instanceof FunctionPatcher && containsSuperCall(this.expression.node)) {
       if (this.isStaticMethod()) {
         if (this.key instanceof DynamicMemberAccessOpPatcher) {
           this.key.indexingExpr.setRequiresRepeatableExpression({
             ref: 'method',
-            forceRepeat: true,
+            forceRepeat: true
           });
         }
       } else {
@@ -71,7 +70,7 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
           // need to be defensive in that case. For other cases, like number
           // literals, we still mark as repeatable so later code can safely get
           // the repeat code.
-          forceRepeat: this.key instanceof StringPatcher && this.key.expressions.length > 0,
+          forceRepeat: this.key instanceof StringPatcher && this.key.expressions.length > 0
         });
       }
     }
@@ -125,8 +124,7 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
    * @protected
    */
   isStaticMethod(): boolean {
-    if (!(this.key instanceof MemberAccessOpPatcher) &&
-      !(this.key instanceof DynamicMemberAccessOpPatcher)) {
+    if (!(this.key instanceof MemberAccessOpPatcher) && !(this.key instanceof DynamicMemberAccessOpPatcher)) {
       return false;
     }
 
@@ -157,8 +155,7 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
     }
     return (
       !this.isStaticMethod() &&
-      (this.expression.node.type === 'BoundFunction' ||
-        this.expression.node.type === 'BoundGeneratorFunction')
+      (this.expression.node.type === 'BoundFunction' || this.expression.node.type === 'BoundGeneratorFunction')
     );
   }
 
@@ -169,7 +166,6 @@ export default class ClassAssignOpPatcher extends ObjectBodyMemberPatcher {
    * @protected
    */
   isMethod(): boolean {
-    return this.expression instanceof ManuallyBoundFunctionPatcher ||
-      super.isMethod();
+    return this.expression instanceof ManuallyBoundFunctionPatcher || super.isMethod();
   }
 }

--- a/src/stages/main/patchers/ClassBlockPatcher.ts
+++ b/src/stages/main/patchers/ClassBlockPatcher.ts
@@ -31,9 +31,9 @@ export default class ClassBlockPatcher extends BlockPatcher {
       if (boundMethods.length > 0) {
         let isSubclass = this.getClassPatcher().isSubclass();
         if (isSubclass && !this.shouldAllowInvalidConstructors()) {
-          throw this.error(getInvalidConstructorErrorMessage(
-            'Cannot automatically convert a subclass that uses bound methods.'
-          ));
+          throw this.error(
+            getInvalidConstructorErrorMessage('Cannot automatically convert a subclass that uses bound methods.')
+          );
         }
 
         let { source } = this.context;
@@ -74,7 +74,7 @@ export default class ClassBlockPatcher extends BlockPatcher {
     }
     return shouldEnable;
   }
-  
+
   getClassPatcher(): ClassPatcher {
     if (!(this.parent instanceof ClassPatcher)) {
       throw this.error('Expected class block parent to be a class.');
@@ -87,9 +87,7 @@ export default class ClassBlockPatcher extends BlockPatcher {
   }
 
   hasConstructor(): boolean {
-    return this.statements.some(
-      statement => statement instanceof ConstructorPatcher
-    );
+    return this.statements.some(statement => statement instanceof ConstructorPatcher);
   }
 
   boundInstanceMethods(): Array<ClassAssignOpPatcher> {

--- a/src/stages/main/patchers/ClassPatcher.ts
+++ b/src/stages/main/patchers/ClassPatcher.ts
@@ -14,7 +14,12 @@ export default class ClassPatcher extends NodePatcher {
   superclass: NodePatcher | null;
   body: ClassBlockPatcher | null;
 
-  constructor(patcherContext: PatcherContext, nameAssignee: NodePatcher | null, parent: NodePatcher | null, body: ClassBlockPatcher | null) {
+  constructor(
+    patcherContext: PatcherContext,
+    nameAssignee: NodePatcher | null,
+    parent: NodePatcher | null,
+    body: ClassBlockPatcher | null
+  ) {
     super(patcherContext);
     this.nameAssignee = nameAssignee;
     this.superclass = parent;
@@ -55,12 +60,11 @@ export default class ClassPatcher extends NodePatcher {
     }
   }
 
-  patchAsExpression({skipParens = false}: PatchOptions = {}): void {
-    let needsAssignment = this.nameAssignee &&
-      (this.isNamespaced() || this.isNameAlreadyDeclared() || this.willPatchAsExpression());
-    let needsParens = !skipParens && needsAssignment &&
-      this.willPatchAsExpression() &&
-      !this.isSurroundedByParentheses();
+  patchAsExpression({ skipParens = false }: PatchOptions = {}): void {
+    let needsAssignment =
+      this.nameAssignee && (this.isNamespaced() || this.isNameAlreadyDeclared() || this.willPatchAsExpression());
+    let needsParens =
+      !skipParens && needsAssignment && this.willPatchAsExpression() && !this.isSurroundedByParentheses();
     if (needsParens) {
       this.insert(this.contentStart, '(');
     }
@@ -89,7 +93,7 @@ export default class ClassPatcher extends NodePatcher {
     if (!this.body) {
       // `class A` → `class A {}`
       //                     ^^^
-      this.insert(this.innerEnd,' {}');
+      this.insert(this.innerEnd, ' {}');
     } else {
       // `class A` → `class A {`
       //                     ^^
@@ -121,7 +125,8 @@ export default class ClassPatcher extends NodePatcher {
     if (classSourceToken.type !== SourceType.CLASS) {
       throw this.error(
         `expected CLASS token but found ${SourceType[classSourceToken.type]}`,
-        classSourceToken.start, classSourceToken.end
+        classSourceToken.start,
+        classSourceToken.end
       );
     }
     return classSourceToken;
@@ -148,9 +153,7 @@ export default class ClassPatcher extends NodePatcher {
    */
   isNameAlreadyDeclared(): boolean {
     let name = this.getName();
-    return this.nameAssignee !== null &&
-      name !== null &&
-      this.getScope().getBinding(name) !== this.nameAssignee.node;
+    return this.nameAssignee !== null && name !== null && this.getScope().getBinding(name) !== this.nameAssignee.node;
   }
 
   /**

--- a/src/stages/main/patchers/ConditionalPatcher.ts
+++ b/src/stages/main/patchers/ConditionalPatcher.ts
@@ -15,7 +15,12 @@ export default class ConditionalPatcher extends NodePatcher {
 
   negated: boolean = false;
 
-  constructor(patcherContext: PatcherContext, condition: NodePatcher, consequent: BlockPatcher | null, alternate: BlockPatcher | null) {
+  constructor(
+    patcherContext: PatcherContext,
+    condition: NodePatcher,
+    consequent: BlockPatcher | null,
+    alternate: BlockPatcher | null
+  ) {
     super(patcherContext);
     this.condition = condition;
     this.consequent = consequent;
@@ -46,10 +51,7 @@ export default class ConditionalPatcher extends NodePatcher {
     if (!consequent || !alternate) {
       return false;
     }
-    return (
-      consequent.prefersToPatchAsExpression() &&
-      alternate.prefersToPatchAsExpression()
-    );
+    return consequent.prefersToPatchAsExpression() && alternate.prefersToPatchAsExpression();
   }
 
   setExpression(force: boolean = false): boolean {
@@ -72,11 +74,10 @@ export default class ConditionalPatcher extends NodePatcher {
 
   willPatchAsTernary(): boolean {
     return (
-      this.prefersToPatchAsExpression() || (
-        this.forcedToPatchAsExpression() &&
+      this.prefersToPatchAsExpression() ||
+      (this.forcedToPatchAsExpression() &&
         (!this.consequent || this.consequent.prefersToPatchAsExpression()) &&
-        (!this.alternate || this.alternate.prefersToPatchAsExpression())
-      )
+        (!this.alternate || this.alternate.prefersToPatchAsExpression()))
     );
   }
 
@@ -87,17 +88,12 @@ export default class ConditionalPatcher extends NodePatcher {
     return !this.willPatchAsTernary() && this.forcedToPatchAsExpression();
   }
 
-  patchAsExpression({needsParens}: PatchOptions = {}): void {
-    let addParens = this.negated ||
-      (needsParens && !this.isSurroundedByParentheses());
+  patchAsExpression({ needsParens }: PatchOptions = {}): void {
+    let addParens = this.negated || (needsParens && !this.isSurroundedByParentheses());
 
     // `if a then b` → `a then b`
     //  ^^^
-    this.overwrite(
-      this.contentStart,
-      this.condition.outerStart,
-      `${this.negated ? '!' : ''}${addParens ? '(' : ''}`
-    );
+    this.overwrite(this.contentStart, this.condition.outerStart, `${this.negated ? '!' : ''}${addParens ? '(' : ''}`);
 
     if (this.node.isUnless) {
       this.condition.negate();
@@ -144,7 +140,9 @@ export default class ConditionalPatcher extends NodePatcher {
       // We might have just a semicolon as the consequent. In that case, it will be null in the AST
       // but we will need to remove it.
       let semicolonTokenIndex = this.indexOfSourceTokenBetweenSourceIndicesMatching(
-        this.condition.outerEnd, elseToken.start, (token) => token.type === SourceType.SEMICOLON
+        this.condition.outerEnd,
+        elseToken.start,
+        token => token.type === SourceType.SEMICOLON
       );
       if (semicolonTokenIndex) {
         let semicolonToken = this.sourceTokenAtIndex(semicolonTokenIndex);
@@ -295,8 +293,7 @@ export default class ConditionalPatcher extends NodePatcher {
       let elseToken = notNull(this.sourceTokenAtIndex(elseTokenIndex));
       this.insert(elseToken.end, ' {}');
     } else if (super.implicitlyReturns()) {
-      let emptyImplicitReturnCode =
-        this.implicitReturnPatcher().getEmptyImplicitReturnCode();
+      let emptyImplicitReturnCode = this.implicitReturnPatcher().getEmptyImplicitReturnCode();
       if (emptyImplicitReturnCode) {
         this.insert(this.innerEnd, ' else {\n');
         this.insert(this.innerEnd, `${this.getIndent(1)}${emptyImplicitReturnCode}\n`);
@@ -343,9 +340,7 @@ export default class ConditionalPatcher extends NodePatcher {
     }
     let ifToken = notNull(this.sourceTokenAtIndex(ifTokenIndex));
     if (ifToken.type !== SourceType.IF) {
-      throw this.error(
-        `expected IF token at start of conditional, but got ${SourceType[ifToken.type]}`
-      );
+      throw this.error(`expected IF token at start of conditional, but got ${SourceType[ifToken.type]}`);
     }
     return ifTokenIndex;
   }
@@ -393,7 +388,9 @@ export default class ConditionalPatcher extends NodePatcher {
     }
 
     return this.indexOfSourceTokenBetweenSourceIndicesMatching(
-      this.condition.outerEnd, searchEnd, token => token.type === SourceType.THEN
+      this.condition.outerEnd,
+      searchEnd,
+      token => token.type === SourceType.THEN
     );
   }
 
@@ -406,9 +403,6 @@ export default class ConditionalPatcher extends NodePatcher {
       return false;
     }
 
-    return (
-      this.consequent.allCodePathsPresent() &&
-      this.alternate.allCodePathsPresent()
-    );
+    return this.consequent.allCodePathsPresent() && this.alternate.allCodePathsPresent();
   }
 }

--- a/src/stages/main/patchers/ConstructorPatcher.ts
+++ b/src/stages/main/patchers/ConstructorPatcher.ts
@@ -76,8 +76,7 @@ export default class ConstructorPatcher extends ObjectBodyMemberPatcher {
   }
 
   shouldAddBabelWorkaround(): boolean {
-    let shouldEnable = !this.options.disableBabelConstructorWorkaround &&
-      this.getInvalidConstructorMessage() !== null;
+    let shouldEnable = !this.options.disableBabelConstructorWorkaround && this.getInvalidConstructorMessage() !== null;
     if (shouldEnable) {
       this.addSuggestion(REMOVE_BABEL_WORKAROUND);
     }
@@ -154,11 +153,9 @@ export default class ConstructorPatcher extends ObjectBodyMemberPatcher {
     }
     let statements = this.expression.body.statements;
     for (let i = 0; i < statements.length; i++) {
-      let usesThis = containsDescendant(
-        statements[i].node,
-        child => child instanceof This,
-        {shouldStopTraversal: child => child instanceof Class || isFunction(child)}
-      );
+      let usesThis = containsDescendant(statements[i].node, child => child instanceof This, {
+        shouldStopTraversal: child => child instanceof Class || isFunction(child)
+      });
       if (usesThis) {
         return i;
       }

--- a/src/stages/main/patchers/DefaultParamPatcher.ts
+++ b/src/stages/main/patchers/DefaultParamPatcher.ts
@@ -4,7 +4,7 @@ import { PatcherContext } from '../../../patchers/types';
 export default class DefaultParamPatcher extends NodePatcher {
   param: NodePatcher;
   value: NodePatcher;
-  
+
   constructor(patcherContext: PatcherContext, param: NodePatcher, value: NodePatcher) {
     super(patcherContext);
     this.param = param;
@@ -15,7 +15,7 @@ export default class DefaultParamPatcher extends NodePatcher {
     this.param.setRequiresExpression();
     this.value.setRequiresExpression();
   }
-  
+
   patchAsExpression(): void {
     this.param.patch();
     this.value.patch();

--- a/src/stages/main/patchers/DoOpPatcher.ts
+++ b/src/stages/main/patchers/DoOpPatcher.ts
@@ -58,16 +58,16 @@ export default class DoOpPatcher extends NodePatcher {
    * should change default params to arguments to the do call.
    */
   hasDoFunction(): boolean {
-    return this.expression instanceof FunctionPatcher ||
-      (this.expression instanceof AssignOpPatcher &&
-        this.expression.expression instanceof FunctionPatcher);
+    return (
+      this.expression instanceof FunctionPatcher ||
+      (this.expression instanceof AssignOpPatcher && this.expression.expression instanceof FunctionPatcher)
+    );
   }
 
   getDoFunction(): FunctionPatcher {
     if (this.expression instanceof FunctionPatcher) {
       return this.expression;
-    } else if (this.expression instanceof AssignOpPatcher &&
-        this.expression.expression instanceof FunctionPatcher) {
+    } else if (this.expression instanceof AssignOpPatcher && this.expression.expression instanceof FunctionPatcher) {
       return this.expression.expression;
     } else {
       throw this.error('Should only call getDoFunction if hasDoFunction is true.');

--- a/src/stages/main/patchers/DynamicMemberAccessOpPatcher.ts
+++ b/src/stages/main/patchers/DynamicMemberAccessOpPatcher.ts
@@ -1,12 +1,10 @@
-import {
-  PatcherContext, PatchOptions, RepeatableOptions
-} from '../../../patchers/types';
+import { PatcherContext, PatchOptions, RepeatableOptions } from '../../../patchers/types';
 import NodePatcher from './../../../patchers/NodePatcher';
 
 export default class DynamicMemberAccessOpPatcher extends NodePatcher {
   expression: NodePatcher;
   indexingExpr: NodePatcher;
-  
+
   constructor(patcherContext: PatcherContext, expression: NodePatcher, indexingExpr: NodePatcher) {
     super(patcherContext);
     this.expression = expression;

--- a/src/stages/main/patchers/EqualityPatcher.ts
+++ b/src/stages/main/patchers/EqualityPatcher.ts
@@ -13,11 +13,7 @@ export default class EqualityPatcher extends BinaryOpPatcher {
 
   patchOperator(): void {
     let compareToken = this.getCompareToken();
-    this.overwrite(
-      compareToken.start,
-      compareToken.end,
-      this.getCompareOperator()
-    );
+    this.overwrite(compareToken.start, compareToken.end, this.getCompareOperator());
   }
 
   getCompareOperator(): string {
@@ -38,11 +34,7 @@ export default class EqualityPatcher extends BinaryOpPatcher {
     );
 
     if (!compareTokenIndex) {
-      throw this.error(
-        'expected OPERATOR token but none was found',
-        left.outerEnd,
-        right.outerStart
-      );
+      throw this.error('expected OPERATOR token but none was found', left.outerEnd, right.outerStart);
     }
 
     return notNull(this.sourceTokenAtIndex(compareTokenIndex));
@@ -54,8 +46,10 @@ export default class EqualityPatcher extends BinaryOpPatcher {
    * to the superclass default behavior of just adding ! to the front.
    */
   negate(): void {
-    if (isCompareOpNegationUnsafe(this.sourceOfToken(this.getCompareToken())) &&
-        !this.options.looseComparisonNegation) {
+    if (
+      isCompareOpNegationUnsafe(this.sourceOfToken(this.getCompareToken())) &&
+      !this.options.looseComparisonNegation
+    ) {
       return super.negate();
     }
     this.negated = !this.negated;

--- a/src/stages/main/patchers/ExistsOpCompoundAssignOpPatcher.ts
+++ b/src/stages/main/patchers/ExistsOpCompoundAssignOpPatcher.ts
@@ -3,10 +3,9 @@ import { SHORTEN_NULL_CHECKS } from '../../../suggestions';
 import CompoundAssignOpPatcher from './CompoundAssignOpPatcher';
 
 export default class ExistsOpCompoundAssignOpPatcher extends CompoundAssignOpPatcher {
-  patchAsExpression({needsParens = false}: PatchOptions = {}): void {
+  patchAsExpression({ needsParens = false }: PatchOptions = {}): void {
     this.addSuggestion(SHORTEN_NULL_CHECKS);
-    let shouldAddParens = this.negated ||
-      (needsParens && !this.isSurroundedByParentheses());
+    let shouldAddParens = this.negated || (needsParens && !this.isSurroundedByParentheses());
     if (this.negated) {
       this.insert(this.contentStart, '!');
     }
@@ -22,10 +21,7 @@ export default class ExistsOpCompoundAssignOpPatcher extends CompoundAssignOpPat
       assigneeAgain = this.assignee.patchRepeatable({ isForAssignment: true });
       // `typeof a ? b` → `typeof a !== 'undefined' && a !== null ? a ?= b`
       //                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      this.insert(
-        this.assignee.outerEnd,
-        ` !== 'undefined' && ${assigneeAgain} !== null ? ${assigneeAgain}`
-      );
+      this.insert(this.assignee.outerEnd, ` !== 'undefined' && ${assigneeAgain} !== null ? ${assigneeAgain}`);
     } else {
       assigneeAgain = this.assignee.patchRepeatable({ isForAssignment: true });
       // `a.b ?= b` → `a.b != null ? a.b ?= b`
@@ -62,10 +58,7 @@ export default class ExistsOpCompoundAssignOpPatcher extends CompoundAssignOpPat
       assigneeAgain = this.assignee.patchRepeatable({ isForAssignment: true });
       // `if (typeof a ?= b` → `if (typeof a === 'undefined' || a === null) { ?= b`
       //                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      this.insert(
-        this.assignee.outerEnd,
-        ` === 'undefined' || ${assigneeAgain} === null) {`
-      );
+      this.insert(this.assignee.outerEnd, ` === 'undefined' || ${assigneeAgain} === null) {`);
     } else {
       // `a.b ?= b` → `if (a.b ?= b`
       //               ^^^^

--- a/src/stages/main/patchers/ExistsOpPatcher.ts
+++ b/src/stages/main/patchers/ExistsOpPatcher.ts
@@ -36,11 +36,7 @@ export default class ExistsOpPatcher extends BinaryOpPatcher {
       let leftAgain = this.left.patchRepeatable({ parens: true, ref: 'left' });
       // `a.b ? c` → `a.b != null ? a.b : c`
       //     ^^^         ^^^^^^^^^^^^^^^^^
-      this.overwrite(
-        this.left.outerEnd,
-        this.right.outerStart,
-        ` != null ? ${leftAgain} : `
-      );
+      this.overwrite(this.left.outerEnd, this.right.outerStart, ` != null ? ${leftAgain} : `);
     }
     this.right.patch();
   }
@@ -61,20 +57,12 @@ export default class ExistsOpPatcher extends BinaryOpPatcher {
       this.insert(this.contentStart, `typeof `);
       // `if (typeof a ? b` → `if (typeof a === 'undefined' || a === null) { b`
       //              ^^^                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      this.overwrite(
-        this.left.outerEnd,
-        this.right.outerStart,
-        ` === 'undefined' || ${leftAgain} === null) { `
-      );
+      this.overwrite(this.left.outerEnd, this.right.outerStart, ` === 'undefined' || ${leftAgain} === null) { `);
     } else {
       this.left.patch();
       // `if (a.b ? b.c` → `if (a.b == null) { b.c`
       //         ^^^               ^^^^^^^^^^^^
-      this.overwrite(
-        this.left.outerEnd,
-        this.right.outerStart,
-        ` == null) { `
-      );
+      this.overwrite(this.left.outerEnd, this.right.outerStart, ` == null) { `);
     }
 
     this.right.patch();

--- a/src/stages/main/patchers/ExpansionPatcher.ts
+++ b/src/stages/main/patchers/ExpansionPatcher.ts
@@ -7,8 +7,6 @@ export default class ExpansionPatcher extends NodePatcher {
     // Any code handling expansions should process them without calling patch.
     // If patch ends up being called, then that means that we've hit an
     // unsupported case that's trying to treat this node as a normal expression.
-    throw this.error(
-      'Unexpected traversal of expansion node.'
-    );
+    throw this.error('Unexpected traversal of expansion node.');
   }
 }

--- a/src/stages/main/patchers/ExportNamedDeclarationPatcher.ts
+++ b/src/stages/main/patchers/ExportNamedDeclarationPatcher.ts
@@ -1,5 +1,5 @@
 import NodePatcher from '../../../patchers/NodePatcher';
-import {PatcherContext} from '../../../patchers/types';
+import { PatcherContext } from '../../../patchers/types';
 import AssignOpPatcher from './AssignOpPatcher';
 
 export default class ExportNamedDeclarationPatcher extends NodePatcher {

--- a/src/stages/main/patchers/FloorDivideOpCompoundAssignOpPatcher.ts
+++ b/src/stages/main/patchers/FloorDivideOpCompoundAssignOpPatcher.ts
@@ -2,9 +2,8 @@ import { PatchOptions } from '../../../patchers/types';
 import CompoundAssignOpPatcher from './CompoundAssignOpPatcher';
 
 export default class FloorDivideOpCompoundAssignOpPatcher extends CompoundAssignOpPatcher {
-  patchAsExpression({needsParens = false}: PatchOptions = {}): void {
-    let shouldAddParens = this.negated ||
-      (needsParens && !this.isSurroundedByParentheses());
+  patchAsExpression({ needsParens = false }: PatchOptions = {}): void {
+    let shouldAddParens = this.negated || (needsParens && !this.isSurroundedByParentheses());
     if (this.negated) {
       this.insert(this.contentStart, '!');
     }

--- a/src/stages/main/patchers/ForFromPatcher.ts
+++ b/src/stages/main/patchers/ForFromPatcher.ts
@@ -1,12 +1,15 @@
 import NodePatcher from '../../../patchers/NodePatcher';
-import {PatcherContext} from '../../../patchers/types';
+import { PatcherContext } from '../../../patchers/types';
 import BlockPatcher from './BlockPatcher';
 import ForInPatcher from './ForInPatcher';
 
 export default class ForFromPatcher extends ForInPatcher {
   constructor(
-    patcherContext: PatcherContext, keyAssignee: NodePatcher | null,
-    valAssignee: NodePatcher | null, target: NodePatcher, filter: NodePatcher | null,
+    patcherContext: PatcherContext,
+    keyAssignee: NodePatcher | null,
+    valAssignee: NodePatcher | null,
+    target: NodePatcher,
+    filter: NodePatcher | null,
     body: BlockPatcher
   ) {
     super(patcherContext, keyAssignee, valAssignee, target, null /* step */, filter, body);

--- a/src/stages/main/patchers/ForInPatcher.ts
+++ b/src/stages/main/patchers/ForInPatcher.ts
@@ -1,13 +1,8 @@
 import { traverse } from 'decaffeinate-parser';
-import {
-  Float, Int, Number, UnaryNegateOp
-} from 'decaffeinate-parser/dist/nodes';
+import { Float, Int, Number, UnaryNegateOp } from 'decaffeinate-parser/dist/nodes';
 import NodePatcher from '../../../patchers/NodePatcher';
 import { PatcherContext } from '../../../patchers/types';
-import {
-  REMOVE_ARRAY_FROM,
-  SIMPLIFY_DYNAMIC_RANGE_LOOPS
-} from '../../../suggestions';
+import { REMOVE_ARRAY_FROM, SIMPLIFY_DYNAMIC_RANGE_LOOPS } from '../../../suggestions';
 import blockStartsWithObjectInitialiser from '../../../utils/blockStartsWithObjectInitialiser';
 import countVariableUsages from '../../../utils/countVariableUsages';
 import notNull from '../../../utils/notNull';
@@ -40,9 +35,14 @@ export default class ForInPatcher extends ForPatcher {
   _step: Step | null = null;
 
   constructor(
-      patcherContext: PatcherContext, keyAssignee: NodePatcher | null,
-      valAssignee: NodePatcher | null, target: NodePatcher,
-      step: NodePatcher | null, filter: NodePatcher | null, body: BlockPatcher) {
+    patcherContext: PatcherContext,
+    keyAssignee: NodePatcher | null,
+    valAssignee: NodePatcher | null,
+    target: NodePatcher,
+    step: NodePatcher | null,
+    filter: NodePatcher | null,
+    body: BlockPatcher
+  ) {
     super(patcherContext, keyAssignee, valAssignee, target, filter, body);
     this.step = step;
   }
@@ -86,10 +86,7 @@ export default class ForInPatcher extends ForPatcher {
     let mapInsertPoint;
     if (this.filter !== null) {
       // b when c d  ->  b.filter((a) => c d
-      this.overwrite(
-        this.target.outerEnd, this.filter.outerStart,
-        `.filter((${assigneeCode}) => `
-      );
+      this.overwrite(this.target.outerEnd, this.filter.outerStart, `.filter((${assigneeCode}) => `);
       this.filter.patch();
       // b.filter((a) => c d  ->  b.filter((a) => c).map((a) => d
       this.insert(this.filter.outerEnd, `)`);
@@ -115,11 +112,9 @@ export default class ForInPatcher extends ForPatcher {
   isMapBodyNoOp(): boolean {
     if (this.valAssignee instanceof IdentifierPatcher) {
       let varName = this.valAssignee.node.data;
-      if (this.body instanceof BlockPatcher &&
-          this.body.statements.length === 1) {
+      if (this.body instanceof BlockPatcher && this.body.statements.length === 1) {
         let statement = this.body.statements[0];
-        if (statement instanceof IdentifierPatcher &&
-            statement.node.data === varName) {
+        if (statement instanceof IdentifierPatcher && statement.node.data === varName) {
           return true;
         }
       }
@@ -132,8 +127,7 @@ export default class ForInPatcher extends ForPatcher {
       throw this.error('Expected non-null body.');
     }
     this.body.setRequiresExpression();
-    let bodyNeedsParens = blockStartsWithObjectInitialiser(this.body)
-      && !this.body.isSurroundedByParentheses();
+    let bodyNeedsParens = blockStartsWithObjectInitialiser(this.body) && !this.body.isSurroundedByParentheses();
     if (bodyNeedsParens) {
       let insertPoint = this.filter ? this.filter.outerEnd : this.target.outerEnd;
       // Handle both inline and multiline cases by either skipping the existing
@@ -232,11 +226,7 @@ export default class ForInPatcher extends ForPatcher {
    * Overridden by CS for...from to always patch as JS for...of.
    */
   shouldPatchAsForOf(): boolean {
-    return (
-      !this.shouldPatchAsInitTestUpdateLoop() &&
-      this.step === null &&
-      this.keyAssignee === null
-    );
+    return !this.shouldPatchAsInitTestUpdateLoop() && this.step === null && this.keyAssignee === null;
   }
 
   getValueBinding(): string {
@@ -338,18 +328,11 @@ export default class ForInPatcher extends ForPatcher {
   }
 
   getLoopHeaderEnd(): number {
-    return Math.max(
-      this.step ? this.step.outerEnd : -1,
-      super.getLoopHeaderEnd()
-    );
+    return Math.max(this.step ? this.step.outerEnd : -1, super.getLoopHeaderEnd());
   }
 
   requiresExtractingTarget(): boolean {
-    return (
-      !this.shouldPatchAsInitTestUpdateLoop() &&
-      !this.target.isRepeatable() &&
-      !this.shouldPatchAsForOf()
-    );
+    return !this.shouldPatchAsInitTestUpdateLoop() && !this.target.isRepeatable() && !this.shouldPatchAsForOf();
   }
 
   targetBindingCandidate(): string {
@@ -529,9 +512,7 @@ export default class ForInPatcher extends ForPatcher {
     if (!(this.target instanceof RangePatcher)) {
       throw this.error('Expected target to be a range.');
     }
-    return !this.target.left.isRepeatable() &&
-      this.getIndexDirection() === UNKNOWN &&
-      this.getStep().isVirtual;
+    return !this.target.left.isRepeatable() && this.getIndexDirection() === UNKNOWN && this.getStep().isVirtual;
   }
 
   getStartCode(): string {
@@ -587,8 +568,8 @@ export default class ForInPatcher extends ForPatcher {
     if (step.isVirtual) {
       if (!this.shouldPatchAsInitTestUpdateLoop()) {
         throw new Error(
-          'Should not be getting asc code when the target is not a range and ' +
-          'the step is unspecified.');
+          'Should not be getting asc code when the target is not a range and ' + 'the step is unspecified.'
+        );
       }
       return `${this.getStartReference()} <= ${this.getEndReference()}`;
     } else {

--- a/src/stages/main/patchers/ForOfPatcher.ts
+++ b/src/stages/main/patchers/ForOfPatcher.ts
@@ -26,10 +26,7 @@ export default class ForOfPatcher extends ForPatcher {
 
     let shouldExtractTarget = this.requiresExtractingTarget();
     if (shouldExtractTarget) {
-      this.insert(
-        this.innerStart,
-        `${this.getTargetReference()} = ${this.getTargetCode()}\n${this.getLoopIndent()}`
-      );
+      this.insert(this.innerStart, `${this.getTargetReference()} = ${this.getTargetCode()}\n${this.getLoopIndent()}`);
     }
 
     let keyBinding = this.getIndexBinding();
@@ -62,8 +59,7 @@ export default class ForOfPatcher extends ForPatcher {
     if (this.node.isOwn) {
       this.addSuggestion(CLEAN_UP_FOR_OWN_LOOPS);
       if (shouldExtractTarget) {
-        this.overwrite(relationToken.end, this.target.outerEnd,
-          ` Object.keys(${targetReference} || {})) {`);
+        this.overwrite(relationToken.end, this.target.outerEnd, ` Object.keys(${targetReference} || {})) {`);
       } else {
         // `for (k of o` → `for (k of Object.keys(o`
         //                            ^^^^^^^^^^^^
@@ -75,8 +71,7 @@ export default class ForOfPatcher extends ForPatcher {
       }
     } else {
       if (shouldExtractTarget) {
-        this.overwrite(relationToken.start, this.target.outerEnd,
-          `in ${targetReference}) {`);
+        this.overwrite(relationToken.start, this.target.outerEnd, `in ${targetReference}) {`);
       } else {
         // `for (k of o` → `for (k in o`
         //         ^^              ^^
@@ -98,10 +93,7 @@ export default class ForOfPatcher extends ForPatcher {
 
   removeOwnTokenIfExists(): void {
     if (this.node.isOwn) {
-      let ownIndex = this.indexOfSourceTokenAfterSourceTokenIndex(
-        this.contentStartTokenIndex,
-        SourceType.OWN
-      );
+      let ownIndex = this.indexOfSourceTokenAfterSourceTokenIndex(this.contentStartTokenIndex, SourceType.OWN);
       if (!ownIndex) {
         throw this.error('Expected to find own token in for-own.');
       }
@@ -126,4 +118,3 @@ export default class ForOfPatcher extends ForPatcher {
     return this.willPatchAsExpression();
   }
 }
-

--- a/src/stages/main/patchers/ForPatcher.ts
+++ b/src/stages/main/patchers/ForPatcher.ts
@@ -21,9 +21,13 @@ export default abstract class ForPatcher extends LoopPatcher {
   _targetReference: string | null = null;
 
   constructor(
-      patcherContext: PatcherContext, keyAssignee: NodePatcher | null,
-      valAssignee: NodePatcher | null, target: NodePatcher,
-      filter: NodePatcher | null, body: BlockPatcher) {
+    patcherContext: PatcherContext,
+    keyAssignee: NodePatcher | null,
+    valAssignee: NodePatcher | null,
+    target: NodePatcher,
+    filter: NodePatcher | null,
+    body: BlockPatcher
+  ) {
     super(patcherContext, body);
     this.keyAssignee = keyAssignee;
     this.valAssignee = valAssignee;
@@ -117,7 +121,8 @@ export default abstract class ForPatcher extends LoopPatcher {
       throw this.error('Expected to find a good starting point to search for relation token.');
     }
     let tokenIndex = this.indexOfSourceTokenBetweenSourceIndicesMatching(
-      searchStart, this.target.outerStart,
+      searchStart,
+      this.target.outerStart,
       // "of" and "in" are relation tokens, but "from" is a plain identifier.
       token => token.type === SourceType.RELATION || token.type === SourceType.IDENTIFIER
     );
@@ -185,7 +190,9 @@ export default abstract class ForPatcher extends LoopPatcher {
       }
     }
     let index = this.indexOfSourceTokenBetweenSourceIndicesMatching(
-      searchStart, searchEnd, token => token.type === SourceType.THEN
+      searchStart,
+      searchEnd,
+      token => token.type === SourceType.THEN
     );
     if (index) {
       let thenToken = notNull(this.sourceTokenAtIndex(index));
@@ -205,10 +212,7 @@ export default abstract class ForPatcher extends LoopPatcher {
    * elements.
    */
   getLoopHeaderEnd(): number {
-    return Math.max(
-      this.filter ? this.filter.outerEnd : -1,
-      this.target.outerEnd,
-    );
+    return Math.max(this.filter ? this.filter.outerEnd : -1, this.target.outerEnd);
   }
 
   getTargetCode(): string {

--- a/src/stages/main/patchers/FunctionApplicationPatcher.ts
+++ b/src/stages/main/patchers/FunctionApplicationPatcher.ts
@@ -22,7 +22,7 @@ export default class FunctionApplicationPatcher extends NodePatcher {
    * Note that we don't need to worry about implicit function applications,
    * since the normalize stage would have already added parens.
    */
-  patchAsExpression({fnNeedsParens = false}: PatchOptions = {}): void {
+  patchAsExpression({ fnNeedsParens = false }: PatchOptions = {}): void {
     let { args, outerEndTokenIndex } = this;
 
     if (fnNeedsParens) {

--- a/src/stages/main/patchers/FunctionPatcher.ts
+++ b/src/stages/main/patchers/FunctionPatcher.ts
@@ -27,7 +27,7 @@ export default class FunctionPatcher extends NodePatcher {
     });
   }
 
-  patchAsExpression({method=false}: PatchOptions = {}): void {
+  patchAsExpression({ method = false }: PatchOptions = {}): void {
     this.patchFunctionStart({ method });
     this.parameters.forEach((parameter, i) => {
       let isLast = i === this.parameters.length - 1;
@@ -40,7 +40,7 @@ export default class FunctionPatcher extends NodePatcher {
     this.patchFunctionBody();
   }
 
-  patchFunctionStart({method=false}: {method: boolean}): void {
+  patchFunctionStart({ method = false }: { method: boolean }): void {
     let arrow = this.getArrowToken();
 
     if (!method) {
@@ -72,8 +72,7 @@ export default class FunctionPatcher extends NodePatcher {
   }
 
   isEndOfFunctionCall(): boolean {
-    return this.parent instanceof FunctionApplicationPatcher &&
-      this.parent.args[this.parent.args.length - 1] === this;
+    return this.parent instanceof FunctionApplicationPatcher && this.parent.args[this.parent.args.length - 1] === this;
   }
 
   /**
@@ -89,7 +88,8 @@ export default class FunctionPatcher extends NodePatcher {
       throw this.error('Expected non-null body.');
     }
     let closeParenIndex = notNull(this.parent).indexOfSourceTokenBetweenSourceIndicesMatching(
-      this.contentEnd, notNull(this.parent).contentEnd,
+      this.contentEnd,
+      notNull(this.parent).contentEnd,
       token => token.type === SourceType.CALL_END || token.type === SourceType.RPAREN
     );
     if (!closeParenIndex) {
@@ -99,8 +99,7 @@ export default class FunctionPatcher extends NodePatcher {
     if (!closeParen) {
       throw this.error('Expected to find close paren after function call.');
     }
-    let shouldMoveCloseParen = !this.body.inline() &&
-      !this.slice(this.contentEnd, closeParen.start).includes('\n');
+    let shouldMoveCloseParen = !this.body.inline() && !this.slice(this.contentEnd, closeParen.start).includes('\n');
     if (shouldMoveCloseParen) {
       this.appendLineAfter('}', -1);
     } else {
@@ -111,12 +110,11 @@ export default class FunctionPatcher extends NodePatcher {
   getArrowToken(): SourceToken {
     let arrowIndex = this.contentStartTokenIndex;
     if (this.hasParamStart()) {
-      let parenRange = this.getProgramSourceTokens()
-        .rangeOfMatchingTokensContainingTokenIndex(
-          SourceType.LPAREN,
-          SourceType.RPAREN,
-          this.contentStartTokenIndex
-        );
+      let parenRange = this.getProgramSourceTokens().rangeOfMatchingTokensContainingTokenIndex(
+        SourceType.LPAREN,
+        SourceType.RPAREN,
+        this.contentStartTokenIndex
+      );
       if (!parenRange) {
         throw this.error('Expected to find function paren range in function.');
       }
@@ -124,10 +122,7 @@ export default class FunctionPatcher extends NodePatcher {
       if (!rparenIndex) {
         throw this.error('Expected to find rparen index in function.');
       }
-      arrowIndex = notNull(this.indexOfSourceTokenAfterSourceTokenIndex(
-        rparenIndex,
-        SourceType.FUNCTION
-      ));
+      arrowIndex = notNull(this.indexOfSourceTokenAfterSourceTokenIndex(rparenIndex, SourceType.FUNCTION));
     }
     let arrow = this.sourceTokenAtIndex(arrowIndex);
     if (!arrow) {
@@ -136,10 +131,7 @@ export default class FunctionPatcher extends NodePatcher {
     let expectedArrowType = this.expectedArrowType();
     let actualArrowType = this.sourceOfToken(arrow);
     if (actualArrowType !== expectedArrowType) {
-      throw this.error(
-        `expected '${expectedArrowType}' but found ${actualArrowType}`,
-        arrow.start, arrow.end
-      );
+      throw this.error(`expected '${expectedArrowType}' but found ${actualArrowType}`, arrow.start, arrow.end);
     }
     return arrow;
   }

--- a/src/stages/main/patchers/GeneratorFunctionPatcher.ts
+++ b/src/stages/main/patchers/GeneratorFunctionPatcher.ts
@@ -4,13 +4,13 @@ import FunctionPatcher from './FunctionPatcher';
  * Handles generator functions, i.e. produced by embedding `yield` statements.
  */
 export default class GeneratorFunctionPatcher extends FunctionPatcher {
-  patchFunctionStart({method=false}: {method: boolean}): void {
+  patchFunctionStart({ method = false }: { method: boolean }): void {
     let arrow = this.getArrowToken();
 
     if (!method) {
       this.insert(this.contentStart, 'function*');
     }
-    
+
     if (!this.hasParamStart()) {
       this.insert(this.contentStart, '() ');
     }

--- a/src/stages/main/patchers/HeregexPatcher.ts
+++ b/src/stages/main/patchers/HeregexPatcher.ts
@@ -1,4 +1,4 @@
-import {Heregex} from 'decaffeinate-parser/dist/nodes';
+import { Heregex } from 'decaffeinate-parser/dist/nodes';
 import InterpolatedPatcher from './InterpolatedPatcher';
 
 const CLOSE_TOKEN_BASE_LENGTH = 3;
@@ -13,8 +13,8 @@ export default class HeregexPatcher extends InterpolatedPatcher {
     this.overwrite(openToken.start, openToken.end, 'new RegExp(`');
     if (closeToken.end - closeToken.start > CLOSE_TOKEN_BASE_LENGTH) {
       // If the close token has flags, e.g. ///gi, keep the flags as a string literal.
-      this.overwrite(closeToken.start, closeToken.start + CLOSE_TOKEN_BASE_LENGTH, '`, \'');
-      this.insert(closeToken.end, '\')');
+      this.overwrite(closeToken.start, closeToken.start + CLOSE_TOKEN_BASE_LENGTH, "`, '");
+      this.insert(closeToken.end, "')");
     } else {
       // Otherwise, don't specify flags.
       this.overwrite(closeToken.start, closeToken.end, '`)');

--- a/src/stages/main/patchers/InOpPatcher.ts
+++ b/src/stages/main/patchers/InOpPatcher.ts
@@ -3,10 +3,7 @@ import SourceToken from 'coffee-lex/dist/SourceToken';
 import { InOp } from 'decaffeinate-parser/dist/nodes';
 import NodePatcher from '../../../patchers/NodePatcher';
 import { PatcherContext } from '../../../patchers/types';
-import {
-  FIX_INCLUDES_EVALUATION_ORDER,
-  REMOVE_ARRAY_FROM
-} from '../../../suggestions';
+import { FIX_INCLUDES_EVALUATION_ORDER, REMOVE_ARRAY_FROM } from '../../../suggestions';
 import ArrayInitialiserPatcher from './ArrayInitialiserPatcher';
 import BinaryOpPatcher from './BinaryOpPatcher';
 import DynamicMemberAccessOpPatcher from './DynamicMemberAccessOpPatcher';
@@ -131,12 +128,14 @@ export default class InOpPatcher extends BinaryOpPatcher {
     // In typical cases, when converting `a in b` to `b.includes(a)`, parens
     // won't be necessary around the `b`, but to be safe, only skip the parens
     // in a specific set of known-good cases.
-    return !(this.right instanceof IdentifierPatcher) &&
+    return (
+      !(this.right instanceof IdentifierPatcher) &&
       !(this.right instanceof MemberAccessOpPatcher) &&
       !(this.right instanceof DynamicMemberAccessOpPatcher) &&
       !(this.right instanceof FunctionApplicationPatcher) &&
       !(this.right instanceof ArrayInitialiserPatcher) &&
-      !(this.right instanceof StringPatcher);
+      !(this.right instanceof StringPatcher)
+    );
   }
 
   patchAsIndexLookup(): void {

--- a/src/stages/main/patchers/InterpolatedPatcher.ts
+++ b/src/stages/main/patchers/InterpolatedPatcher.ts
@@ -2,8 +2,7 @@ import { SourceType } from 'coffee-lex';
 
 import SourceToken from 'coffee-lex/dist/SourceToken';
 import { PatcherContext } from '../../../patchers/types';
-import downgradeUnicodeCodePointEscapesInRange
-  from '../../../utils/downgradeUnicodeCodePointEscapesInRange';
+import downgradeUnicodeCodePointEscapesInRange from '../../../utils/downgradeUnicodeCodePointEscapesInRange';
 import escape from '../../../utils/escape';
 import escapeSpecialWhitespaceInRange from '../../../utils/escapeSpecialWhitespaceInRange';
 import escapeZeroCharsInRange from '../../../utils/escapeZeroCharsInRange';
@@ -45,14 +44,15 @@ export default class InterpolatedPatcher extends NodePatcher {
 
   getInterpolationStartTokenAtIndex(index: number): SourceToken {
     let interpolationStartIndex = this.indexOfSourceTokenBetweenSourceIndicesMatching(
-      this.quasis[index].contentEnd, this.contentEnd, token => token.type === SourceType.INTERPOLATION_START
+      this.quasis[index].contentEnd,
+      this.contentEnd,
+      token => token.type === SourceType.INTERPOLATION_START
     );
     if (!interpolationStartIndex) {
       throw this.error('Cannot find interpolation start for string interpolation.');
     }
     let interpolationStart = this.sourceTokenAtIndex(interpolationStartIndex);
-    if (!interpolationStart ||
-        this.slice(interpolationStart.start, interpolationStart.start + 1) !== '#') {
+    if (!interpolationStart || this.slice(interpolationStart.start, interpolationStart.start + 1) !== '#') {
       throw this.error("Cannot find '#' in interpolation start.");
     }
     return interpolationStart;
@@ -73,8 +73,9 @@ export default class InterpolatedPatcher extends NodePatcher {
    */
   processContents(): void {
     for (let quasi of this.quasis) {
-      let tokens = this.getProgramSourceTokens().slice(
-        quasi.contentStartTokenIndex, notNull(quasi.contentEndTokenIndex.next())).toArray();
+      let tokens = this.getProgramSourceTokens()
+        .slice(quasi.contentStartTokenIndex, notNull(quasi.contentEndTokenIndex.next()))
+        .toArray();
       for (let token of tokens) {
         if (token.type === SourceType.STRING_PADDING || token.type === SourceType.HEREGEXP_COMMENT) {
           let paddingCode = this.slice(token.start, token.end);
@@ -88,7 +89,7 @@ export default class InterpolatedPatcher extends NodePatcher {
             escapeZeroCharsInRange(token.start, token.end, this);
           }
           if (this.shouldDowngradeUnicodeCodePointEscapes()) {
-            downgradeUnicodeCodePointEscapesInRange(token.start, token.end, this, {needsExtraEscape: true});
+            downgradeUnicodeCodePointEscapesInRange(token.start, token.end, this, { needsExtraEscape: true });
           }
         }
       }
@@ -105,8 +106,9 @@ export default class InterpolatedPatcher extends NodePatcher {
 
   escapeQuasis(skipPattern: RegExp, escapeStrings: Array<string>): void {
     for (let quasi of this.quasis) {
-      let tokens = this.getProgramSourceTokens().slice(
-        quasi.contentStartTokenIndex, notNull(quasi.contentEndTokenIndex.next())).toArray();
+      let tokens = this.getProgramSourceTokens()
+        .slice(quasi.contentStartTokenIndex, notNull(quasi.contentEndTokenIndex.next()))
+        .toArray();
       for (let token of tokens) {
         if (token.type === SourceType.STRING_CONTENT) {
           escape(this.context.source, this.editor, skipPattern, escapeStrings, token.start, token.end);

--- a/src/stages/main/patchers/JavaScriptPatcher.ts
+++ b/src/stages/main/patchers/JavaScriptPatcher.ts
@@ -13,8 +13,9 @@ export default class JavaScriptPatcher extends NodePatcher {
     // For any normal surrounding parens, CoffeeScript's rule is to remove them,
     // which allows things like comment-only inline JS. Function call parens
     // should not be removed, though.
-    let shouldRemoveSurroundingParens =
-      !(this.parent instanceof FunctionApplicationPatcher && this === this.parent.args[0]);
+    let shouldRemoveSurroundingParens = !(
+      this.parent instanceof FunctionApplicationPatcher && this === this.parent.args[0]
+    );
 
     if (shouldRemoveSurroundingParens) {
       this.remove(this.outerStart, this.contentStart);

--- a/src/stages/main/patchers/LogicalOpCompoundAssignOpPatcher.ts
+++ b/src/stages/main/patchers/LogicalOpCompoundAssignOpPatcher.ts
@@ -2,9 +2,8 @@ import { PatchOptions } from '../../../patchers/types';
 import CompoundAssignOpPatcher from './CompoundAssignOpPatcher';
 
 export default class LogicalOpCompoundAssignOpPatcher extends CompoundAssignOpPatcher {
-  patchAsExpression({needsParens = false}: PatchOptions = {}): void {
-    let shouldAddParens = this.negated ||
-      (needsParens && !this.isSurroundedByParentheses());
+  patchAsExpression({ needsParens = false }: PatchOptions = {}): void {
+    let shouldAddParens = this.negated || (needsParens && !this.isSurroundedByParentheses());
     if (this.negated) {
       this.insert(this.contentStart, '!');
     }
@@ -16,11 +15,7 @@ export default class LogicalOpCompoundAssignOpPatcher extends CompoundAssignOpPa
 
     // `a &&= b` → `a && b`
     //    ^^^         ^^
-    this.overwrite(
-      operator.start,
-      operator.end,
-      this.isOrOp() ? `||` : `&&`
-    );
+    this.overwrite(operator.start, operator.end, this.isOrOp() ? `||` : `&&`);
 
     let assigneeAgain = this.assignee.patchRepeatable({ isForAssignment: true });
 
@@ -58,7 +53,7 @@ export default class LogicalOpCompoundAssignOpPatcher extends CompoundAssignOpPa
     // `if (a &&= b` → `if (a) { a = b`
     //       ^^^^^           ^^^^^^^^
     this.overwrite(this.assignee.outerEnd, this.expression.outerStart, `) { ${assigneeAgain} = `);
-    
+
     this.expression.patch();
 
     // `if (a) { a = b` → `if (a) { a = b }`

--- a/src/stages/main/patchers/LogicalOpPatcher.ts
+++ b/src/stages/main/patchers/LogicalOpPatcher.ts
@@ -16,11 +16,7 @@ export default class LogicalOpPatcher extends BinaryOpPatcher {
 
   patchOperator(): void {
     let operatorToken = this.getOperatorToken();
-    this.overwrite(
-      operatorToken.start,
-      operatorToken.end,
-      this.getOperator()
-    );
+    this.overwrite(operatorToken.start, operatorToken.end, this.getOperator());
   }
 
   /**
@@ -30,10 +26,7 @@ export default class LogicalOpPatcher extends BinaryOpPatcher {
    */
   getOperator(): string {
     let operatorToken = this.getOperatorToken();
-    let operator = this.context.source.slice(
-      operatorToken.start,
-      operatorToken.end
-    );
+    let operator = this.context.source.slice(operatorToken.start, operatorToken.end);
     if (operator === 'and') {
       operator = '&&';
     } else if (operator === 'or') {

--- a/src/stages/main/patchers/MemberAccessOpPatcher.ts
+++ b/src/stages/main/patchers/MemberAccessOpPatcher.ts
@@ -1,9 +1,7 @@
 import { SourceType } from 'coffee-lex';
 import SourceToken from 'coffee-lex/dist/SourceToken';
 import { MemberAccessOp } from 'decaffeinate-parser/dist/nodes';
-import {
-  PatcherContext, PatchOptions, RepeatableOptions
-} from '../../../patchers/types';
+import { PatcherContext, PatchOptions, RepeatableOptions } from '../../../patchers/types';
 import notNull from '../../../utils/notNull';
 import NodePatcher from './../../../patchers/NodePatcher';
 import IdentifierPatcher from './IdentifierPatcher';
@@ -48,7 +46,8 @@ export default class MemberAccessOpPatcher extends NodePatcher {
    * We can make member accesses repeatable by making the base expression
    * repeatable if it isn't already.
    */
-  patchAsRepeatableExpression(repeatableOptions: RepeatableOptions = {}, patchOptions: PatchOptions = {}): string {  // eslint-disable-line no-unused-vars
+  patchAsRepeatableExpression(repeatableOptions: RepeatableOptions = {}, patchOptions: PatchOptions = {}): string {
+    // eslint-disable-line no-unused-vars
     if (repeatableOptions.isForAssignment) {
       this.expression.setRequiresRepeatableExpression({ isForAssignment: true, parens: true, ref: 'base' });
       this.patchAsExpression();
@@ -65,7 +64,9 @@ export default class MemberAccessOpPatcher extends NodePatcher {
 
   getMemberOperatorSourceToken(): SourceToken | null {
     let dotIndex = this.indexOfSourceTokenBetweenSourceIndicesMatching(
-      this.expression.outerEnd, this.outerEnd - 1, token => token.type === SourceType.DOT
+      this.expression.outerEnd,
+      this.outerEnd - 1,
+      token => token.type === SourceType.DOT
     );
 
     if (!dotIndex) {

--- a/src/stages/main/patchers/ModuloOpCompoundAssignOpPatcher.ts
+++ b/src/stages/main/patchers/ModuloOpCompoundAssignOpPatcher.ts
@@ -3,11 +3,10 @@ import registerModHelper from '../../../utils/registerModHelper';
 import CompoundAssignOpPatcher from './CompoundAssignOpPatcher';
 
 export default class ModuloOpCompoundAssignOpPatcher extends CompoundAssignOpPatcher {
-  patchAsExpression({needsParens = false}: PatchOptions = {}): void {
+  patchAsExpression({ needsParens = false }: PatchOptions = {}): void {
     let helper = registerModHelper(this);
 
-    let shouldAddParens = this.negated ||
-      (needsParens && !this.isSurroundedByParentheses());
+    let shouldAddParens = this.negated || (needsParens && !this.isSurroundedByParentheses());
     if (this.negated) {
       this.insert(this.contentStart, '!');
     }

--- a/src/stages/main/patchers/NegatableBinaryOpPatcher.ts
+++ b/src/stages/main/patchers/NegatableBinaryOpPatcher.ts
@@ -8,7 +8,7 @@ import BinaryOpPatcher from './BinaryOpPatcher';
  */
 export default class NegatableBinaryOpPatcher extends BinaryOpPatcher {
   negated: boolean;
-  
+
   constructor(patcherContext: PatcherContext, left: NodePatcher, right: NodePatcher) {
     super(patcherContext, left, right);
     this.negated = (patcherContext.node as OfOp | InstanceofOp).isNot;

--- a/src/stages/main/patchers/NewOpPatcher.ts
+++ b/src/stages/main/patchers/NewOpPatcher.ts
@@ -7,7 +7,8 @@ import MemberAccessOpPatcher from './MemberAccessOpPatcher';
  */
 export default class NewOpPatcher extends FunctionApplicationPatcher {
   patchAsExpression(): void {
-    let fnNeedsParens = !this.fn.isSurroundedByParentheses() &&
+    let fnNeedsParens =
+      !this.fn.isSurroundedByParentheses() &&
       !(this.fn instanceof IdentifierPatcher) &&
       !(this.fn instanceof MemberAccessOpPatcher);
     super.patchAsExpression({ fnNeedsParens });

--- a/src/stages/main/patchers/ObjectBodyMemberPatcher.ts
+++ b/src/stages/main/patchers/ObjectBodyMemberPatcher.ts
@@ -1,4 +1,4 @@
-import {ObjectInitialiserMember} from 'decaffeinate-parser/dist/nodes';
+import { ObjectInitialiserMember } from 'decaffeinate-parser/dist/nodes';
 import { PatcherContext } from '../../../patchers/types';
 import NodePatcher from './../../../patchers/NodePatcher';
 import AsyncFunctionPatcher from './AsyncFunctionPatcher';
@@ -111,11 +111,13 @@ export default abstract class ObjectBodyMemberPatcher extends NodePatcher {
    * gets the patcher for that computed key node, if any.
    */
   getComputedKeyPatcher(): NodePatcher | null {
-    if (this.key instanceof StringPatcher &&
-        this.key.quasis.length === 2 &&
-        this.key.expressions.length === 1 &&
-        this.key.quasis[0].node.data === '' &&
-        this.key.quasis[1].node.data === '') {
+    if (
+      this.key instanceof StringPatcher &&
+      this.key.quasis.length === 2 &&
+      this.key.expressions.length === 1 &&
+      this.key.quasis[0].node.data === '' &&
+      this.key.quasis[1].node.data === ''
+    ) {
       return this.key.expressions[0];
     }
     return null;
@@ -139,9 +141,11 @@ export default abstract class ObjectBodyMemberPatcher extends NodePatcher {
    * @protected
    */
   isMethod(): boolean {
-    return this.expression instanceof FunctionPatcher &&
-        !(this.expression instanceof ManuallyBoundFunctionPatcher) &&
-        !(this.expression instanceof BoundFunctionPatcher);
+    return (
+      this.expression instanceof FunctionPatcher &&
+      !(this.expression instanceof ManuallyBoundFunctionPatcher) &&
+      !(this.expression instanceof BoundFunctionPatcher)
+    );
   }
 
   /**
@@ -152,12 +156,12 @@ export default abstract class ObjectBodyMemberPatcher extends NodePatcher {
    * @protected
    */
   isGeneratorMethod(): boolean {
-    return this.expression instanceof GeneratorFunctionPatcher ||
-      this.expression instanceof BoundGeneratorFunctionPatcher;
+    return (
+      this.expression instanceof GeneratorFunctionPatcher || this.expression instanceof BoundGeneratorFunctionPatcher
+    );
   }
 
   isAsyncMethod(): boolean {
-    return this.expression instanceof AsyncFunctionPatcher ||
-      this.expression instanceof BoundAsyncFunctionPatcher;
+    return this.expression instanceof AsyncFunctionPatcher || this.expression instanceof BoundAsyncFunctionPatcher;
   }
 }

--- a/src/stages/main/patchers/ObjectInitialiserMemberPatcher.ts
+++ b/src/stages/main/patchers/ObjectInitialiserMemberPatcher.ts
@@ -1,5 +1,5 @@
 import SourceType from 'coffee-lex/dist/SourceType';
-import {Identifier, ObjectInitialiserMember} from 'decaffeinate-parser/dist/nodes';
+import { Identifier, ObjectInitialiserMember } from 'decaffeinate-parser/dist/nodes';
 import MemberAccessOpPatcher from './MemberAccessOpPatcher';
 import ObjectBodyMemberPatcher from './ObjectBodyMemberPatcher';
 import StringPatcher from './StringPatcher';
@@ -24,7 +24,7 @@ export default class ObjectInitialiserMemberPatcher extends ObjectBodyMemberPatc
     if (this.expression === null) {
       let shouldExpand = !(this.key.node instanceof Identifier) || this.node.isComputed;
       this.patchAsShorthand({
-        expand: shouldExpand,
+        expand: shouldExpand
       });
     } else {
       super.patchAsProperty();
@@ -34,22 +34,17 @@ export default class ObjectInitialiserMemberPatcher extends ObjectBodyMemberPatc
   /**
    * @private
    */
-  patchAsShorthand({expand=false}: {expand: boolean}): void {
+  patchAsShorthand({ expand = false }: { expand: boolean }): void {
     let { key } = this;
     if (key instanceof MemberAccessOpPatcher) {
       key.patch();
       // e.g. `{ @name }`
       if (!(key.expression instanceof ThisPatcher)) {
-        throw this.error(
-          `expected property key member access on 'this', e.g. '@name'`
-        );
+        throw this.error(`expected property key member access on 'this', e.g. '@name'`);
       }
       // `{ @name }` → `{ name: @name }`
       //                  ^^^^^^
-      this.insert(
-        key.outerStart,
-        `${key.getMemberName()}: `
-      );
+      this.insert(key.outerStart, `${key.getMemberName()}: `);
     } else if (expand) {
       let needsBrackets = key instanceof StringPatcher && key.shouldBecomeTemplateLiteral();
 

--- a/src/stages/main/patchers/ObjectInitialiserPatcher.ts
+++ b/src/stages/main/patchers/ObjectInitialiserPatcher.ts
@@ -9,9 +9,9 @@ import ObjectInitialiserMemberPatcher from './ObjectInitialiserMemberPatcher';
 import SpreadPatcher from './SpreadPatcher';
 
 export type OpenCurlyInfo = {
-  curlyBraceInsertionPosition: number,
-  textToInsert: string,
-  shouldIndent: boolean,
+  curlyBraceInsertionPosition: number;
+  textToInsert: string;
+  shouldIndent: boolean;
 };
 
 /**
@@ -48,11 +48,7 @@ export default class ObjectInitialiserPatcher extends NodePatcher {
   patchAsExpression(): void {
     let implicitObject = this.isImplicitObject();
     if (implicitObject) {
-      let {
-        curlyBraceInsertionPosition,
-        textToInsert,
-        shouldIndent
-      } = this.getOpenCurlyInfo();
+      let { curlyBraceInsertionPosition, textToInsert, shouldIndent } = this.getOpenCurlyInfo();
       this.insert(curlyBraceInsertionPosition, textToInsert);
       if (shouldIndent) {
         this.indent();
@@ -77,8 +73,7 @@ export default class ObjectInitialiserPatcher extends NodePatcher {
         textToInsert = `{\n${this.getIndent()}`;
         shouldIndent = true;
       } else {
-        let tokenIndexBeforeOuterStartTokenIndex: SourceTokenListIndex | null
-          = this.outerStartTokenIndex;
+        let tokenIndexBeforeOuterStartTokenIndex: SourceTokenListIndex | null = this.outerStartTokenIndex;
         if (!this.isSurroundedByParentheses()) {
           tokenIndexBeforeOuterStartTokenIndex = tokenIndexBeforeOuterStartTokenIndex.previous();
         }
@@ -93,11 +88,7 @@ export default class ObjectInitialiserPatcher extends NodePatcher {
             curlyBraceInsertionPosition = precedingToken.end;
             let precedingTokenText = this.sourceOfToken(precedingToken);
             let lastCharOfToken = precedingTokenText[precedingTokenText.length - 1];
-            let needsSpace = (
-              lastCharOfToken === ':' ||
-              lastCharOfToken === '=' ||
-              lastCharOfToken === ','
-            );
+            let needsSpace = lastCharOfToken === ':' || lastCharOfToken === '=' || lastCharOfToken === ',';
             if (needsSpace) {
               textToInsert = ' {';
             }
@@ -154,8 +145,7 @@ export default class ObjectInitialiserPatcher extends NodePatcher {
   shouldExpandCurlyBraces(): boolean {
     return (
       this.isMultiline() ||
-      (this.parent instanceof ObjectInitialiserMemberPatcher &&
-        notNull(this.parent.parent).isMultiline())
+      (this.parent instanceof ObjectInitialiserMemberPatcher && notNull(this.parent.parent).isMultiline())
     );
   }
 

--- a/src/stages/main/patchers/ProgramPatcher.ts
+++ b/src/stages/main/patchers/ProgramPatcher.ts
@@ -129,11 +129,7 @@ export default class ProgramPatcher extends SharedProgramPatcher {
     let coffeeIndex = commentBody.indexOf('coffee');
 
     if (coffeeIndex >= 0) {
-      this.overwrite(
-        start + coffeeIndex,
-        start + coffeeIndex + 'coffee'.length,
-        'node'
-      );
+      this.overwrite(start + coffeeIndex, start + coffeeIndex + 'coffee'.length, 'node');
     }
   }
 
@@ -144,4 +140,3 @@ export default class ProgramPatcher extends SharedProgramPatcher {
     return true;
   }
 }
-

--- a/src/stages/main/patchers/RangePatcher.ts
+++ b/src/stages/main/patchers/RangePatcher.ts
@@ -4,8 +4,7 @@ import SourceToken from 'coffee-lex/dist/SourceToken';
 import { Int, Range } from 'decaffeinate-parser/dist/nodes';
 import BinaryOpPatcher from './BinaryOpPatcher';
 
-const RANGE_HELPER =
-`function __range__(left, right, inclusive) {
+const RANGE_HELPER = `function __range__(left, right, inclusive) {
   let range = [];
   let ascending = left < right;
   let end = !inclusive ? right : ascending ? right + 1 : right - 1;
@@ -93,7 +92,7 @@ export default class RangePatcher extends BinaryOpPatcher {
       return false;
     }
 
-    let [ first, last ] = range;
+    let [first, last] = range;
     return Math.abs(last - first) <= MAXIMUM_LITERAL_RANGE_ELEMENTS;
   }
 

--- a/src/stages/main/patchers/RegexPatcher.ts
+++ b/src/stages/main/patchers/RegexPatcher.ts
@@ -1,7 +1,6 @@
-import {Regex} from 'decaffeinate-parser/dist/nodes';
+import { Regex } from 'decaffeinate-parser/dist/nodes';
 import NodePatcher from '../../../patchers/NodePatcher';
-import downgradeUnicodeCodePointEscapesInRange
-  from '../../../utils/downgradeUnicodeCodePointEscapesInRange';
+import downgradeUnicodeCodePointEscapesInRange from '../../../utils/downgradeUnicodeCodePointEscapesInRange';
 import escapeSpecialWhitespaceInRange from '../../../utils/escapeSpecialWhitespaceInRange';
 
 export default class RegexPatcher extends NodePatcher {

--- a/src/stages/main/patchers/ReturnPatcher.ts
+++ b/src/stages/main/patchers/ReturnPatcher.ts
@@ -6,7 +6,7 @@ import SwitchPatcher from './SwitchPatcher';
 
 export default class ReturnPatcher extends NodePatcher {
   expression: NodePatcher | null;
-  
+
   constructor(patcherContext: PatcherContext, expression: NodePatcher | null) {
     super(patcherContext);
     this.expression = expression;
@@ -46,9 +46,9 @@ export default class ReturnPatcher extends NodePatcher {
     if (!this.expression) {
       throw this.error('Expected non-null expression.');
     }
-    return !this.expression.isSurroundedByParentheses() && (
-      this.expression instanceof ConditionalPatcher ||
-      this.expression instanceof SwitchPatcher
+    return (
+      !this.expression.isSurroundedByParentheses() &&
+      (this.expression instanceof ConditionalPatcher || this.expression instanceof SwitchPatcher)
     );
   }
 }

--- a/src/stages/main/patchers/SlicePatcher.ts
+++ b/src/stages/main/patchers/SlicePatcher.ts
@@ -16,7 +16,12 @@ export default class SlicePatcher extends NodePatcher {
   /**
    * `node` is of type `Slice`.
    */
-  constructor(patcherContext: PatcherContext, expression: NodePatcher, left: NodePatcher | null, right: NodePatcher | null) {
+  constructor(
+    patcherContext: PatcherContext,
+    expression: NodePatcher,
+    left: NodePatcher | null,
+    right: NodePatcher | null
+  ) {
     super(patcherContext);
     this.expression = expression;
     this.left = left;
@@ -59,16 +64,9 @@ export default class SlicePatcher extends NodePatcher {
     if (right) {
       if (this.isInclusive()) {
         if (right.node.raw === '-1') {
-          this.remove(
-            slice.start,
-            right.outerEnd
-          );
+          this.remove(slice.start, right.outerEnd);
         } else if (right.node instanceof Int) {
-          this.overwrite(
-            slice.start,
-            right.outerEnd,
-            `, ${right.node.data + 1}`
-          );
+          this.overwrite(slice.start, right.outerEnd, `, ${right.node.data + 1}`);
         } else {
           // `a.slice(0..1]` → `a.slice(0, +1]`
           //           ^^                ^^^

--- a/src/stages/main/patchers/SoakedDynamicMemberAccessOpPatcher.ts
+++ b/src/stages/main/patchers/SoakedDynamicMemberAccessOpPatcher.ts
@@ -6,8 +6,7 @@ import nodeContainsSoakOperation from '../../../utils/nodeContainsSoakOperation'
 import ternaryNeedsParens from '../../../utils/ternaryNeedsParens';
 import DynamicMemberAccessOpPatcher from './DynamicMemberAccessOpPatcher';
 
-const GUARD_HELPER =
-  `function __guard__(value, transform) {
+const GUARD_HELPER = `function __guard__(value, transform) {
   return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
 }`;
 
@@ -75,8 +74,7 @@ export default class SoakedDynamicMemberAccessOpPatcher extends DynamicMemberAcc
         soakContainer.appendDeferredSuffix(')');
       }
     } else {
-      soakContainer.insert(
-        soakContainer.contentStart,  `if (${conditionCode}) {\n${soakContainer.getIndent(1)}`);
+      soakContainer.insert(soakContainer.contentStart, `if (${conditionCode}) {\n${soakContainer.getIndent(1)}`);
       soakContainer.appendDeferredSuffix(`\n${soakContainer.getIndent()}}`);
     }
   }

--- a/src/stages/main/patchers/SoakedFunctionApplicationPatcher.ts
+++ b/src/stages/main/patchers/SoakedFunctionApplicationPatcher.ts
@@ -11,8 +11,7 @@ import MemberAccessOpPatcher from './MemberAccessOpPatcher';
 import SoakedDynamicMemberAccessOpPatcher from './SoakedDynamicMemberAccessOpPatcher';
 import SoakedMemberAccessOpPatcher from './SoakedMemberAccessOpPatcher';
 
-const GUARD_FUNC_HELPER =
-  `function __guardFunc__(func, transform) {
+const GUARD_FUNC_HELPER = `function __guardFunc__(func, transform) {
   return typeof func === 'function' ? transform(func) : undefined;
 }`;
 
@@ -35,8 +34,7 @@ const GUARD_FUNC_HELPER =
  *   this avoids the need to have two slightly different functions to handle
  *   this case which is already fairly obscure.
  */
-const GUARD_METHOD_HELPER =
-  `function __guardMethod__(obj, methodName, transform) {
+const GUARD_METHOD_HELPER = `function __guardMethod__(obj, methodName, transform) {
   if (typeof obj !== 'undefined' && obj !== null && typeof obj[methodName] === 'function') {
     return transform(obj, methodName);
   } else {
@@ -99,8 +97,7 @@ export default class SoakedFunctionApplicationPatcher extends FunctionApplicatio
         soakContainer.appendDeferredSuffix(')');
       }
     } else {
-      soakContainer.insert(
-        soakContainer.contentStart, `if (${conditionCode}) {\n${soakContainer.getIndent(1)}`);
+      soakContainer.insert(soakContainer.contentStart, `if (${conditionCode}) {\n${soakContainer.getIndent(1)}`);
       soakContainer.appendDeferredSuffix(`\n${soakContainer.getIndent()}}`);
     }
   }
@@ -129,8 +126,11 @@ export default class SoakedFunctionApplicationPatcher extends FunctionApplicatio
     }
     // Since memberName is always a valid identifier, we can put it in a string
     // literal without worrying about escaping.
-    this.overwrite(fn.expression.outerEnd, callStartToken.end,
-      `, '${memberName}', ${varName} => ${prefix}${varName}.${memberName}(`);
+    this.overwrite(
+      fn.expression.outerEnd,
+      callStartToken.end,
+      `, '${memberName}', ${varName} => ${prefix}${varName}.${memberName}(`
+    );
     soakContainer.insert(soakContainer.contentStart, '__guardMethod__(');
     soakContainer.appendDeferredSuffix(')');
   }
@@ -139,7 +139,7 @@ export default class SoakedFunctionApplicationPatcher extends FunctionApplicatio
    * Change a[b]?() to __guardMethod__(a, b, (o, m) => o[m]())
    */
   patchDynamicMethodCall(fn: DynamicMemberAccessOpPatcher): void {
-    let {expression, indexingExpr} = fn;
+    let { expression, indexingExpr } = fn;
 
     this.registerHelper('__guardMethod__', GUARD_METHOD_HELPER);
     this.addSuggestion(REMOVE_GUARD);
@@ -156,8 +156,11 @@ export default class SoakedFunctionApplicationPatcher extends FunctionApplicatio
       this.remove(soakContainer.contentStart, this.fn.outerStart);
     }
     this.overwrite(expression.outerEnd, indexingExpr.outerStart, `, `);
-    this.overwrite(indexingExpr.outerEnd, callStartToken.end,
-      `, (${objVarName}, ${methodVarName}) => ${prefix}${objVarName}[${methodVarName}](`);
+    this.overwrite(
+      indexingExpr.outerEnd,
+      callStartToken.end,
+      `, (${objVarName}, ${methodVarName}) => ${prefix}${objVarName}[${methodVarName}](`
+    );
     soakContainer.insert(soakContainer.contentStart, '__guardMethod__(');
     soakContainer.appendDeferredSuffix(')');
   }

--- a/src/stages/main/patchers/SoakedMemberAccessOpPatcher.ts
+++ b/src/stages/main/patchers/SoakedMemberAccessOpPatcher.ts
@@ -4,8 +4,7 @@ import nodeContainsSoakOperation from '../../../utils/nodeContainsSoakOperation'
 import ternaryNeedsParens from '../../../utils/ternaryNeedsParens';
 import MemberAccessOpPatcher from './MemberAccessOpPatcher';
 
-const GUARD_HELPER =
-  `function __guard__(value, transform) {
+const GUARD_HELPER = `function __guard__(value, transform) {
   return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
 }`;
 
@@ -64,8 +63,7 @@ export default class SoakedMemberAccessOpPatcher extends MemberAccessOpPatcher {
         soakContainer.appendDeferredSuffix(')');
       }
     } else {
-      soakContainer.insert(
-        soakContainer.contentStart,  `if (${conditionCode}) {\n${soakContainer.getIndent(1)}`);
+      soakContainer.insert(soakContainer.contentStart, `if (${conditionCode}) {\n${soakContainer.getIndent(1)}`);
       soakContainer.appendDeferredSuffix(`\n${soakContainer.getIndent()}}`);
     }
   }

--- a/src/stages/main/patchers/SoakedSlicePatcher.ts
+++ b/src/stages/main/patchers/SoakedSlicePatcher.ts
@@ -5,8 +5,7 @@ import { REMOVE_GUARD } from '../../../suggestions';
 import findSoakContainer from '../../../utils/findSoakContainer';
 import SlicePatcher from './SlicePatcher';
 
-const GUARD_HELPER =
-  `function __guard__(value, transform) {
+const GUARD_HELPER = `function __guard__(value, transform) {
   return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
 }`;
 

--- a/src/stages/main/patchers/SpreadPatcher.ts
+++ b/src/stages/main/patchers/SpreadPatcher.ts
@@ -10,7 +10,7 @@ import FunctionApplicationPatcher from './FunctionApplicationPatcher';
  */
 export default class SpreadPatcher extends NodePatcher {
   expression: NodePatcher;
-  
+
   constructor(patcherContext: PatcherContext, expression: NodePatcher) {
     super(patcherContext);
     this.expression = expression;
@@ -52,9 +52,11 @@ export default class SpreadPatcher extends NodePatcher {
     if (needsArrayFrom) {
       // Replicate a bug in CoffeeScript where you're allowed to pass null or
       // undefined when the argument spread is the only argument.
-      if (this.parent instanceof FunctionApplicationPatcher &&
+      if (
+        this.parent instanceof FunctionApplicationPatcher &&
         this.parent.args.length === 1 &&
-        this.parent.args[0] === this) {
+        this.parent.args[0] === this
+      ) {
         this.insert(this.contentEnd, ' || []');
       }
       // `...Array.from(a` → `...Array.from(a)`
@@ -73,8 +75,7 @@ export default class SpreadPatcher extends NodePatcher {
       return false;
     }
     // Spreading over arguments is always safe.
-    if (this.expression.node instanceof Identifier &&
-        this.expression.node.data === 'arguments') {
+    if (this.expression.node instanceof Identifier && this.expression.node.data === 'arguments') {
       return false;
     }
     this.addSuggestion(REMOVE_ARRAY_FROM);

--- a/src/stages/main/patchers/StringPatcher.ts
+++ b/src/stages/main/patchers/StringPatcher.ts
@@ -1,5 +1,5 @@
 import { SourceType } from 'coffee-lex';
-import {PatchOptions} from '../../../patchers/types';
+import { PatchOptions } from '../../../patchers/types';
 
 import InterpolatedPatcher from './InterpolatedPatcher';
 
@@ -8,7 +8,7 @@ import InterpolatedPatcher from './InterpolatedPatcher';
  * interpolations and whether or not they are multiline.
  */
 export default class StringPatcher extends InterpolatedPatcher {
-  patchAsExpression({forceTemplateLiteral}: PatchOptions = {}): void {
+  patchAsExpression({ forceTemplateLiteral }: PatchOptions = {}): void {
     let shouldBecomeTemplateLiteral = forceTemplateLiteral || this.shouldBecomeTemplateLiteral();
 
     let escapeStrings = [];
@@ -21,9 +21,9 @@ export default class StringPatcher extends InterpolatedPatcher {
       this.overwrite(openQuoteToken.start, openQuoteToken.end, '`');
       this.overwrite(closeQuoteToken.start, closeQuoteToken.end, '`');
     } else if (openQuoteToken.type === SourceType.TSSTRING_START) {
-      escapeStrings.push('\'');
-      this.overwrite(openQuoteToken.start, openQuoteToken.end, '\'');
-      this.overwrite(closeQuoteToken.start, closeQuoteToken.end, '\'');
+      escapeStrings.push("'");
+      this.overwrite(openQuoteToken.start, openQuoteToken.end, "'");
+      this.overwrite(closeQuoteToken.start, closeQuoteToken.end, "'");
     } else if (openQuoteToken.type === SourceType.TDSTRING_START) {
       escapeStrings.push('"');
       this.overwrite(openQuoteToken.start, openQuoteToken.end, '"');

--- a/src/stages/main/patchers/SuperPatcher.ts
+++ b/src/stages/main/patchers/SuperPatcher.ts
@@ -36,20 +36,23 @@ export default class SuperPatcher extends NodePatcher {
       if (!accessCode) {
         throw this.error(
           'Cannot handle a super call in an inner function in a constructor. ' +
-          'Please either rewrite your CoffeeScript code to not use this ' +
-          'construct or file a bug to discuss ways that decaffeinate could ' +
-          'handle this case.');
+            'Please either rewrite your CoffeeScript code to not use this ' +
+            'construct or file a bug to discuss ways that decaffeinate could ' +
+            'handle this case.'
+        );
       }
       if (!classCode) {
-        throw this.error(
-          'Complex super calls within anonymous classes are not yet supported.');
+        throw this.error('Complex super calls within anonymous classes are not yet supported.');
       }
       let openParenToken = this.getFollowingOpenParenToken();
       // Note that this code snippet works for instance methods but not static
       // methods. Static methods that require the expanded call form like this
       // have already been converted in the normalize step.
-      this.overwrite(this.contentStart, openParenToken.end,
-        `${classCode}.prototype.__proto__${accessCode}.call(this, `);
+      this.overwrite(
+        this.contentStart,
+        openParenToken.end,
+        `${classCode}.prototype.__proto__${accessCode}.call(this, `
+      );
     }
   }
 
@@ -77,19 +80,17 @@ export default class SuperPatcher extends NodePatcher {
       }
       return {
         classCode: this.getEnclosingClassName(methodAssignment),
-        accessCode,
+        accessCode
       };
     } else if (methodAssignment instanceof ConstructorPatcher) {
       return {
         classCode: this.getEnclosingClassName(methodAssignment),
-        accessCode: null,
+        accessCode: null
       };
     } else {
       let methodInfo = this.getPrototypeAssignInfo(methodAssignment);
       if (!methodInfo) {
-        throw this.error(
-          'Expected a valid method assignment from getEnclosingMethodAssignment.'
-        );
+        throw this.error('Expected a valid method assignment from getEnclosingMethodAssignment.');
       }
       return methodInfo;
     }
@@ -118,16 +119,16 @@ export default class SuperPatcher extends NodePatcher {
   getEnclosingMethodAssignment(): NodePatcher {
     let { parent } = this;
     while (parent) {
-      if (parent instanceof ClassAssignOpPatcher ||
-          parent instanceof ConstructorPatcher ||
-          this.getPrototypeAssignInfo(parent) !== null) {
+      if (
+        parent instanceof ClassAssignOpPatcher ||
+        parent instanceof ConstructorPatcher ||
+        this.getPrototypeAssignInfo(parent) !== null
+      ) {
         return parent;
       }
       parent = parent.parent;
     }
-    throw this.error(
-      'super called in a context where we cannot determine the class and method name.'
-    );
+    throw this.error('super called in a context where we cannot determine the class and method name.');
   }
 
   /**
@@ -145,17 +146,17 @@ export default class SuperPatcher extends NodePatcher {
     if (methodAccessPatcher instanceof MemberAccessOpPatcher) {
       return {
         classCode: classRefPatcher.getRepeatCode(),
-        accessCode: `.${methodAccessPatcher.member.node.data}`,
+        accessCode: `.${methodAccessPatcher.member.node.data}`
       };
     } else if (methodAccessPatcher instanceof DynamicMemberAccessOpPatcher) {
       return {
         classCode: classRefPatcher.getRepeatCode(),
-        accessCode: `[${methodAccessPatcher.indexingExpr.getRepeatCode()}]`,
+        accessCode: `[${methodAccessPatcher.indexingExpr.getRepeatCode()}]`
       };
     } else {
       throw this.error(
-        'Expected the method access patcher to be either ' +
-        'MemberAccessOpPatcher or DynamicMemberAccessOpPatcher.');
+        'Expected the method access patcher to be either ' + 'MemberAccessOpPatcher or DynamicMemberAccessOpPatcher.'
+      );
     }
   }
 
@@ -174,8 +175,7 @@ export default class SuperPatcher extends NodePatcher {
    */
   canConvertToJsSuper(): boolean {
     let methodAssignment = this.getEnclosingMethodAssignment();
-    if (methodAssignment instanceof ConstructorPatcher ||
-        methodAssignment instanceof ClassAssignOpPatcher) {
+    if (methodAssignment instanceof ConstructorPatcher || methodAssignment instanceof ClassAssignOpPatcher) {
       return methodAssignment.expression === this.getEnclosingFunction();
     }
     return false;
@@ -200,7 +200,9 @@ export default class SuperPatcher extends NodePatcher {
    */
   getFollowingOpenParenToken(): SourceToken {
     let openParenTokenIndex = this.indexOfSourceTokenAfterSourceTokenIndex(
-      this.contentEndTokenIndex, SourceType.CALL_START);
+      this.contentEndTokenIndex,
+      SourceType.CALL_START
+    );
     if (!openParenTokenIndex) {
       throw this.error('Expected open-paren after super.');
     }

--- a/src/stages/main/patchers/SwitchCasePatcher.ts
+++ b/src/stages/main/patchers/SwitchCasePatcher.ts
@@ -48,7 +48,6 @@ export default class SwitchCasePatcher extends NodePatcher {
       this.insert(condition.outerEnd, ':');
     });
 
-
     // `case a: case b: case c: then d → `case a: case b: case c: d`
     //                          ^^^^^
     let thenToken = this.getThenToken();
@@ -64,11 +63,10 @@ export default class SwitchCasePatcher extends NodePatcher {
       this.consequent.patch({ leftBrace: false, rightBrace: false });
     }
 
-    let implicitReturnWillBreak = (
+    let implicitReturnWillBreak =
       this.implicitlyReturns() &&
       this.implicitReturnPatcher().implicitReturnWillBreak() &&
-      (!this.consequent || this.consequent.allCodePathsPresent())
-    );
+      (!this.consequent || this.consequent.allCodePathsPresent());
     let shouldAddBreak = !this.hasExistingBreak() && !implicitReturnWillBreak;
     if (shouldAddBreak) {
       if (thenToken) {
@@ -127,14 +125,12 @@ export default class SwitchCasePatcher extends NodePatcher {
       let left = this.conditions[i - 1];
       let right = this.conditions[i];
       let commaIndex = this.indexOfSourceTokenBetweenPatchersMatching(
-        left, right, token => token.type === SourceType.COMMA
+        left,
+        right,
+        token => token.type === SourceType.COMMA
       );
       if (!commaIndex) {
-        throw this.error(
-          `unable to find comma between 'when' conditions`,
-          left.contentEnd,
-          right.contentStart
-        );
+        throw this.error(`unable to find comma between 'when' conditions`, left.contentEnd, right.contentStart);
       }
       result.push(notNull(this.sourceTokenAtIndex(commaIndex)));
     }

--- a/src/stages/main/patchers/SwitchPatcher.ts
+++ b/src/stages/main/patchers/SwitchPatcher.ts
@@ -9,7 +9,12 @@ export default class SwitchPatcher extends NodePatcher {
   cases: Array<NodePatcher>;
   alternate: NodePatcher | null;
 
-  constructor(patcherContext: PatcherContext, expression: NodePatcher, cases: Array<NodePatcher>, alternate: NodePatcher | null) {
+  constructor(
+    patcherContext: PatcherContext,
+    expression: NodePatcher,
+    cases: Array<NodePatcher>,
+    alternate: NodePatcher | null
+  ) {
     super(patcherContext);
     this.expression = expression;
     this.cases = cases;
@@ -61,8 +66,7 @@ export default class SwitchPatcher extends NodePatcher {
     if (this.alternate) {
       this.alternate.patch({ leftBrace: false, rightBrace: false });
     } else if (this.getElseToken() === null && super.implicitlyReturns()) {
-      let emptyImplicitReturnCode =
-        this.implicitReturnPatcher().getEmptyImplicitReturnCode();
+      let emptyImplicitReturnCode = this.implicitReturnPatcher().getEmptyImplicitReturnCode();
       if (emptyImplicitReturnCode) {
         this.insert(this.contentEnd, `\n`);
         this.insert(this.contentEnd, `${this.getIndent(1)}default:\n`);
@@ -138,7 +142,9 @@ export default class SwitchPatcher extends NodePatcher {
     }
 
     let elseTokenIndex = this.indexOfSourceTokenBetweenSourceIndicesMatching(
-      searchStart, searchEnd, token => token.type === SourceType.ELSE
+      searchStart,
+      searchEnd,
+      token => token.type === SourceType.ELSE
     );
     if (!elseTokenIndex || elseTokenIndex.isBefore(this.contentStartTokenIndex)) {
       if (this.alternate) {
@@ -173,9 +179,6 @@ export default class SwitchPatcher extends NodePatcher {
       return false;
     }
 
-    return (
-      this.cases.every(switchCase => switchCase.allCodePathsPresent()) &&
-      this.alternate.allCodePathsPresent()
-    );
+    return this.cases.every(switchCase => switchCase.allCodePathsPresent()) && this.alternate.allCodePathsPresent();
   }
 }

--- a/src/stages/main/patchers/TaggedTemplateLiteralPatcher.ts
+++ b/src/stages/main/patchers/TaggedTemplateLiteralPatcher.ts
@@ -1,5 +1,5 @@
 import NodePatcher from '../../../patchers/NodePatcher';
-import {PatcherContext} from '../../../patchers/types';
+import { PatcherContext } from '../../../patchers/types';
 import StringPatcher from './StringPatcher';
 
 export default class TaggedTemplateLiteralPatcher extends NodePatcher {
@@ -14,6 +14,6 @@ export default class TaggedTemplateLiteralPatcher extends NodePatcher {
 
   patchAsExpression(): void {
     this.tag.patch();
-    this.template.patch({forceTemplateLiteral: true});
+    this.template.patch({ forceTemplateLiteral: true });
   }
 }

--- a/src/stages/main/patchers/ThisPatcher.ts
+++ b/src/stages/main/patchers/ThisPatcher.ts
@@ -19,10 +19,10 @@ export default class ThisPatcher extends NodePatcher {
 
   reportTopLevelThisIfNecessary(): void {
     let scope = this.getScope();
-    while (scope.parent &&
-        [
-          'Program', 'Function', 'GeneratorFunction', 'Class'
-        ].indexOf(scope.containerNode.type) === -1) {
+    while (
+      scope.parent &&
+      ['Program', 'Function', 'GeneratorFunction', 'Class'].indexOf(scope.containerNode.type) === -1
+    ) {
       scope = scope.parent;
     }
     if (scope.containerNode.type === 'Program') {

--- a/src/stages/main/patchers/TryPatcher.ts
+++ b/src/stages/main/patchers/TryPatcher.ts
@@ -19,9 +19,12 @@ export default class TryPatcher extends NodePatcher {
   _errorBinding: string | null = null;
 
   constructor(
-      patcherContext: PatcherContext, body: BlockPatcher | null,
-      catchAssignee: NodePatcher | null, catchBody: BlockPatcher | null,
-      finallyBody: BlockPatcher | null) {
+    patcherContext: PatcherContext,
+    body: BlockPatcher | null,
+    catchAssignee: NodePatcher | null,
+    catchBody: BlockPatcher | null,
+    finallyBody: BlockPatcher | null
+  ) {
     super(patcherContext);
     this.body = body;
     this.catchAssignee = catchAssignee;
@@ -92,10 +95,7 @@ export default class TryPatcher extends NodePatcher {
     }
 
     if (catchToken) {
-      let afterCatchHeader =
-        this.catchAssignee ?
-          this.catchAssignee.outerEnd :
-          catchToken.end;
+      let afterCatchHeader = this.catchAssignee ? this.catchAssignee.outerEnd : catchToken.end;
 
       if (this.catchAssignee) {
         let addErrorParens = !this.catchAssignee.isSurroundedByParentheses();
@@ -221,7 +221,9 @@ export default class TryPatcher extends NodePatcher {
     }
 
     let catchTokenIndex = this.indexOfSourceTokenBetweenSourceIndicesMatching(
-      searchStart, searchEnd, token => token.type === SourceType.CATCH
+      searchStart,
+      searchEnd,
+      token => token.type === SourceType.CATCH
     );
     if (!catchTokenIndex) {
       return null;
@@ -259,7 +261,8 @@ export default class TryPatcher extends NodePatcher {
     }
 
     return this.indexOfSourceTokenBetweenSourceIndicesMatching(
-      searchStart, searchEnd,
+      searchStart,
+      searchEnd,
       token => token.type === SourceType.THEN
     );
   }
@@ -287,7 +290,9 @@ export default class TryPatcher extends NodePatcher {
     }
 
     let finallyTokenIndex = this.indexOfSourceTokenBetweenSourceIndicesMatching(
-      searchStart, searchEnd, token => token.type === SourceType.FINALLY
+      searchStart,
+      searchEnd,
+      token => token.type === SourceType.FINALLY
     );
     if (!finallyTokenIndex) {
       return null;

--- a/src/stages/main/patchers/UnaryExistsOpPatcher.ts
+++ b/src/stages/main/patchers/UnaryExistsOpPatcher.ts
@@ -37,7 +37,7 @@ export default class UnaryExistsOpPatcher extends UnaryOpPatcher {
    *
    *   'set? ' + (a != null);
    */
-  patchAsExpression({needsParens=true}: PatchOptions = {}): void {
+  patchAsExpression({ needsParens = true }: PatchOptions = {}): void {
     let addParens = needsParens && !this.isSurroundedByParentheses();
     if (addParens) {
       // `a?` → `(a?`
@@ -57,7 +57,10 @@ export default class UnaryExistsOpPatcher extends UnaryOpPatcher {
    */
   patchAsStatement(): void {
     this.addSuggestion(SHORTEN_NULL_CHECKS);
-    let { node: { expression }, negated } = this;
+    let {
+      node: { expression },
+      negated
+    } = this;
     let needsTypeofCheck = this.needsTypeofCheck();
 
     this.expression.patch();
@@ -79,7 +82,6 @@ export default class UnaryExistsOpPatcher extends UnaryOpPatcher {
           `typeof ${expression.raw} !== 'undefined' && ${expression.raw} !== null`
         );
       }
-
     } else {
       if (negated) {
         // `a.b?` → `a.b == null`

--- a/src/stages/main/patchers/UnaryOpPatcher.ts
+++ b/src/stages/main/patchers/UnaryOpPatcher.ts
@@ -3,7 +3,7 @@ import NodePatcher from './../../../patchers/NodePatcher';
 
 export default class UnaryOpPatcher extends NodePatcher {
   expression: NodePatcher;
-  
+
   constructor(patcherContext: PatcherContext, expression: NodePatcher) {
     super(patcherContext);
     this.expression = expression;

--- a/src/stages/main/patchers/WhilePatcher.ts
+++ b/src/stages/main/patchers/WhilePatcher.ts
@@ -78,7 +78,6 @@ export default class WhilePatcher extends LoopPatcher {
           this.guard.outerStart,
           `${conditionNeedsParens ? ')' : ''} {\n${this.getOuterLoopBodyIndent()}if ${guardNeedsParens ? '(' : ''}`
         );
-
       }
       this.guard.patch({ needsParens: false });
 
@@ -102,8 +101,7 @@ export default class WhilePatcher extends LoopPatcher {
       }
     }
 
-    this.patchPossibleNewlineAfterLoopHeader(
-      this.guard ? this.guard.outerEnd : this.condition.outerEnd);
+    this.patchPossibleNewlineAfterLoopHeader(this.guard ? this.guard.outerEnd : this.condition.outerEnd);
     this.patchBody();
 
     if (this.guard) {
@@ -165,7 +163,9 @@ export default class WhilePatcher extends LoopPatcher {
 
     // `while a then …`
     return this.indexOfSourceTokenBetweenSourceIndicesMatching(
-      searchStart, searchEnd, token => token.type === SourceType.THEN
+      searchStart,
+      searchEnd,
+      token => token.type === SourceType.THEN
     );
   }
 

--- a/src/stages/main/patchers/YieldFromPatcher.ts
+++ b/src/stages/main/patchers/YieldFromPatcher.ts
@@ -5,7 +5,7 @@ export default class YieldFromPatcher extends YieldPatcher {
   /**
    * 'yield' 'from' EXPRESSION
    */
-  patchAsExpression({needsParens = true}: PatchOptions = {}): void {
+  patchAsExpression({ needsParens = true }: PatchOptions = {}): void {
     let firstToken = this.firstToken();
     this.overwrite(firstToken.start, firstToken.end, 'yield*');
     super.patchAsExpression({ needsParens });

--- a/src/stages/main/patchers/YieldPatcher.ts
+++ b/src/stages/main/patchers/YieldPatcher.ts
@@ -6,12 +6,12 @@ import ReturnPatcher from './ReturnPatcher';
 
 export default class YieldPatcher extends NodePatcher {
   expression: NodePatcher | null;
-  
+
   constructor(patcherContext: PatcherContext, expression: NodePatcher | null) {
     super(patcherContext);
     this.expression = expression;
   }
-  
+
   initialize(): void {
     this.yields();
     if (this.expression) {
@@ -22,7 +22,7 @@ export default class YieldPatcher extends NodePatcher {
   /**
    * 'yield' EXPRESSION
    */
-  patchAsExpression({needsParens = true}: PatchOptions = {}): void {
+  patchAsExpression({ needsParens = true }: PatchOptions = {}): void {
     let surroundInParens = this.needsParens() && !this.isSurroundedByParentheses();
     if (surroundInParens) {
       this.insert(this.contentStart, '(');
@@ -39,6 +39,7 @@ export default class YieldPatcher extends NodePatcher {
     return !(
       this.parent instanceof BlockPatcher ||
       this.parent instanceof ReturnPatcher ||
-      (this.parent instanceof AssignOpPatcher && this.parent.expression === this));
+      (this.parent instanceof AssignOpPatcher && this.parent.expression === this)
+    );
   }
 }

--- a/src/stages/normalize/patchers/AssignOpPatcher.ts
+++ b/src/stages/normalize/patchers/AssignOpPatcher.ts
@@ -9,8 +9,8 @@ import FunctionPatcher from './FunctionPatcher';
 import MemberAccessOpPatcher from './MemberAccessOpPatcher';
 
 export type EarlySuperTransformInfo = {
-  classCode: string,
-  accessCode: string,
+  classCode: string;
+  accessCode: string;
 };
 
 export default class AssignOpPatcher extends NodePatcher {
@@ -39,10 +39,11 @@ export default class AssignOpPatcher extends NodePatcher {
 
   isDynamicallyCreatedClassAssignment(): boolean {
     let classParent = this.getClassParent();
-    return classParent !== null &&
+    return (
+      classParent !== null &&
       classParent.isClassAssignment(this.node) &&
-      !(classParent.isClassMethod(this) &&
-        notNull(classParent.body).statements.indexOf(this) > -1);
+      !(classParent.isClassMethod(this) && notNull(classParent.body).statements.indexOf(this) > -1)
+    );
   }
 
   patchClassAssignmentPrefix(): void {
@@ -88,9 +89,11 @@ export default class AssignOpPatcher extends NodePatcher {
     if (!this.isDynamicallyCreatedClassAssignment()) {
       return false;
     }
-    return this.node.type !== 'ClassProtoAssignOp' &&
+    return (
+      this.node.type !== 'ClassProtoAssignOp' &&
       this.expression instanceof FunctionPatcher &&
-      containsSuperCall(this.expression.node);
+      containsSuperCall(this.expression.node)
+    );
   }
 
   prepareEarlySuperTransform(): void {
@@ -99,17 +102,17 @@ export default class AssignOpPatcher extends NodePatcher {
         this.assignee.expression.setRequiresRepeatableExpression({
           parens: true,
           ref: 'cls',
-          forceRepeat: true,
+          forceRepeat: true
         });
       } else if (this.assignee instanceof DynamicMemberAccessOpPatcher) {
         this.assignee.expression.setRequiresRepeatableExpression({
           parens: true,
           ref: 'cls',
-          forceRepeat: true,
+          forceRepeat: true
         });
         this.assignee.indexingExpr.setRequiresRepeatableExpression({
           ref: 'method',
-          forceRepeat: true,
+          forceRepeat: true
         });
       } else {
         throw this.error('Unexpected assignee type for early super transform.');
@@ -122,12 +125,12 @@ export default class AssignOpPatcher extends NodePatcher {
       if (this.assignee instanceof MemberAccessOpPatcher) {
         return {
           classCode: this.assignee.expression.getRepeatCode(),
-          accessCode: `.${this.assignee.member.node.data}`,
+          accessCode: `.${this.assignee.member.node.data}`
         };
       } else if (this.assignee instanceof DynamicMemberAccessOpPatcher) {
         return {
           classCode: this.assignee.expression.getRepeatCode(),
-          accessCode: `[${this.assignee.indexingExpr.getRepeatCode()}]`,
+          accessCode: `[${this.assignee.indexingExpr.getRepeatCode()}]`
         };
       } else {
         throw this.error('Unexpected assignee type for early super transform.');

--- a/src/stages/normalize/patchers/BlockPatcher.ts
+++ b/src/stages/normalize/patchers/BlockPatcher.ts
@@ -33,8 +33,8 @@ export default class BlockPatcher extends SharedBlockPatcher {
           let charsToRemove = indentLength - blockIndentLength;
           if (charsToRemove < 0) {
             throw this.error(
-              'Unexpected statement at an earlier indentation level than an ' +
-              'earlier statement in the block.');
+              'Unexpected statement at an earlier indentation level than an ' + 'earlier statement in the block.'
+            );
           }
           if (charsToRemove > 0) {
             this.removePrecedingSpaceChars(statement.outerStart, charsToRemove);
@@ -86,8 +86,7 @@ export default class BlockPatcher extends SharedBlockPatcher {
    */
   normalizeAfterStatement(statement: NodePatcher): void {
     let followingComma = statement.nextSemanticToken();
-    if (!followingComma || followingComma.type !== SourceType.COMMA ||
-        followingComma.start >= this.contentEnd) {
+    if (!followingComma || followingComma.type !== SourceType.COMMA || followingComma.start >= this.contentEnd) {
       return;
     }
     this.overwrite(followingComma.start, followingComma.end, ';');

--- a/src/stages/normalize/patchers/ConditionalPatcher.ts
+++ b/src/stages/normalize/patchers/ConditionalPatcher.ts
@@ -21,7 +21,12 @@ export default class ConditionalPatcher extends NodePatcher {
   consequent: NodePatcher | null;
   alternate: NodePatcher | null;
 
-  constructor(patcherContext: PatcherContext, condition: NodePatcher, consequent: NodePatcher, alternate: NodePatcher | null) {
+  constructor(
+    patcherContext: PatcherContext,
+    condition: NodePatcher,
+    consequent: NodePatcher,
+    alternate: NodePatcher | null
+  ) {
     super(patcherContext);
     this.condition = condition;
     this.consequent = consequent;
@@ -51,8 +56,10 @@ export default class ConditionalPatcher extends NodePatcher {
       throw this.error('Expected non-null consequent for post-if.');
     }
     this.condition.patch();
-    if (postfixExpressionRequiresParens(this.slice(this.condition.contentStart, this.condition.contentEnd)) &&
-        !this.condition.isSurroundedByParentheses()) {
+    if (
+      postfixExpressionRequiresParens(this.slice(this.condition.contentStart, this.condition.contentEnd)) &&
+      !this.condition.isSurroundedByParentheses()
+    ) {
       this.condition.surroundInParens();
     }
 
@@ -76,8 +83,7 @@ export default class ConditionalPatcher extends NodePatcher {
   }
 
   isPostIf(): boolean {
-    return this.consequent !== null
-      && this.condition.contentStart > this.consequent.contentStart;
+    return this.consequent !== null && this.condition.contentStart > this.consequent.contentStart;
   }
 
   getIfTokenIndex(): SourceTokenListIndex {

--- a/src/stages/normalize/patchers/DefaultParamPatcher.ts
+++ b/src/stages/normalize/patchers/DefaultParamPatcher.ts
@@ -44,8 +44,7 @@ export default class DefaultParamPatcher extends PassthroughPatcher {
       }
       // Don't consider this node if we're on the right side of another default
       // param (e.g. `(foo = (bar=3) ->) ->`).
-      if (patcher.parent instanceof DefaultParamPatcher &&
-        patcher.parent.value === patcher) {
+      if (patcher.parent instanceof DefaultParamPatcher && patcher.parent.value === patcher) {
         break;
       }
       patcher = patcher.parent;
@@ -70,13 +69,14 @@ export default class DefaultParamPatcher extends PassthroughPatcher {
     if (this.value.node.type === 'Null') {
       return false;
     }
-    if (this.parent instanceof FunctionPatcher &&
-        this.parent.parent instanceof DoOpPatcher) {
+    if (this.parent instanceof FunctionPatcher && this.parent.parent instanceof DoOpPatcher) {
       return false;
     }
-    if (this.parent instanceof FunctionPatcher &&
-        this.parent.parent instanceof AssignOpPatcher &&
-        this.parent.parent.parent instanceof DoOpPatcher) {
+    if (
+      this.parent instanceof FunctionPatcher &&
+      this.parent.parent instanceof AssignOpPatcher &&
+      this.parent.parent.parent instanceof DoOpPatcher
+    ) {
       return false;
     }
     return true;

--- a/src/stages/normalize/patchers/ForInPatcher.ts
+++ b/src/stages/normalize/patchers/ForInPatcher.ts
@@ -6,11 +6,16 @@ import ForPatcher from './ForPatcher';
 
 export default class ForInPatcher extends ForPatcher {
   step: NodePatcher | null;
-  
+
   constructor(
-      patcherContext: PatcherContext, keyAssignee: NodePatcher | null,
-      valAssignee: NodePatcher | null, target: NodePatcher, step: NodePatcher | null,
-      filter: NodePatcher | null, body: BlockPatcher) {
+    patcherContext: PatcherContext,
+    keyAssignee: NodePatcher | null,
+    valAssignee: NodePatcher | null,
+    target: NodePatcher,
+    step: NodePatcher | null,
+    filter: NodePatcher | null,
+    body: BlockPatcher
+  ) {
     super(patcherContext, keyAssignee, valAssignee, target, filter, body);
     this.step = step;
   }

--- a/src/stages/normalize/patchers/ForPatcher.ts
+++ b/src/stages/normalize/patchers/ForPatcher.ts
@@ -17,9 +17,13 @@ export default class ForPatcher extends NodePatcher {
   body: BlockPatcher;
 
   constructor(
-      patcherContext: PatcherContext, keyAssignee: NodePatcher | null,
-      valAssignee: NodePatcher | null, target: NodePatcher,
-      filter: NodePatcher | null, body: BlockPatcher) {
+    patcherContext: PatcherContext,
+    keyAssignee: NodePatcher | null,
+    valAssignee: NodePatcher | null,
+    target: NodePatcher,
+    filter: NodePatcher | null,
+    body: BlockPatcher
+  ) {
     super(patcherContext);
     this.keyAssignee = keyAssignee;
     this.valAssignee = valAssignee;
@@ -112,8 +116,7 @@ export default class ForPatcher extends NodePatcher {
     if (postfixExpressionRequiresParens(this.slice(this.target.contentStart, this.target.contentEnd))) {
       this.target.surroundInParens();
     }
-    if (this.filter &&
-      postfixExpressionRequiresParens(this.slice(this.filter.contentStart, this.filter.contentEnd))) {
+    if (this.filter && postfixExpressionRequiresParens(this.slice(this.filter.contentStart, this.filter.contentEnd))) {
       this.filter.surroundInParens();
     }
   }
@@ -125,7 +128,8 @@ export default class ForPatcher extends NodePatcher {
     if (this.isPostFor()) {
       let afterForToken = this.getFirstHeaderPatcher();
       let index = this.indexOfSourceTokenBetweenPatchersMatching(
-        this.body, afterForToken,
+        this.body,
+        afterForToken,
         token => token.type === SourceType.FOR
       );
       if (!index) {
@@ -150,7 +154,9 @@ export default class ForPatcher extends NodePatcher {
     let candidates = [this.keyAssignee, this.valAssignee, this.target];
     let result: NodePatcher | null = null;
     candidates.forEach(candidate => {
-      if (!candidate) { return; }
+      if (!candidate) {
+        return;
+      }
       if (result === null || candidate.contentStart < result.contentStart) {
         result = candidate;
       }

--- a/src/stages/normalize/patchers/FunctionApplicationPatcher.ts
+++ b/src/stages/normalize/patchers/FunctionApplicationPatcher.ts
@@ -1,7 +1,7 @@
 import { SourceType } from 'coffee-lex';
 
 import SourceToken from 'coffee-lex/dist/SourceToken';
-import {CSXElement} from 'decaffeinate-parser/dist/nodes';
+import { CSXElement } from 'decaffeinate-parser/dist/nodes';
 import { PatcherContext } from '../../../patchers/types';
 import normalizeListItem from '../../../utils/normalizeListItem';
 import NodePatcher from './../../../patchers/NodePatcher';
@@ -24,8 +24,9 @@ export default class FunctionApplicationPatcher extends NodePatcher {
 
     if (implicitCall) {
       let firstArg = args[0];
-      let firstArgIsOnNextLine = !firstArg ? false :
-        /\n/.test(this.context.source.slice(this.fn.outerEnd, firstArg.outerStart));
+      let firstArgIsOnNextLine = !firstArg
+        ? false
+        : /\n/.test(this.context.source.slice(this.fn.outerEnd, firstArg.outerStart));
       let funcEnd = this.getFuncEnd();
       if (firstArgIsOnNextLine) {
         this.insert(funcEnd, '(');
@@ -60,8 +61,7 @@ export default class FunctionApplicationPatcher extends NodePatcher {
       this.fn.surroundInParens();
     }
 
-    let argListCode = this.slice(
-      this.args[0].contentStart, this.args[this.args.length - 1].contentEnd);
+    let argListCode = this.slice(this.args[0].contentStart, this.args[this.args.length - 1].contentEnd);
     let isArgListMultiline = argListCode.indexOf('\n') !== -1;
     let lastTokenType = this.lastToken().type;
     if (!isArgListMultiline || lastTokenType === SourceType.RBRACE || lastTokenType === SourceType.RBRACKET) {
@@ -127,8 +127,9 @@ export default class FunctionApplicationPatcher extends NodePatcher {
     let maxInsertionPoint = this.getEditingBounds()[1];
     let enclosingIndentedPatcher: NodePatcher = this;
     while (
-        !enclosingIndentedPatcher.isFirstNodeInLine(enclosingIndentedPatcher.contentStart) &&
-        enclosingIndentedPatcher.parent) {
+      !enclosingIndentedPatcher.isFirstNodeInLine(enclosingIndentedPatcher.contentStart) &&
+      enclosingIndentedPatcher.parent
+    ) {
       enclosingIndentedPatcher = enclosingIndentedPatcher.parent;
     }
     return Math.min(maxInsertionPoint, enclosingIndentedPatcher.contentEnd);
@@ -149,8 +150,13 @@ export default class FunctionApplicationPatcher extends NodePatcher {
     }
     let searchStart = this.fn.outerEnd;
     let searchEnd = this.args[0].outerStart;
-    return this.indexOfSourceTokenBetweenSourceIndicesMatching(
-      searchStart, searchEnd, token => token.type === SourceType.CALL_START) === null;
+    return (
+      this.indexOfSourceTokenBetweenSourceIndicesMatching(
+        searchStart,
+        searchEnd,
+        token => token.type === SourceType.CALL_START
+      ) === null
+    );
   }
 
   /**
@@ -160,7 +166,9 @@ export default class FunctionApplicationPatcher extends NodePatcher {
   getFuncEnd(): number {
     if (this.node.type === 'SoakedFunctionApplication' || this.node.type === 'SoakedNewOp') {
       let questionMarkTokenIndex = this.indexOfSourceTokenAfterSourceTokenIndex(
-        this.fn.outerEndTokenIndex, SourceType.EXISTENCE);
+        this.fn.outerEndTokenIndex,
+        SourceType.EXISTENCE
+      );
       if (!questionMarkTokenIndex) {
         throw this.error('Expected to find question mark token index.');
       }

--- a/src/stages/normalize/patchers/MemberAccessOpPatcher.ts
+++ b/src/stages/normalize/patchers/MemberAccessOpPatcher.ts
@@ -38,8 +38,7 @@ export default class MemberAccessOpPatcher extends PassthroughPatcher {
       // Don't consider this node if we're on the right side of a default param
       // (e.g. `(foo = @bar) ->`) or if we're on the left side of an object
       // destructure (e.g. the logical `a` key in `({@a}) ->`).
-      if (patcher.parent instanceof DefaultParamPatcher &&
-          patcher.parent.value === patcher) {
+      if (patcher.parent instanceof DefaultParamPatcher && patcher.parent.value === patcher) {
         break;
       }
       patcher = patcher.parent;

--- a/src/stages/normalize/patchers/SuperPatcher.ts
+++ b/src/stages/normalize/patchers/SuperPatcher.ts
@@ -21,7 +21,7 @@ export default class SuperPatcher extends NodePatcher {
    * super calls in the normalize stage. Otherwise, the code will move into an
    * initClass method and super calls will refer to super.initClass.
    */
-  patchEarlySuperTransform({classCode, accessCode}: EarlySuperTransformInfo): void {
+  patchEarlySuperTransform({ classCode, accessCode }: EarlySuperTransformInfo): void {
     // Note that this code snippet works for static methods but not instance
     // methods. Expanded super calls for instance methods are handled in the
     // main stage.
@@ -52,7 +52,9 @@ export default class SuperPatcher extends NodePatcher {
 
   getFollowingOpenParenToken(): SourceToken {
     let openParenTokenIndex = this.indexOfSourceTokenAfterSourceTokenIndex(
-      this.contentEndTokenIndex, SourceType.CALL_START);
+      this.contentEndTokenIndex,
+      SourceType.CALL_START
+    );
     if (!openParenTokenIndex) {
       throw this.error('Expected open-paren after super.');
     }

--- a/src/stages/normalize/patchers/ThisPatcher.ts
+++ b/src/stages/normalize/patchers/ThisPatcher.ts
@@ -8,10 +8,9 @@ export default class ThisPatcher extends PassthroughPatcher {
    * When patching a shorthand like `@a` as repeatable, we need to add a dot to
    * make the result still syntactically valid.
    */
-  patchAsRepeatableExpression(repeatableOptions: RepeatableOptions={}, patchOptions: PatchOptions={}): string {
+  patchAsRepeatableExpression(repeatableOptions: RepeatableOptions = {}, patchOptions: PatchOptions = {}): string {
     let ref = super.patchAsRepeatableExpression(repeatableOptions, patchOptions);
-    let addedParens = (!this.isRepeatable() || repeatableOptions.forceRepeat) &&
-      repeatableOptions.parens;
+    let addedParens = (!this.isRepeatable() || repeatableOptions.forceRepeat) && repeatableOptions.parens;
     if (addedParens && this.parent instanceof MemberAccessOpPatcher) {
       let nextToken = this.nextSemanticToken();
       if (!nextToken || nextToken.type !== SourceType.DOT) {

--- a/src/stages/normalize/patchers/TryPatcher.ts
+++ b/src/stages/normalize/patchers/TryPatcher.ts
@@ -11,9 +11,12 @@ export default class TryPatcher extends NodePatcher {
   finallyBody: BlockPatcher | null;
 
   constructor(
-      patcherContext: PatcherContext, body: BlockPatcher | null,
-      catchAssignee: NodePatcher | null, catchBody: BlockPatcher | null,
-      finallyBody: BlockPatcher | null) {
+    patcherContext: PatcherContext,
+    body: BlockPatcher | null,
+    catchAssignee: NodePatcher | null,
+    catchBody: BlockPatcher | null,
+    finallyBody: BlockPatcher | null
+  ) {
     super(patcherContext);
     this.body = body;
     this.catchAssignee = catchAssignee;
@@ -73,9 +76,7 @@ export default class TryPatcher extends NodePatcher {
       return true;
     }
     let varName = this.catchAssignee.node.data;
-    let exceptionVarUsages = this.catchBody
-      ? countVariableUsages(this.catchBody.node, varName) + 1
-      : 1;
+    let exceptionVarUsages = this.catchBody ? countVariableUsages(this.catchBody.node, varName) + 1 : 1;
     let totalVarUsages = countVariableUsages(this.getScope().containerNode, varName);
     return totalVarUsages > exceptionVarUsages;
   }

--- a/src/stages/normalize/patchers/WhilePatcher.ts
+++ b/src/stages/normalize/patchers/WhilePatcher.ts
@@ -18,7 +18,7 @@ export default class WhilePatcher extends NodePatcher {
   condition: NodePatcher;
   guard: NodePatcher | null;
   body: NodePatcher | null;
-  
+
   constructor(patcherContext: PatcherContext, condition: NodePatcher, guard: NodePatcher | null, body: NodePatcher) {
     super(patcherContext);
     this.condition = condition;
@@ -54,17 +54,11 @@ export default class WhilePatcher extends NodePatcher {
     if (this.body === null) {
       throw this.error('Expected non-null body.');
     }
-    let patchedCondition = this.slice(
-      this.condition.outerStart,
-      this.condition.outerEnd
-    );
+    let patchedCondition = this.slice(this.condition.outerStart, this.condition.outerEnd);
     if (postfixExpressionRequiresParens(patchedCondition) && !this.condition.isSurroundedByParentheses()) {
       patchedCondition = `(${patchedCondition})`;
     }
-    let patchedBody = this.slice(
-      this.body.outerStart,
-      this.body.outerEnd
-    );
+    let patchedBody = this.slice(this.body.outerStart, this.body.outerEnd);
     let patchedGuard = null;
     if (this.guard) {
       patchedGuard = this.slice(this.guard.outerStart, this.guard.outerEnd);
@@ -73,15 +67,13 @@ export default class WhilePatcher extends NodePatcher {
       }
     }
     let whileToken = this.node.isUntil ? 'until' : 'while';
-    let newContent = `${whileToken} ${patchedCondition} ${patchedGuard ? `when ${patchedGuard} ` : ''}then ${patchedBody}`;
+    let newContent = `${whileToken} ${patchedCondition} ${
+      patchedGuard ? `when ${patchedGuard} ` : ''
+    }then ${patchedBody}`;
     if (postfixNodeNeedsOuterParens(this)) {
       newContent = `(${newContent})`;
     }
-    this.overwrite(
-      this.contentStart,
-      this.contentEnd,
-      newContent
-    );
+    this.overwrite(this.contentStart, this.contentEnd, newContent);
   }
 
   /**

--- a/src/stages/semicolons/index.ts
+++ b/src/stages/semicolons/index.ts
@@ -18,7 +18,7 @@ const BABYLON_PLUGINS: Array<PluginName> = [
   'functionBind',
   'functionSent',
   'objectRestSpread',
-  'optionalChaining' as any,  // tslint:disable-line no-any
+  'optionalChaining' as any // tslint:disable-line no-any
 ];
 
 export default class SemicolonsStage {
@@ -31,8 +31,8 @@ export default class SemicolonsStage {
       sourceType: 'module',
       plugins: BABYLON_PLUGINS,
       allowReturnOutsideFunction: true,
-      tokens: true,
-    } as any);  // tslint:disable-line no-any
+      tokens: true
+    } as any); // tslint:disable-line no-any
     let config = buildConfig(content, ast);
 
     asi(config);
@@ -42,7 +42,7 @@ export default class SemicolonsStage {
 
     return {
       code: editor.toString(),
-      suggestions: [],
+      suggestions: []
     };
   }
 }

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -1,76 +1,76 @@
 export type Suggestion = {
-  suggestionCode: string,
-  message: string,
+  suggestionCode: string;
+  message: string;
 };
 
 export const REMOVE_BABEL_WORKAROUND = {
   suggestionCode: 'DS001',
-  message: 'Remove Babel/TypeScript constructor workaround',
+  message: 'Remove Babel/TypeScript constructor workaround'
 };
 
 export const REMOVE_ARRAY_FROM = {
   suggestionCode: 'DS101',
-  message: 'Remove unnecessary use of Array.from',
+  message: 'Remove unnecessary use of Array.from'
 };
 
 export const CLEAN_UP_IMPLICIT_RETURNS = {
   suggestionCode: 'DS102',
-  message: 'Remove unnecessary code created because of implicit returns',
+  message: 'Remove unnecessary code created because of implicit returns'
 };
 
 export const REMOVE_GUARD = {
   suggestionCode: 'DS103',
-  message: 'Rewrite code to no longer use __guard__',
+  message: 'Rewrite code to no longer use __guard__'
 };
 
 export const AVOID_INLINE_ASSIGNMENTS = {
   suggestionCode: 'DS104',
-  message: 'Avoid inline assignments',
+  message: 'Avoid inline assignments'
 };
 
 export const SIMPLIFY_COMPLEX_ASSIGNMENTS = {
   suggestionCode: 'DS201',
-  message: 'Simplify complex destructure assignments',
+  message: 'Simplify complex destructure assignments'
 };
 
 export const SIMPLIFY_DYNAMIC_RANGE_LOOPS = {
   suggestionCode: 'DS202',
-  message: 'Simplify dynamic range loops',
+  message: 'Simplify dynamic range loops'
 };
 
 export const CLEAN_UP_FOR_OWN_LOOPS = {
   suggestionCode: 'DS203',
-  message: 'Remove `|| {}` from converted for-own loops',
+  message: 'Remove `|| {}` from converted for-own loops'
 };
 
 export const FIX_INCLUDES_EVALUATION_ORDER = {
   suggestionCode: 'DS204',
-  message: 'Change includes calls to have a more natural evaluation order',
+  message: 'Change includes calls to have a more natural evaluation order'
 };
 
 export const AVOID_IIFES = {
   suggestionCode: 'DS205',
-  message: 'Consider reworking code to avoid use of IIFEs',
+  message: 'Consider reworking code to avoid use of IIFEs'
 };
 
 export const AVOID_INITCLASS = {
   suggestionCode: 'DS206',
-  message: 'Consider reworking classes to avoid initClass',
+  message: 'Consider reworking classes to avoid initClass'
 };
 
 export const SHORTEN_NULL_CHECKS = {
   suggestionCode: 'DS207',
-  message: 'Consider shorter variations of null checks',
+  message: 'Consider shorter variations of null checks'
 };
 
 export const AVOID_TOP_LEVEL_THIS = {
   suggestionCode: 'DS208',
-  message: 'Avoid top-level this',
+  message: 'Avoid top-level this'
 };
 
 export const AVOID_TOP_LEVEL_RETURN = {
   suggestionCode: 'DS209',
-  message: 'Avoid top-level return',
+  message: 'Avoid top-level return'
 };
 
 export function mergeSuggestions(suggestions: Array<Suggestion>): Array<Suggestion> {
@@ -78,7 +78,9 @@ export function mergeSuggestions(suggestions: Array<Suggestion>): Array<Suggesti
   for (let suggestion of suggestions) {
     suggestionsByCode[suggestion.suggestionCode] = suggestion;
   }
-  return Object.keys(suggestionsByCode).sort().map(code => suggestionsByCode[code]);
+  return Object.keys(suggestionsByCode)
+    .sort()
+    .map(code => suggestionsByCode[code]);
 }
 
 export function prependSuggestionComment(code: string, suggestions: Array<Suggestion>): string {
@@ -88,18 +90,14 @@ export function prependSuggestionComment(code: string, suggestions: Array<Sugges
   let commentLines = [
     '/*',
     ' * decaffeinate suggestions:',
-    ...suggestions.map(({suggestionCode, message}) => ` * ${suggestionCode}: ${message}`),
+    ...suggestions.map(({ suggestionCode, message }) => ` * ${suggestionCode}: ${message}`),
     ' * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md',
     ' */'
   ];
 
   let codeLines = code.split('\n');
   if (codeLines[0].startsWith('#!')) {
-    return [
-      codeLines[0],
-      ...commentLines,
-      ...codeLines.slice(1),
-    ].join('\n');
+    return [codeLines[0], ...commentLines, ...codeLines.slice(1)].join('\n');
   } else {
     return [...commentLines, ...codeLines].join('\n');
   }

--- a/src/utils/CodeContext.ts
+++ b/src/utils/CodeContext.ts
@@ -28,8 +28,7 @@ export default class CodeContext {
     if (!location) {
       return 'INVALID POSITION';
     }
-    let {line, column} = location;
+    let { line, column } = location;
     return `${line + 1}:${column + 1}(${index})`;
   }
-
 }

--- a/src/utils/DecaffeinateContext.ts
+++ b/src/utils/DecaffeinateContext.ts
@@ -17,12 +17,11 @@ export default class DecaffeinateContext {
     readonly coffeeAST: Block,
     readonly linesAndColumns: LinesAndColumns,
     private readonly parentMap: Map<Node, Node | null>,
-    private readonly scopeMap: Map<Node, Scope>,
-  ) {
-  }
+    private readonly scopeMap: Map<Node, Scope>
+  ) {}
 
   static create(source: string, useCS2: boolean): DecaffeinateContext {
-    let program = decaffeinateParse(source, {useCS2});
+    let program = decaffeinateParse(source, { useCS2 });
     return new DecaffeinateContext(
       program,
       source,

--- a/src/utils/PatchError.ts
+++ b/src/utils/PatchError.ts
@@ -2,12 +2,7 @@ import LinesAndColumns from 'lines-and-columns';
 import printTable, { Column } from './printTable';
 
 export default class PatchError extends Error {
-  constructor(
-    readonly message: string,
-    readonly source: string,
-    readonly start: number,
-    readonly end: number,
-  ) {
+  constructor(readonly message: string, readonly source: string, readonly start: number, readonly end: number) {
     super(message);
   }
 
@@ -23,12 +18,7 @@ export default class PatchError extends Error {
    * @see http://stackoverflow.com/a/33837088/549363
    */
   static detect(error: Error): boolean {
-    return (
-      error instanceof Error &&
-      'source' in error &&
-      'start' in error &&
-      'end' in error
-    );
+    return error instanceof Error && 'source' in error && 'start' in error && 'end' in error;
   }
 
   static prettyPrint(error: PatchError): string {
@@ -60,13 +50,9 @@ export default class PatchError extends Error {
       let lineSource = trimRight(source.slice(startOfLine, endOfLine));
       if (startLoc.line !== endLoc.line) {
         if (line >= startLoc.line && line <= endLoc.line) {
-          rows.push(
-            [`>`, `${line + 1} |`, lineSource]
-          );
+          rows.push([`>`, `${line + 1} |`, lineSource]);
         } else {
-          rows.push(
-            [``, `${line + 1} |`, lineSource]
-          );
+          rows.push([``, `${line + 1} |`, lineSource]);
         }
       } else if (line === startLoc.line) {
         let highlightLength = Math.max(endLoc.column - startLoc.column, 1);
@@ -75,9 +61,7 @@ export default class PatchError extends Error {
           [``, `|`, ' '.repeat(startLoc.column) + '^'.repeat(highlightLength)]
         );
       } else {
-        rows.push(
-          [``, `${line + 1} |`, lineSource]
-        );
+        rows.push([``, `${line + 1} |`, lineSource]);
       }
     }
 

--- a/src/utils/Scope.ts
+++ b/src/utils/Scope.ts
@@ -1,4 +1,23 @@
-import { ArrayInitialiser, AssignOp, BaseFunction, Class, CompoundAssignOp, DefaultParam, Expansion, For, Identifier, MemberAccessOp, Node, ObjectInitialiser, PostDecrementOp, PostIncrementOp, PreDecrementOp, PreIncrementOp, Rest, Try } from 'decaffeinate-parser/dist/nodes';
+import {
+  ArrayInitialiser,
+  AssignOp,
+  BaseFunction,
+  Class,
+  CompoundAssignOp,
+  DefaultParam,
+  Expansion,
+  For,
+  Identifier,
+  MemberAccessOp,
+  Node,
+  ObjectInitialiser,
+  PostDecrementOp,
+  PostIncrementOp,
+  PreDecrementOp,
+  PreIncrementOp,
+  Rest,
+  Try
+} from 'decaffeinate-parser/dist/nodes';
 import flatMap from './flatMap';
 import isReservedWord from './isReservedWord';
 import leftHandIdentifiers from './leftHandIdentifiers';
@@ -13,10 +32,7 @@ export default class Scope {
   private modificationsAfterDeclaration: { [key: string]: boolean };
   private innerClosureModifications: { [key: string]: boolean };
 
-  constructor(
-    readonly containerNode: Node,
-    readonly parent: Scope | null = null
-  ) {
+  constructor(readonly containerNode: Node, readonly parent: Scope | null = null) {
     this.bindings = Object.create(parent ? parent.bindings : {});
     this.modificationsAfterDeclaration = {};
     this.innerClosureModifications = {};
@@ -88,8 +104,10 @@ export default class Scope {
     }
   }
 
-  claimFreeBinding(node: Node, name: (string | Array<string> | null) = null): string {
-    if (!name) { name = 'ref'; }
+  claimFreeBinding(node: Node, name: string | Array<string> | null = null): string {
+    if (!name) {
+      name = 'ref';
+    }
     let names = Array.isArray(name) ? name : [name];
     let binding = names.find(name => this.isBindingAvailable(name));
 
@@ -128,15 +146,17 @@ export default class Scope {
    */
   processNode(node: Node): void {
     if (node instanceof AssignOp) {
-      leftHandIdentifiers(node.assignee).forEach(identifier =>
-        this.assigns(identifier.data, identifier)
-      );
+      leftHandIdentifiers(node.assignee).forEach(identifier => this.assigns(identifier.data, identifier));
     } else if (node instanceof CompoundAssignOp) {
       if (node.assignee instanceof Identifier) {
         this.modifies(node.assignee.data);
       }
-    } else if (node instanceof PostDecrementOp || node instanceof PostIncrementOp ||
-        node instanceof PreDecrementOp || node instanceof PreIncrementOp) {
+    } else if (
+      node instanceof PostDecrementOp ||
+      node instanceof PostIncrementOp ||
+      node instanceof PreDecrementOp ||
+      node instanceof PreIncrementOp
+    ) {
       if (node.expression instanceof Identifier) {
         this.modifies(node.expression.data);
       }
@@ -145,16 +165,12 @@ export default class Scope {
     } else if (node instanceof For) {
       [node.keyAssignee, node.valAssignee].forEach(assignee => {
         if (assignee) {
-          leftHandIdentifiers(assignee).forEach(identifier =>
-            this.assigns(identifier.data, identifier)
-          );
+          leftHandIdentifiers(assignee).forEach(identifier => this.assigns(identifier.data, identifier));
         }
       });
     } else if (node instanceof Try) {
       if (node.catchAssignee) {
-        leftHandIdentifiers(node.catchAssignee).forEach(identifier =>
-          this.assigns(identifier.data, identifier)
-        );
+        leftHandIdentifiers(node.catchAssignee).forEach(identifier => this.assigns(identifier.data, identifier));
       }
     } else if (node instanceof Class) {
       if (node.nameAssignee && node.nameAssignee instanceof Identifier && this.parent) {
@@ -183,8 +199,7 @@ export default class Scope {
 function getBindingsForNode(node: Node): Array<Identifier> {
   if (node instanceof BaseFunction) {
     return flatMap(node.parameters, getBindingsForNode);
-  } else if (node instanceof Identifier || node instanceof ArrayInitialiser ||
-      node instanceof ObjectInitialiser) {
+  } else if (node instanceof Identifier || node instanceof ArrayInitialiser || node instanceof ObjectInitialiser) {
     return leftHandIdentifiers(node);
   } else if (node instanceof DefaultParam) {
     return getBindingsForNode(node.param);

--- a/src/utils/babelConstructorWorkaroundLines.ts
+++ b/src/utils/babelConstructorWorkaroundLines.ts
@@ -26,5 +26,5 @@ export default [
   '  let thisFn = (() => { return this; }).toString();',
   "  let thisName = thisFn.slice(thisFn.indexOf('return') + 6 + 1, thisFn.indexOf(';')).trim();",
   '  eval(`${thisName} = this;`);',
-  '}',
+  '}'
 ];

--- a/src/utils/blockStartsWithObjectInitialiser.ts
+++ b/src/utils/blockStartsWithObjectInitialiser.ts
@@ -13,6 +13,8 @@ export default function blockStartsWithObjectInitialiser(patcher: NodePatcher): 
     return false;
   }
   let statement = patcher.statements[0];
-  return containsDescendant(statement.node, child =>
-    child instanceof ObjectInitialiser && child.start === statement.contentStart);
+  return containsDescendant(
+    statement.node,
+    child => child instanceof ObjectInitialiser && child.start === statement.contentStart
+  );
 }

--- a/src/utils/canPatchAssigneeToJavaScript.ts
+++ b/src/utils/canPatchAssigneeToJavaScript.ts
@@ -8,20 +8,40 @@
  * JS falls back to the default if the value only if the value is undefined.
  */
 import {
-  ArrayInitialiser, AssignOp, DynamicMemberAccessOp, Elision, Expansion, Identifier,
-  MemberAccessOp, Node, ObjectInitialiser, ObjectInitialiserMember,
-  ProtoMemberAccessOp, Rest, SoakedDynamicMemberAccessOp, SoakedMemberAccessOp,
-  SoakedProtoMemberAccessOp, Spread
+  ArrayInitialiser,
+  AssignOp,
+  DynamicMemberAccessOp,
+  Elision,
+  Expansion,
+  Identifier,
+  MemberAccessOp,
+  Node,
+  ObjectInitialiser,
+  ObjectInitialiserMember,
+  ProtoMemberAccessOp,
+  Rest,
+  SoakedDynamicMemberAccessOp,
+  SoakedMemberAccessOp,
+  SoakedProtoMemberAccessOp,
+  Spread
 } from 'decaffeinate-parser/dist/nodes';
-import {Options} from '../options';
+import { Options } from '../options';
 
 export default function canPatchAssigneeToJavaScript(
-  node: Node, options: Options, isTopLevel: boolean = true
+  node: Node,
+  options: Options,
+  isTopLevel: boolean = true
 ): boolean {
-  if (node instanceof Identifier || node instanceof MemberAccessOp ||
-      node instanceof SoakedMemberAccessOp || node instanceof ProtoMemberAccessOp ||
-      node instanceof DynamicMemberAccessOp || node instanceof SoakedDynamicMemberAccessOp ||
-      node instanceof SoakedProtoMemberAccessOp || node instanceof Elision) {
+  if (
+    node instanceof Identifier ||
+    node instanceof MemberAccessOp ||
+    node instanceof SoakedMemberAccessOp ||
+    node instanceof ProtoMemberAccessOp ||
+    node instanceof DynamicMemberAccessOp ||
+    node instanceof SoakedDynamicMemberAccessOp ||
+    node instanceof SoakedProtoMemberAccessOp ||
+    node instanceof Elision
+  ) {
     return true;
   }
   if (node instanceof ArrayInitialiser) {
@@ -40,10 +60,12 @@ export default function canPatchAssigneeToJavaScript(
       if (isInFinalPosition && member instanceof Expansion) {
         return true;
       }
-      if (isInFinalPosition &&
-          (member instanceof Spread || member instanceof Rest) &&
-          !(member.expression instanceof ObjectInitialiser) &&
-          canPatchAssigneeToJavaScript(member.expression, options, false)) {
+      if (
+        isInFinalPosition &&
+        (member instanceof Spread || member instanceof Rest) &&
+        !(member.expression instanceof ObjectInitialiser) &&
+        canPatchAssigneeToJavaScript(member.expression, options, false)
+      ) {
         return true;
       }
       return canPatchAssigneeToJavaScript(member, options, false);

--- a/src/utils/containsDescendant.ts
+++ b/src/utils/containsDescendant.ts
@@ -4,10 +4,10 @@ import { Node } from 'decaffeinate-parser/dist/nodes';
 export default function containsDescendant(
   node: Node,
   predicate: (node: Node) => boolean,
-  {shouldStopTraversal = () => false}: {shouldStopTraversal?: (node: Node) => boolean} = {}
+  { shouldStopTraversal = () => false }: { shouldStopTraversal?: (node: Node) => boolean } = {}
 ): boolean {
   let found = false;
-  traverse(node, (childNode) => {
+  traverse(node, childNode => {
     if (found) {
       return false;
     }

--- a/src/utils/containsSuperCall.ts
+++ b/src/utils/containsSuperCall.ts
@@ -1,12 +1,8 @@
-import {
-  BareSuperFunctionApplication, Class, Node, Super
-} from 'decaffeinate-parser/dist/nodes';
+import { BareSuperFunctionApplication, Class, Node, Super } from 'decaffeinate-parser/dist/nodes';
 import containsDescendant from './containsDescendant';
 
 export default function containsSuperCall(node: Node): boolean {
-  return containsDescendant(
-    node,
-    child => child instanceof Super || child instanceof BareSuperFunctionApplication,
-    {shouldStopTraversal: child => child instanceof Class}
-  );
+  return containsDescendant(node, child => child instanceof Super || child instanceof BareSuperFunctionApplication, {
+    shouldStopTraversal: child => child instanceof Class
+  });
 }

--- a/src/utils/determineIndent.ts
+++ b/src/utils/determineIndent.ts
@@ -3,7 +3,7 @@ const detectIndent = require('detect-indent');
 const DEFAULT_INDENT = '  ';
 
 export default function determineIndent(source: string): string {
-  let indent: { amount: number, type: 'space' | 'tab', indent: string } = detectIndent(source);
+  let indent: { amount: number; type: 'space' | 'tab'; indent: string } = detectIndent(source);
   if (indent.type === 'space' && indent.amount % 2 === 1) {
     return DEFAULT_INDENT;
   }

--- a/src/utils/downgradeUnicodeCodePointEscapesInRange.ts
+++ b/src/utils/downgradeUnicodeCodePointEscapesInRange.ts
@@ -14,7 +14,7 @@ export default function downgradeUnicodeCodePointEscapesInRange(
   start: number,
   end: number,
   patcher: NodePatcher,
-  {needsExtraEscape}: {needsExtraEscape?: boolean} = {}
+  { needsExtraEscape }: { needsExtraEscape?: boolean } = {}
 ): void {
   const source = patcher.context.source;
   let numBackslashes = 0;
@@ -35,8 +35,8 @@ export default function downgradeUnicodeCodePointEscapesInRange(
       if (codePoint < 0x10000) {
         patcher.overwrite(i, codePointEnd + 1, toUnicodeEscape(codePoint));
       } else {
-        let high = Math.floor((codePoint - 0x10000) / 0x400) + 0xD800;
-        let low = (codePoint - 0x10000) % 0x400 + 0xDC00;
+        let high = Math.floor((codePoint - 0x10000) / 0x400) + 0xd800;
+        let low = (codePoint - 0x10000) % 0x400 + 0xdc00;
         patcher.overwrite(
           i,
           codePointEnd + 1,

--- a/src/utils/escape.ts
+++ b/src/utils/escape.ts
@@ -10,8 +10,13 @@ import MagicString from 'magic-string';
  * whitespace.
  */
 export default function escape(
-    source: string, patcher: MagicString, skipPattern: RegExp,
-    escapeStrings: Array<string>, start: number, end: number): void {
+  source: string,
+  patcher: MagicString,
+  skipPattern: RegExp,
+  escapeStrings: Array<string>,
+  start: number,
+  end: number
+): void {
   for (let i = start; i < end; i++) {
     if (skipPattern.test(source.slice(i, end))) {
       i++;

--- a/src/utils/escapeSpecialWhitespaceInRange.ts
+++ b/src/utils/escapeSpecialWhitespaceInRange.ts
@@ -1,10 +1,8 @@
-
 import NodePatcher from '../patchers/NodePatcher';
 
 function isAlreadyEscaped(i: number, start: number, patcher: NodePatcher): boolean {
   let numLeadingBackslashes = 0;
-  while (i - numLeadingBackslashes - 1 >= start &&
-      patcher.context.source[i - numLeadingBackslashes - 1] === '\\') {
+  while (i - numLeadingBackslashes - 1 >= start && patcher.context.source[i - numLeadingBackslashes - 1] === '\\') {
     numLeadingBackslashes++;
   }
   return numLeadingBackslashes % 2 === 1;

--- a/src/utils/extractPrototypeAssignPatchers.ts
+++ b/src/utils/extractPrototypeAssignPatchers.ts
@@ -16,16 +16,17 @@ export type PrototypeAssignPatchers = {
  * the enclosing function.
  */
 export default function extractPrototypeAssignPatchers(patcher: NodePatcher): PrototypeAssignPatchers | null {
-  if (!(patcher instanceof AssignOpPatcher) ||
-      !(patcher.expression instanceof FunctionPatcher) ||
-      !(patcher.assignee instanceof MemberAccessOpPatcher ||
-      patcher.assignee instanceof DynamicMemberAccessOpPatcher) ||
-      !(patcher.assignee.expression instanceof MemberAccessOpPatcher) ||
-      patcher.assignee.expression.member.node.data !== 'prototype') {
+  if (
+    !(patcher instanceof AssignOpPatcher) ||
+    !(patcher.expression instanceof FunctionPatcher) ||
+    !(patcher.assignee instanceof MemberAccessOpPatcher || patcher.assignee instanceof DynamicMemberAccessOpPatcher) ||
+    !(patcher.assignee.expression instanceof MemberAccessOpPatcher) ||
+    patcher.assignee.expression.member.node.data !== 'prototype'
+  ) {
     return null;
   }
   return {
     classRefPatcher: patcher.assignee.expression.expression,
-    methodAccessPatcher: patcher.assignee,
+    methodAccessPatcher: patcher.assignee
   };
 }

--- a/src/utils/findSoakContainer.ts
+++ b/src/utils/findSoakContainer.ts
@@ -45,34 +45,39 @@ function canParentHandleSoak(patcher: NodePatcher): boolean {
   // is a special case and the `.c?(` will be patched. In this case, the `a?.b`
   // is what we should set as our soak container, since the method-style soak
   // implementation will "take over" from that point.
-  if ((patcher.parent instanceof MemberAccessOpPatcher
-        || patcher.parent instanceof DynamicMemberAccessOpPatcher)
-      && patcher.parent.parent !== null
-      && patcher.parent.parent instanceof SoakedFunctionApplicationPatcher
-      && patcher.parent.parent.fn === patcher.parent) {
+  if (
+    (patcher.parent instanceof MemberAccessOpPatcher || patcher.parent instanceof DynamicMemberAccessOpPatcher) &&
+    patcher.parent.parent !== null &&
+    patcher.parent.parent instanceof SoakedFunctionApplicationPatcher &&
+    patcher.parent.parent.fn === patcher.parent
+  ) {
     return false;
   }
-  if (patcher.parent instanceof MemberAccessOpPatcher
-      && !(patcher.parent instanceof SoakedMemberAccessOpPatcher)) {
+  if (patcher.parent instanceof MemberAccessOpPatcher && !(patcher.parent instanceof SoakedMemberAccessOpPatcher)) {
     return true;
   }
-  if (patcher.parent instanceof DynamicMemberAccessOpPatcher
-      && !(patcher.parent instanceof SoakedDynamicMemberAccessOpPatcher)
-      && patcher.parent.expression === patcher) {
+  if (
+    patcher.parent instanceof DynamicMemberAccessOpPatcher &&
+    !(patcher.parent instanceof SoakedDynamicMemberAccessOpPatcher) &&
+    patcher.parent.expression === patcher
+  ) {
     return true;
   }
-  if (patcher.parent instanceof FunctionApplicationPatcher
-      && !(patcher.parent instanceof SoakedFunctionApplicationPatcher)
-      && patcher.parent.fn === patcher) {
+  if (
+    patcher.parent instanceof FunctionApplicationPatcher &&
+    !(patcher.parent instanceof SoakedFunctionApplicationPatcher) &&
+    patcher.parent.fn === patcher
+  ) {
     return true;
   }
-  if (patcher.parent instanceof AssignOpPatcher
-      && patcher.parent.assignee === patcher) {
+  if (patcher.parent instanceof AssignOpPatcher && patcher.parent.assignee === patcher) {
     return true;
   }
-  if ([
-        'PostIncrementOp', 'PostDecrementOp', 'PreIncrementOp', 'PreDecrementOp', 'DeleteOp'
-      ].indexOf(patcher.parent.node.type) >= 0) {
+  if (
+    ['PostIncrementOp', 'PostDecrementOp', 'PreIncrementOp', 'PreDecrementOp', 'DeleteOp'].indexOf(
+      patcher.parent.node.type
+    ) >= 0
+  ) {
     return true;
   }
   return false;

--- a/src/utils/formatCoffeeLexTokens.ts
+++ b/src/utils/formatCoffeeLexTokens.ts
@@ -4,8 +4,6 @@ import SourceTokenList from 'coffee-lex/dist/SourceTokenList';
 import CodeContext from './CodeContext';
 
 export default function formatCoffeeLexTokens(tokens: SourceTokenList, context: CodeContext): string {
-  let resultLines = tokens.map(token =>
-    `${context.formatRange(token.start, token.end)}: ${SourceType[token.type]}`
-  );
+  let resultLines = tokens.map(token => `${context.formatRange(token.start, token.end)}: ${SourceType[token.type]}`);
   return resultLines.map(line => line + '\n').join('');
 }

--- a/src/utils/formatCoffeeScriptAst.ts
+++ b/src/utils/formatCoffeeScriptAst.ts
@@ -58,7 +58,7 @@ function formatAstNodeLines(node: CS1Base | CS2Base, context: CodeContext): Arra
   return [
     `${node.constructor.name} ${formatCoffeeScriptLocationData(node.locationData, context)} {`,
     ...propLines.map(s => '  ' + s),
-    '}',
+    '}'
   ];
 }
 

--- a/src/utils/formatCoffeeScriptLexerTokens.ts
+++ b/src/utils/formatCoffeeScriptLexerTokens.ts
@@ -3,8 +3,9 @@ import CodeContext from './CodeContext';
 import formatCoffeeScriptLocationData from './formatCoffeeScriptLocationData';
 
 export default function formatCoffeeScriptLexerTokens(tokens: Array<Token>, context: CodeContext): string {
-  let resultLines = tokens.map(([tag, value, locationData]) =>
-    `${formatCoffeeScriptLocationData(locationData, context)}: ${tag}: ${JSON.stringify(value)}`
+  let resultLines = tokens.map(
+    ([tag, value, locationData]) =>
+      `${formatCoffeeScriptLocationData(locationData, context)}: ${tag}: ${JSON.stringify(value)}`
   );
   return resultLines.map(line => line + '\n').join('');
 }

--- a/src/utils/formatCoffeeScriptLocationData.ts
+++ b/src/utils/formatCoffeeScriptLocationData.ts
@@ -2,12 +2,12 @@ import { LocationData } from 'decaffeinate-coffeescript2/lib/coffeescript/nodes'
 import CodeContext from './CodeContext';
 
 export default function formatCoffeeScriptLocationData(locationData: LocationData, context: CodeContext): string {
-  let {first_line, first_column, last_line, last_column} = locationData;
-  let firstIndex = context.linesAndColumns.indexForLocation({line: first_line, column: first_column});
+  let { first_line, first_column, last_line, last_column } = locationData;
+  let firstIndex = context.linesAndColumns.indexForLocation({ line: first_line, column: first_column });
   if (firstIndex === null) {
     return 'INVALID RANGE';
   }
-  let lastIndex = context.linesAndColumns.indexForLocation({line: last_line, column: last_column});
+  let lastIndex = context.linesAndColumns.indexForLocation({ line: last_line, column: last_column });
   if (lastIndex === null) {
     return 'INVALID RANGE';
   }

--- a/src/utils/formatDecaffeinateParserAst.ts
+++ b/src/utils/formatDecaffeinateParserAst.ts
@@ -9,9 +9,16 @@ export default function formatDecaffeinateParserAst(program: Node, context: Code
 function formatAstNodeLines(node: Node, context: CodeContext): Array<string> {
   let propLines = [];
   let childPropNames = node.getChildNames();
-  let blacklistedProps = childPropNames.concat(
-    ['raw', 'line', 'column', 'type', 'parentNode', 'context', 'start', 'end']
-  );
+  let blacklistedProps = childPropNames.concat([
+    'raw',
+    'line',
+    'column',
+    'type',
+    'parentNode',
+    'context',
+    'start',
+    'end'
+  ]);
   for (let key of Object.keys(node)) {
     if (blacklistedProps.indexOf(key) !== -1) {
       continue;
@@ -44,9 +51,5 @@ function formatAstNodeLines(node: Node, context: CodeContext): Array<string> {
     }
   }
   let rangeStr = context.formatRange(node.start, node.end);
-  return [
-    `${node.type} ${rangeStr} {`,
-    ...propLines.map(s => '  ' + s),
-    '}',
-  ];
+  return [`${node.type} ${rangeStr} {`, ...propLines.map(s => '  ' + s), '}'];
 }

--- a/src/utils/getAssigneeBindings.ts
+++ b/src/utils/getAssigneeBindings.ts
@@ -2,7 +2,16 @@
  * Determine the variables introduced by this assignee (array destructure,
  * object destructure, rest, etc.).
  */
-import { ArrayInitialiser, AssignOp, Identifier, Node, ObjectInitialiser, ObjectInitialiserMember, Rest, Spread } from 'decaffeinate-parser/dist/nodes';
+import {
+  ArrayInitialiser,
+  AssignOp,
+  Identifier,
+  Node,
+  ObjectInitialiser,
+  ObjectInitialiserMember,
+  Rest,
+  Spread
+} from 'decaffeinate-parser/dist/nodes';
 
 export default function getAssigneeBindings(node: Node): Array<string> {
   if (node instanceof Identifier) {

--- a/src/utils/getEnclosingScopeBlock.ts
+++ b/src/utils/getEnclosingScopeBlock.ts
@@ -8,8 +8,10 @@ import notNull from './notNull';
 export default function getEnclosingScopeBlock(patcher: NodePatcher): BlockPatcher {
   let currentPatcher: NodePatcher | null = patcher;
   while (currentPatcher) {
-    if (currentPatcher instanceof BlockPatcher &&
-      notNull(currentPatcher.parent).node === patcher.getScope().containerNode) {
+    if (
+      currentPatcher instanceof BlockPatcher &&
+      notNull(currentPatcher.parent).node === patcher.getScope().containerNode
+    ) {
       return currentPatcher;
     }
     currentPatcher = currentPatcher.parent;

--- a/src/utils/isReservedWord.ts
+++ b/src/utils/isReservedWord.ts
@@ -2,38 +2,67 @@
 // https://github.com/jashkenas/coffeescript/blob/master/src/lexer.coffee
 
 const JS_KEYWORDS = [
-  'true', 'false', 'null', 'this',
-  'new', 'delete', 'typeof', 'in', 'instanceof',
-  'return', 'throw', 'break', 'continue', 'debugger', 'yield',
-  'if', 'else', 'switch', 'for', 'while', 'do', 'try', 'catch', 'finally',
-  'class', 'extends', 'super',
-  'import', 'export', 'default',
+  'true',
+  'false',
+  'null',
+  'this',
+  'new',
+  'delete',
+  'typeof',
+  'in',
+  'instanceof',
+  'return',
+  'throw',
+  'break',
+  'continue',
+  'debugger',
+  'yield',
+  'if',
+  'else',
+  'switch',
+  'for',
+  'while',
+  'do',
+  'try',
+  'catch',
+  'finally',
+  'class',
+  'extends',
+  'super',
+  'import',
+  'export',
+  'default'
 ];
 
-const COFFEE_KEYWORDS = [
-  'undefined', 'Infinity', 'NaN',
-  'then', 'unless', 'until', 'loop', 'of', 'by', 'when',
-];
+const COFFEE_KEYWORDS = ['undefined', 'Infinity', 'NaN', 'then', 'unless', 'until', 'loop', 'of', 'by', 'when'];
 
-const COFFEE_ALIASES = [
-  'and', 'or', 'is', 'isnt', 'not', 'yes', 'no', 'on', 'off',
-];
+const COFFEE_ALIASES = ['and', 'or', 'is', 'isnt', 'not', 'yes', 'no', 'on', 'off'];
 
 const RESERVED = [
-  'case', 'default', 'function', 'var', 'void', 'with', 'const', 'let', 'enum',
-  'export', 'import', 'native', 'implements', 'interface', 'package', 'private',
-  'protected', 'public', 'static',
+  'case',
+  'default',
+  'function',
+  'var',
+  'void',
+  'with',
+  'const',
+  'let',
+  'enum',
+  'export',
+  'import',
+  'native',
+  'implements',
+  'interface',
+  'package',
+  'private',
+  'protected',
+  'public',
+  'static'
 ];
 
-const STRICT_PROSCRIBED = [
-  'arguments', 'eval',
-];
+const STRICT_PROSCRIBED = ['arguments', 'eval'];
 
-const JS_FORBIDDEN = new Set([
-  ...JS_KEYWORDS,
-  ...RESERVED,
-  ...STRICT_PROSCRIBED
-]);
+const JS_FORBIDDEN = new Set([...JS_KEYWORDS, ...RESERVED, ...STRICT_PROSCRIBED]);
 
 const RESERVED_WORDS = new Set([
   ...JS_KEYWORDS,
@@ -42,7 +71,7 @@ const RESERVED_WORDS = new Set([
   ...RESERVED,
   ...STRICT_PROSCRIBED,
   // Mentioned in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Future_reserved_keywords
-  'await',
+  'await'
 ]);
 
 /**

--- a/src/utils/leftHandIdentifiers.ts
+++ b/src/utils/leftHandIdentifiers.ts
@@ -1,5 +1,10 @@
 import {
-  ArrayInitialiser, Identifier, Node, ObjectInitialiser, ObjectInitialiserMember, Spread
+  ArrayInitialiser,
+  Identifier,
+  Node,
+  ObjectInitialiser,
+  ObjectInitialiserMember,
+  Spread
 } from 'decaffeinate-parser/dist/nodes';
 import flatMap from './flatMap';
 
@@ -24,7 +29,8 @@ export default function leftHandIdentifiers(node: Node): Array<Identifier> {
         return leftHandIdentifiers(member.expression || member.key);
       } else if (member instanceof Spread) {
         return leftHandIdentifiers(member.expression);
-      } {
+      }
+      {
         return leftHandIdentifiers(member.assignee);
       }
     });

--- a/src/utils/nodeContainsSoakOperation.ts
+++ b/src/utils/nodeContainsSoakOperation.ts
@@ -1,5 +1,7 @@
 import {
-  Node, SoakedDynamicMemberAccessOp, SoakedFunctionApplication,
+  Node,
+  SoakedDynamicMemberAccessOp,
+  SoakedFunctionApplication,
   SoakedMemberAccessOp
 } from 'decaffeinate-parser/dist/nodes';
 import containsDescendant from './containsDescendant';
@@ -8,9 +10,11 @@ import containsDescendant from './containsDescendant';
  * Determine if there are any soak operations within this subtree of the AST.
  */
 export default function nodeContainsSoakOperation(node: Node): boolean {
-  return containsDescendant(node, child =>
-    child instanceof SoakedDynamicMemberAccessOp ||
-    child instanceof SoakedFunctionApplication ||
-    child instanceof SoakedMemberAccessOp
+  return containsDescendant(
+    node,
+    child =>
+      child instanceof SoakedDynamicMemberAccessOp ||
+      child instanceof SoakedFunctionApplication ||
+      child instanceof SoakedMemberAccessOp
   );
 }

--- a/src/utils/normalizeListItem.ts
+++ b/src/utils/normalizeListItem.ts
@@ -4,14 +4,16 @@
  * syntax in the normalize stage.
  */
 import { SourceType } from 'coffee-lex';
-import {Block, Elision} from 'decaffeinate-parser/dist/nodes';
+import { Block, Elision } from 'decaffeinate-parser/dist/nodes';
 import NodePatcher from '../patchers/NodePatcher';
 import containsDescendant from './containsDescendant';
 import notNull from './notNull';
 
 export default function normalizeListItem(
-    patcher: NodePatcher, listItemPatcher: NodePatcher,
-    nextListItemPatcher: NodePatcher | null): void {
+  patcher: NodePatcher,
+  listItemPatcher: NodePatcher,
+  nextListItemPatcher: NodePatcher | null
+): void {
   // If the last token of the arg is a comma, then the actual delimiter must
   // be a newline and the comma is unnecessary and can cause a syntax error
   // when combined with other normalize stage transformations. So just
@@ -23,8 +25,7 @@ export default function normalizeListItem(
   // CoffeeScript allows semicolon-separated lists, so just change them to
   // commas if we see them.
   let nextToken = listItemPatcher.nextSemanticToken();
-  if (nextToken && nextToken.type === SourceType.SEMICOLON &&
-      nextToken.end <= patcher.contentEnd) {
+  if (nextToken && nextToken.type === SourceType.SEMICOLON && nextToken.end <= patcher.contentEnd) {
     if (patcherEndsInStatement(listItemPatcher)) {
       patcher.remove(nextToken.start, nextToken.end);
     } else {
@@ -36,7 +37,8 @@ export default function normalizeListItem(
     // We have two adjacent items, so do some cleanups based on the tokens
     // between them (comma tokens, or technically semicolons are treated as
     // commas as well).
-    let commaTokens = patcher.getProgramSourceTokens()
+    let commaTokens = patcher
+      .getProgramSourceTokens()
       .slice(notNull(listItemPatcher.outerEndTokenIndex.next()), nextListItemPatcher.outerStartTokenIndex)
       .filter(token => token.type === SourceType.COMMA || token.type === SourceType.SEMICOLON)
       .toArray();
@@ -44,9 +46,11 @@ export default function normalizeListItem(
     // Sometimes other normalize steps can cause two adjacent list items to be
     // reinterpreted as a function call, so put a comma in between them to stop
     // that, but avoid other cases where adding a comma would cause a crash.
-    if (nextListItemPatcher.node.type === 'ObjectInitialiser' &&
-        !isNestedListItem(listItemPatcher) &&
-        commaTokens.length === 0) {
+    if (
+      nextListItemPatcher.node.type === 'ObjectInitialiser' &&
+      !isNestedListItem(listItemPatcher) &&
+      commaTokens.length === 0
+    ) {
       patcher.insert(listItemPatcher.outerEnd, ',');
     }
   }
@@ -58,18 +62,20 @@ export default function normalizeListItem(
  * so could cause a parser crash.
  */
 function isNestedListItem(patcher: NodePatcher): boolean {
-  return [
-    'BoundFunction',
-    'BoundGeneratorFunction',
-    'Conditional',
-    'ForIn',
-    'ForOf',
-    'Function',
-    'GeneratorFunction',
-    'Switch',
-    'Try',
-    'While',
-  ].indexOf(patcher.node.type) > -1;
+  return (
+    [
+      'BoundFunction',
+      'BoundGeneratorFunction',
+      'Conditional',
+      'ForIn',
+      'ForOf',
+      'Function',
+      'GeneratorFunction',
+      'Switch',
+      'Try',
+      'While'
+    ].indexOf(patcher.node.type) > -1
+  );
 }
 
 /**
@@ -79,7 +85,5 @@ function isNestedListItem(patcher: NodePatcher): boolean {
  * they're not included in the normal statement bounds.
  */
 function patcherEndsInStatement(patcher: NodePatcher): boolean {
-  return containsDescendant(patcher.node, child =>
-    child instanceof Block && child.end === patcher.contentEnd
-  );
+  return containsDescendant(patcher.node, child => child instanceof Block && child.end === patcher.contentEnd);
 }

--- a/src/utils/postfixNodeNeedsOuterParens.ts
+++ b/src/utils/postfixNodeNeedsOuterParens.ts
@@ -1,5 +1,5 @@
 import { SourceType } from 'coffee-lex';
-import {Spread} from 'decaffeinate-parser/dist/nodes';
+import { Spread } from 'decaffeinate-parser/dist/nodes';
 import NodePatcher from '../patchers/NodePatcher';
 import ObjectInitialiserPatcher from '../stages/normalize/patchers/ObjectInitialiserPatcher';
 
@@ -19,11 +19,7 @@ export default function postfixNodeNeedsOuterParens(patcher: NodePatcher): boole
       return true;
     }
     let grandparent = parent.parent;
-    if (
-      grandparent &&
-      grandparent instanceof ObjectInitialiserPatcher &&
-      grandparent.isImplicitObjectInitializer()
-    ) {
+    if (grandparent && grandparent instanceof ObjectInitialiserPatcher && grandparent.isImplicitObjectInitializer()) {
       return true;
     }
   }

--- a/src/utils/printTable.ts
+++ b/src/utils/printTable.ts
@@ -1,21 +1,20 @@
 export type Column = {
-  id: string,
-  align: 'left' | 'right',
+  id: string;
+  align: 'left' | 'right';
 };
 
 export type Table = {
-  rows: Array<Array<string>>,
-  columns: Array<Column>,
+  rows: Array<Array<string>>;
+  columns: Array<Column>;
 };
 
-export default function printTable(table: Table, buffer: string=' '): string {
+export default function printTable(table: Table, buffer: string = ' '): string {
   let widths: Array<number> = [];
   table.rows.forEach(row => {
     row.forEach((cell, i) => {
       if (widths.length <= i) {
         widths[i] = cell.length;
-      }
-      else if (widths[i] < cell.length) {
+      } else if (widths[i] < cell.length) {
         widths[i] = cell.length;
       }
     });

--- a/src/utils/referencesArguments.ts
+++ b/src/utils/referencesArguments.ts
@@ -3,9 +3,7 @@ import containsDescendant from './containsDescendant';
 import { isFunction } from './types';
 
 export default function referencesArguments(node: Node): boolean {
-  return containsDescendant(
-    node,
-    child => child instanceof Identifier && child.data === 'arguments',
-    {shouldStopTraversal: child => child !== node && isFunction(child)}
-  );
+  return containsDescendant(node, child => child instanceof Identifier && child.data === 'arguments', {
+    shouldStopTraversal: child => child !== node && isFunction(child)
+  });
 }

--- a/src/utils/registerModHelper.ts
+++ b/src/utils/registerModHelper.ts
@@ -1,7 +1,6 @@
 import NodePatcher from '../patchers/NodePatcher';
 
-const MOD_HELPER =
-  `function __mod__(a, b) {
+const MOD_HELPER = `function __mod__(a, b) {
   a = +a;
   b = +b;
   return (a % b + b) % b;

--- a/src/utils/removeUnicodeBOMIfNecessary.ts
+++ b/src/utils/removeUnicodeBOMIfNecessary.ts
@@ -4,9 +4,9 @@
  * should do the same.
  */
 export default function removeUnicodeBOMIfNecessary(source: string): string {
-    if (source[0] === '\uFEFF') {
-        return source.slice(1);
-    } else {
-        return source;
-    }
+  if (source[0] === '\uFEFF') {
+    return source.slice(1);
+  } else {
+    return source;
+  }
 }

--- a/src/utils/resolveToPatchError.ts
+++ b/src/utils/resolveToPatchError.ts
@@ -8,12 +8,8 @@ import PatchError from './PatchError';
  */
 // tslint:disable-next-line no-any
 export default function resolveToPatchError(err: any, content: string, stageName: string): PatchError | null {
-  let makePatchError = (start: number, end: number, source: string) => new PatchError(
-    `${stageName} failed to parse: ${err.message}`,
-    source,
-    start,
-    end
-  );
+  let makePatchError = (start: number, end: number, source: string) =>
+    new PatchError(`${stageName} failed to parse: ${err.message}`, source, start, end);
 
   if (err.pos) {
     // Handle JavaScript parse errors.
@@ -30,8 +26,8 @@ export default function resolveToPatchError(err: any, content: string, stageName
     // Handle CoffeeScript parse errors.
     let { first_line, first_column, last_line, last_column } = err.syntaxError.location;
     let lineMap = new LinesAndColumns(content);
-    let firstIndex = lineMap.indexForLocation({line: first_line, column: first_column});
-    let lastIndex = lineMap.indexForLocation({line: last_line, column: last_column});
+    let firstIndex = lineMap.indexForLocation({ line: first_line, column: first_column });
+    let lastIndex = lineMap.indexForLocation({ line: last_line, column: last_column });
     if (firstIndex !== null) {
       if (lastIndex === null) {
         lastIndex = firstIndex + 1;

--- a/src/utils/ternaryNeedsParens.ts
+++ b/src/utils/ternaryNeedsParens.ts
@@ -26,10 +26,11 @@ export default function ternaryNeedsParens(patcher: NodePatcher): boolean {
     patcher.isSurroundedByParentheses() ||
     (parent instanceof FunctionApplicationPatcher && patcher !== parent.fn) ||
     (parent instanceof DynamicMemberAccessOpPatcher && patcher === parent.indexingExpr) ||
-    (parent instanceof ConditionalPatcher && !parent.node.isUnless &&
-      patcher === parent.condition && !parent.willPatchAsTernary()) ||
-    (parent instanceof WhilePatcher && !parent.node.isUntil &&
-      patcher === parent.condition) ||
+    (parent instanceof ConditionalPatcher &&
+      !parent.node.isUnless &&
+      patcher === parent.condition &&
+      !parent.willPatchAsTernary()) ||
+    (parent instanceof WhilePatcher && !parent.node.isUntil && patcher === parent.condition) ||
     parent instanceof InOpPatcher ||
     (parent instanceof AssignOpPatcher && patcher === parent.expression) ||
     // This function is called for soak operations, so outer soak operations

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -5,9 +5,12 @@ import { Node } from 'decaffeinate-parser/dist/nodes';
 /**
  * Determines whether a node represents a function, i.e. `->` or `=>`.
  */
-export function isFunction(node: Node, allowBound: boolean=true): boolean {
-  return node.type === 'Function' || node.type === 'GeneratorFunction' ||
-    (allowBound && (node.type === 'BoundFunction' || node.type === 'BoundGeneratorFunction'));
+export function isFunction(node: Node, allowBound: boolean = true): boolean {
+  return (
+    node.type === 'Function' ||
+    node.type === 'GeneratorFunction' ||
+    (allowBound && (node.type === 'BoundFunction' || node.type === 'BoundGeneratorFunction'))
+  );
 }
 
 const NON_SEMANTIC_SOURCE_TOKEN_TYPES = [SourceType.COMMENT, SourceType.HERECOMMENT, SourceType.NEWLINE];

--- a/test/array_test.ts
+++ b/test/array_test.ts
@@ -10,21 +10,25 @@ describe('arrays', () => {
   });
 
   it('does not change multi-line arrays when there are all the commas between elements', () => {
-    check(`
+    check(
+      `
       [
         1,
         2
       ]
-    `, `
+    `,
+      `
       [
         1,
         2
       ];
-    `);
+    `
+    );
   });
 
   it('does not change multi-line arrays when there are all the commas, even in weird places', () => {
-    check(`
+    check(
+      `
       [
         1
         ,
@@ -33,7 +37,8 @@ describe('arrays', () => {
         ,
         3
       ]
-    `, `
+    `,
+      `
       [
         1
         ,
@@ -42,57 +47,68 @@ describe('arrays', () => {
         ,
         3
       ];
-    `);
+    `
+    );
   });
 
   it('adds missing commas between multi-line elements', () => {
-    check(`
+    check(
+      `
       [
         1
         2
         3
       ]
-    `, `
+    `,
+      `
       [
         1,
         2,
         3
       ];
-    `);
+    `
+    );
   });
 
   it('adds missing commas even when there are commas in comments between elements', () => {
-    check(`
+    check(
+      `
       [
         1 #,
         2
       ]
-    `, `
+    `,
+      `
       [
         1, //,
         2
       ];
-    `);
+    `
+    );
   });
 
   it('adds commas only at the end of the line', () => {
-    check(`
+    check(
+      `
       [
         1, 2
         3
         4
       ]
-    `, `
+    `,
+      `
       [
         1, 2,
         3,
         4
       ];
-    `);
+    `
+    );
   });
 
   it('inserts commas in nested arrays', () => {
-    check(`
+    check(
+      `
       [
         [
           1
@@ -100,7 +116,8 @@ describe('arrays', () => {
         ]
         3
       ]
-    `, `
+    `,
+      `
       [
         [
           1,
@@ -108,67 +125,79 @@ describe('arrays', () => {
         ],
         3
       ];
-    `);
+    `
+    );
   });
 
   it('handles arrays containing implicit function calls', () => {
-    check(`
+    check(
+      `
       [a(b, c {
       })]
-    `, `
+    `,
+      `
       [a(b, c({
       }))];
-    `);
+    `
+    );
   });
 
   it('keeps array elements inserting within the array', () =>
-    check(`
+    check(
+      `
       [->
         a
         b]
-    `, `
+    `,
+      `
       [function() {
         a;
         return b;
       }];
-    `)
-  );
+    `
+    ));
 
   it('allows semicolon delimiters between array values', () =>
-    check(`
+    check(
+      `
       [a, b; c, d;]
-    `, `
+    `,
+      `
       [a, b, c, d,];
-    `)
-  );
+    `
+    ));
 
   it('allows a function call over an object followed by an object array element', () =>
-    check(`
+    check(
+      `
       [
         a {}
           b: {}
       ]
-    `, `
+    `,
+      `
       [
         a({}),
           {b: {}}
       ];
-    `)
-  );
+    `
+    ));
 
   it('allows a block ending in an implicit call followed by an implicit object', () =>
-    check(`
+    check(
+      `
       [
         if a
           b c
          d: {}
       ]
-    `, `
+    `,
+      `
       [
         a ?
           b(c) : undefined,
          {d: {}}
       ];
-    `)
-  );
+    `
+    ));
 });

--- a/test/await_test.ts
+++ b/test/await_test.ts
@@ -1,43 +1,54 @@
-import {checkCS2} from './support/check';
+import { checkCS2 } from './support/check';
 
 describe('await', () => {
   it('handles basic async function transformation', () => {
-    checkCS2(`
+    checkCS2(
+      `
       f = ->
         await @g()
-    `, `
+    `,
+      `
       const f = async function() {
         return await this.g();
       };
-    `);
+    `
+    );
   });
 
   it('handles bound async function transformation', () => {
-    checkCS2(`
+    checkCS2(
+      `
       f = =>
         await g()
-    `, `
+    `,
+      `
       const f = async () => {
         return await g();
       };
-    `);
+    `
+    );
   });
 
   it('handles await return', () => {
-    checkCS2(`
+    checkCS2(
+      `
       f = ->
         await return 3
-    `, `
+    `,
+      `
       const f = async () => 3;
-    `);
+    `
+    );
   });
 
   it('handles nested await', () => {
-    checkCS2(`
+    checkCS2(
+      `
       f = ->
         x = for a in b
           await c
-    `, `
+    `,
+      `
       const f = async function() {
         let x;
         return x = await (async () => {
@@ -48,35 +59,42 @@ describe('await', () => {
           return result;
         })();
       };
-    `);
+    `
+    );
   });
 
   it('handles await within an object method', () => {
-    checkCS2(`
+    checkCS2(
+      `
       o = {
         f: ->
           await 3
       }
-    `, `
+    `,
+      `
       const o = {
         async f() {
           return await 3;
         }
       };
-    `);
+    `
+    );
   });
 
   it('handles await within a class method', () => {
-    checkCS2(`
+    checkCS2(
+      `
       class C
         f: ->
           await 3
-    `, `
+    `,
+      `
       class C {
         async f() {
           return await 3;
         }
       }
-    `);
+    `
+    );
   });
 });

--- a/test/binary_operator_test.ts
+++ b/test/binary_operator_test.ts
@@ -1,154 +1,207 @@
-import check, {checkCS1} from './support/check';
+import check, { checkCS1 } from './support/check';
 
 describe('binary operators', () => {
   it('passes subtraction through', () => {
-    check(`
+    check(
+      `
       a - b
-    `, `
+    `,
+      `
       a - b;
-    `);
+    `
+    );
   });
 
   it('passes bitwise `and` through', () => {
-    check(`
+    check(
+      `
       a & b
-    `, `
+    `,
+      `
       a & b;
-    `);
+    `
+    );
   });
 
   it('passes bitwise `xor` through', () => {
-    check(`
+    check(
+      `
       a ^ b
-    `, `
+    `,
+      `
       a ^ b;
-    `);
+    `
+    );
   });
 
   it('passes compound subtraction and bitwise `and` through', () => {
-    check(`
+    check(
+      `
       a - b & c
       a & b - c
-    `, `
+    `,
+      `
       (a - b) & c;
       a & (b - c);
-    `);
+    `
+    );
   });
 
   it('passes compound subtraction and bitwise `or` through', () => {
-    check(`
+    check(
+      `
       a - b | c
       a | b - c
-    `, `
+    `,
+      `
       (a - b) | c;
       a | (b - c);
-    `);
+    `
+    );
   });
 
   it('passes left shift through', () => {
-    check(`
+    check(
+      `
       a << b
-    `, `
+    `,
+      `
       a << b;
-    `);
+    `
+    );
   });
 
   it('passes signed right shift through', () => {
-    check(`
+    check(
+      `
       a >> b
-    `, `
+    `,
+      `
       a >> b;
-    `);
+    `
+    );
   });
 
   it('passes unsigned right shift through', () => {
-    check(`
+    check(
+      `
       a >>> b
-    `, `
+    `,
+      `
       a >>> b;
-    `);
+    `
+    );
   });
 
   it('passes chained logical `or` through', () => {
-    check(`
+    check(
+      `
       a || b || c
-    `, `
+    `,
+      `
       a || b || c;
-    `);
+    `
+    );
   });
 
   it('handles binary existence operator with a global LHS as a statement', () => {
-    check(`
+    check(
+      `
       a ? b
-    `, `
+    `,
+      `
       if (typeof a === 'undefined' || a === null) { b; }
-    `);
+    `
+    );
   });
 
   it('handles binary existence operator with a global LHS as an expression', () => {
-    check(`
+    check(
+      `
       x = (a ? b)
-    `, `
+    `,
+      `
       const x = (typeof a !== 'undefined' && a !== null ? a : b);
-    `);
+    `
+    );
   });
 
   it('handles binary existence operator with a safe-to-repeat member expression as a statement', () => {
-    check(`
+    check(
+      `
       a.b ? a
-    `, `
+    `,
+      `
       if (a.b == null) { a; }
-    `);
+    `
+    );
   });
 
   it('handles binary existence operator with a `this` accesses', () => {
-    check(`
+    check(
+      `
       @a ? @b
-    `, `
+    `,
+      `
       if (this.a == null) { this.b; }
-    `);
+    `
+    );
   });
 
   it('handles binary existence operator with a `this` access on the right side', () => {
-    check(`
+    check(
+      `
       a ? @b
-    `, `
+    `,
+      `
       if (typeof a === 'undefined' || a === null) { this.b; }
-    `);
+    `
+    );
   });
 
   it('handles binary existence operator with a safe-to-repeat member expression as an expression', () => {
-    check(`
+    check(
+      `
       x = (a.b ? a)
-    `, `
+    `,
+      `
       const x = (a.b != null ? a.b : a);
-    `);
+    `
+    );
   });
 
   it('handles binary existence operator with a this-access on the left side', () => {
-    check(`
+    check(
+      `
       x = (@a.b ? c)
-    `, `
+    `,
+      `
       const x = (this.a.b != null ? this.a.b : c);
-    `);
+    `
+    );
   });
 
-
   it('handles binary existence operator with an unsafe-to-repeat member expression as a statement', () => {
-    check(`
+    check(
+      `
       a() ? b
-    `, `
+    `,
+      `
       if (a() == null) { b; }
-    `);
+    `
+    );
   });
 
   it('handles binary existence operator with an unsafe-to-repeat member expression as an expression', () => {
-    check(`
+    check(
+      `
       x = (a() ? b)
-    `, `
+    `,
+      `
       let left;
       const x = ((left = a()) != null ? left : b);
-    `);
+    `
+    );
   });
 
   it.skip('deals gracefully with extra parens in simple binary existential operators', () => {
@@ -166,82 +219,105 @@ describe('binary operators', () => {
   });
 
   it('prevents using temporary variables that clash with existing bindings', () => {
-    check(`
+    check(
+      `
         left = 1
         x = a() ? @b
-      `, `
+      `,
+      `
         let left1;
         const left = 1;
         const x = (left1 = a()) != null ? left1 : this.b;
-      `);
+      `
+    );
   });
 
   it('prevents using temporary variables that clash with existing temporary variables', () => {
-    check(`
+    check(
+      `
         x = a() ? @b
         y = c() ? @d
-      `, `
+      `,
+      `
         let left, left1;
         const x = (left = a()) != null ? left : this.b;
         const y = (left1 = c()) != null ? left1 : this.d;
-      `);
+      `
+    );
   });
 
   it('handles binary existence operator combined with plus', () => {
-    check(`
+    check(
+      `
       x = 1 + (y ? 0)
-    `, `
+    `,
+      `
       const x = 1 + (typeof y !== 'undefined' && y !== null ? y : 0);
-    `);
+    `
+    );
   });
 
   it('handles multiline binary existence operator with escaped newline', () => {
-    check(`
+    check(
+      `
       a ? \\
         b
-    `, `
+    `,
+      `
       if (typeof a === 'undefined' || a === null) { b; }
-    `);
+    `
+    );
   });
 
   it('handles left shift as a nested operator', () => {
-    check(`
+    check(
+      `
       value = object.id << 8 | object.type
-    `, `
+    `,
+      `
       const value = (object.id << 8) | object.type;
-    `);
+    `
+    );
   });
 
   it('handles modulo operator', () => {
-    check(`
+    check(
+      `
       a %% b
-    `, `
+    `,
+      `
       __mod__(a, b);
       function __mod__(a, b) {
         a = +a;
         b = +b;
         return (a % b + b) % b;
       }
-    `);
+    `
+    );
   });
 
   it('handles modulo operator applied multiple times', () => {
-    check(`
+    check(
+      `
       a(b() %% c(d) %% e + f)
-    `, `
+    `,
+      `
       a(__mod__(__mod__(b(), c(d)), e) + f);
       function __mod__(a, b) {
         a = +a;
         b = +b;
         return (a % b + b) % b;
       }
-    `);
+    `
+    );
   });
 
   it('handles `extends` operator', () => {
-    checkCS1(`
+    checkCS1(
+      `
       a extends b
-    `, `
+    `,
+      `
       __extends__(a, b);
       function __extends__(child, parent) {
         Object.getOwnPropertyNames(parent).forEach(
@@ -251,66 +327,87 @@ describe('binary operators', () => {
         child.__super__ = parent.prototype;
         return child;
       }
-    `);
+    `
+    );
   });
 
   it('adds parens around an assignment combined with a logical operator', () => {
-    check(`
+    check(
+      `
       a and b = c
-    `, `
+    `,
+      `
       let b;
       a && (b = c);
-    `);
+    `
+    );
   });
 
   it('adds parens around a compound existence assignment combined with a logical operator', () => {
-    check(`
+    check(
+      `
       b = 1
       a and b ?= c
-    `, `
+    `,
+      `
       let b = 1;
       a && (b != null ? b : (b = c));
-    `);
+    `
+    );
   });
 
   it('adds parens around a compound logical assignment combined with a logical operator', () => {
-    check(`
+    check(
+      `
       b = 1
       a and b or= c
-    `, `
+    `,
+      `
       let b = 1;
       a && (b || (b = c));
-    `);
+    `
+    );
   });
 
   it('removes the unnecessary `then` token after an assignment operator', () => {
-    check(`
+    check(
+      `
       a = then b
-    `, `
+    `,
+      `
       const a = b;
-    `);
+    `
+    );
   });
 
   it('removes the unnecessary `then` token after a compound assignment operator', () => {
-    check(`
+    check(
+      `
       a += then b
-    `, `
+    `,
+      `
       a += b;
-    `);
+    `
+    );
   });
 
   it('removes the unnecessary `then` token after an assignment with no space', () => {
-    check(`
+    check(
+      `
       a =then b
-    `, `
+    `,
+      `
       const a = b;
-    `);
+    `
+    );
   });
 
   it('handles a range literal on the RHS of a binary operator', () => {
-    check(`
+    check(
+      `
       a or [b...c]
-    `, `
+    `,
+      `
       a || __range__(b, c, false);
       function __range__(left, right, inclusive) {
         let range = [];
@@ -321,13 +418,16 @@ describe('binary operators', () => {
         }
         return range;
       }
-    `);
+    `
+    );
   });
 
   it('handles an "extends" usage on the RHS of a binary operator', () => {
-    checkCS1(`
+    checkCS1(
+      `
       a or (b extends c)
-    `, `
+    `,
+      `
       a || (__extends__(b, c));
       function __extends__(child, parent) {
         Object.getOwnPropertyNames(parent).forEach(
@@ -337,6 +437,7 @@ describe('binary operators', () => {
         child.__super__ = parent.prototype;
         return child;
       }
-    `);
+    `
+    );
   });
 });

--- a/test/chained_comparison_test.ts
+++ b/test/chained_comparison_test.ts
@@ -3,147 +3,196 @@ import validate from './support/validate';
 
 describe('chained comparison', () => {
   it('repeats the middle operand when it is safe', () => {
-    check(`
+    check(
+      `
       a < b < c
-    `, `
+    `,
+      `
       a < b && b < c;
-    `);
+    `
+    );
 
-    check(`
+    check(
+      `
       a > b > c
-    `, `
+    `,
+      `
       a > b && b > c;
-    `);
+    `
+    );
 
-    check(`
+    check(
+      `
       a <= b <= c
-    `, `
+    `,
+      `
       a <= b && b <= c;
-    `);
+    `
+    );
 
-    check(`
+    check(
+      `
       a >= b >= c
-    `, `
+    `,
+      `
       a >= b && b >= c;
-    `);
+    `
+    );
   });
 
   it('saves the middle operand when it is not safe to repeat', () => {
-    check(`
+    check(
+      `
       a < b() < c
-    `, `
+    `,
+      `
       let middle;
       a < (middle = b()) && middle < c;
-    `);
+    `
+    );
   });
 
   it('picks a temporary variable name that is safe to use', () => {
-    check(`
+    check(
+      `
       middle = 1
       a < b() < c
-    `, `
+    `,
+      `
       let middle1;
       const middle = 1;
       a < (middle1 = b()) && middle1 < c;
-    `);
+    `
+    );
   });
 
   it('handles an intermediate expression with nontrivial patching', () => {
-    check(`
+    check(
+      `
       a < (b ? c) < d
-    `, `
+    `,
+      `
       let middle;
       a < ((middle = typeof b !== 'undefined' && b !== null ? b : c)) && middle < d;
-    `);
+    `
+    );
   });
 
   it('is fine being used in an expression context', () => {
-    check(`
+    check(
+      `
       if a < b < c
         d
-    `, `
+    `,
+      `
       if (a < b && b < c) {
         d;
       }
-    `);
+    `
+    );
   });
 
   it('works with more than two chained operators', () => {
-    check(`
+    check(
+      `
       a < b < c < d
-    `, `
+    `,
+      `
       a < b && b < c && c < d;
-    `);
+    `
+    );
   });
 
   it('works with more than two chained operators with unsafe-to-repeat operands', () => {
-    check(`
+    check(
+      `
       a() < b() < c() < d()
-    `, `
+    `,
+      `
       let middle, middle1;
       a() < (middle = b()) && middle < (middle1 = c()) && middle1 < d();
-    `);
+    `
+    );
   });
 
   it('flips the inequalities when used in an `unless` with loose mode specified', () => {
-    check(`
+    check(
+      `
       unless a < b <= c
         d
-    `, `
+    `,
+      `
       if (a >= b || b > c) {
         d;
       }
-    `, {
-      options: {
-        looseComparisonNegation: true,
+    `,
+      {
+        options: {
+          looseComparisonNegation: true
+        }
       }
-    });
+    );
   });
 
   it('does not flip the inequalities when used in an `unless` by default', () => {
-    check(`
+    check(
+      `
       unless a < b <= c
         d
-    `, `
+    `,
+      `
       if (!(a < b && b <= c)) {
         d;
       }
-    `);
+    `
+    );
   });
 
   it('adds variable declarations to enclosing method', () => {
-    check(`
+    check(
+      `
       d: ->
         a < b() < c
-    `,`
+    `,
+      `
       ({
         d() {
           let middle;
           return a < (middle = b()) && middle < c;
         }
       });
-    `);
+    `
+    );
   });
 
   it('expands deeply nested chained operators', () => {
-    check(`
+    check(
+      `
       a is b isnt c is d isnt e
-    `, `
+    `,
+      `
       a === b && b !== c && c === d && d !== e;
-    `);
+    `
+    );
   });
 
   it('does not count parenthesis-wrapped binary operators as part of the chain', () => {
-    check(`
+    check(
+      `
       (a == b) == c == d == e
-    `, `
+    `,
+      `
       (a === b) === c && c === d && d === e;
-    `);
+    `
+    );
   });
 
   it('obeys operator precedence with chained comparison ops', () => {
-    validate(`
+    validate(
+      `
       setResult(1 | 2 < 3 < 4)
-    `, 1);
+    `,
+      1
+    );
   });
 });

--- a/test/class_test.ts
+++ b/test/class_test.ts
@@ -1,6 +1,6 @@
 import assertError from './support/assertError';
-import check, {checkCS1, checkCS2} from './support/check';
-import validate, {validateCS1} from './support/validate';
+import check, { checkCS1, checkCS2 } from './support/check';
+import validate, { validateCS1 } from './support/validate';
 
 describe('classes', () => {
   it('converts named classes without bodies', () => {
@@ -12,40 +12,48 @@ describe('classes', () => {
   });
 
   it('converts anonymous classes with bodies', () => {
-    check(`
+    check(
+      `
       Animal = class
         a: ->
           1
-    `, `
+    `,
+      `
       const Animal = class {
         a() {
           return 1;
         }
       };
-    `);
+    `
+    );
   });
 
   it('preserves class body functions as method definitions', () => {
-    check(`
+    check(
+      `
       class A
         a: ->
           1
-    `, `
+    `,
+      `
       class A {
         a() {
           return 1;
         }
       }
-    `);
+    `
+    );
     // FIXME: Ideally the semi-colon would be directly after the closing curly.
     // This is due to an edge case that esnext chose not to address in its
     // `functions.arrow` plugin.
-    check(`
+    check(
+      `
       ->
         class
           a: ->
             1
-    `, `
+    `,
+      `
       () =>
         class {
           a() {
@@ -53,72 +61,88 @@ describe('classes', () => {
           }
         }
       ;
-    `);
+    `
+    );
   });
 
   it('preserves class body generator functions as generator method definitions', () => {
-    check(`
+    check(
+      `
       class A
         'a a': ->
           yield 1
-    `, `
+    `,
+      `
       class A {
         *'a a'() {
           return yield 1;
         }
       }
-    `);
+    `
+    );
   });
 
   it('preserves anonymous subclasses', () => {
-    check(`
+    check(
+      `
       class extends Parent
         constructor: ->
-    `, `
+    `,
+      `
       (class extends Parent {
         constructor() {}
       });
-    `, {
-      options: {
-        disableBabelConstructorWorkaround: true,
+    `,
+      {
+        options: {
+          disableBabelConstructorWorkaround: true
+        }
       }
-    });
+    );
   });
 
   it('preserves class constructors without arguments', () => {
-    check(`
+    check(
+      `
       class A
         constructor: ->
           @a = 1
-    `, `
+    `,
+      `
       class A {
         constructor() {
           this.a = 1;
         }
       }
-    `);
+    `
+    );
   });
 
   it('preserves class constructors with arguments', () => {
-    check(`
+    check(
+      `
       class A
         constructor: (a) ->
           @a = a
-    `, `
+    `,
+      `
       class A {
         constructor(a) {
           this.a = a;
         }
       }
-    `);
+    `
+    );
   });
 
   describe('assign properties from method parameters', () => {
     it('constructor without function body', () => {
-      checkCS1(`
+      checkCS1(
+        `
         class A
           constructor: ([@a = 1], {test: @b = 2}, @c) ->
-      `, `
+      `,
+        `
         class A {
           constructor(...args) {
             let array, obj, val, val1;
@@ -131,11 +155,14 @@ describe('classes', () => {
               this.c = args[2];
           }
         }
-      `);
-      checkCS2(`
+      `
+      );
+      checkCS2(
+        `
         class A
           constructor: ([@a = 1], {test: @b = 2}, @c) ->
-      `, `
+      `,
+        `
         class A {
           constructor([a = 1], {test: b = 2}, c) {
             this.a = a;
@@ -143,40 +170,49 @@ describe('classes', () => {
             this.c = c;
           }
         }
-      `);
+      `
+      );
     });
 
     it('constructor with function body', () => {
-      check(`
+      check(
+        `
         class A
           constructor: (@a) ->
-      `, `
+      `,
+        `
         class A {
           constructor(a) {
             this.a = a;
           }
         }
-      `);
+      `
+      );
     });
 
     it('method', () => {
-      check(`
+      check(
+        `
         class A
           method: (@a) ->
-      `, `
+      `,
+        `
         class A {
           method(a) {
             this.a = a;
           }
         }
-      `);
+      `
+      );
     });
 
     it('bound method', () => {
-      check(`
+      check(
+        `
         class A
           method: (@a) =>
-      `, `
+      `,
+        `
         class A {
           constructor() {
             this.method = this.method.bind(this);
@@ -186,11 +222,13 @@ describe('classes', () => {
             this.a = a;
           }
         }
-      `);
+      `
+      );
     });
 
     it('errors when specified when using this before super in a constructor', () => {
-      assertError(`
+      assertError(
+        `
         class A extends B
           constructor: ->
             @a = 2
@@ -198,18 +236,21 @@ describe('classes', () => {
       `,
         'Cannot automatically convert a subclass with a constructor that uses `this` before `super`.',
         {
-          disallowInvalidConstructors: true,
-        });
+          disallowInvalidConstructors: true
+        }
+      );
     });
 
     it('does not error when using `this` in a function before `super` in a constructor', () => {
-      checkCS1(`
+      checkCS1(
+        `
         class A extends B
           constructor: ->
             f = -> @a = 2
             super
             f()
-      `, `
+      `,
+        `
         class A extends B {
           constructor() {
             const f = function() { return this.a = 2; };
@@ -217,35 +258,41 @@ describe('classes', () => {
             f();
           }
         }
-      `);
+      `
+      );
     });
 
     it('errors when specified when a subclass constructor omits super', () => {
-      assertError(`
+      assertError(
+        `
         class A extends B
           constructor: ->
             @a = 2
       `,
         'Cannot automatically convert a subclass with a constructor that does not call super.',
         {
-          disallowInvalidConstructors: true,
-        });
+          disallowInvalidConstructors: true
+        }
+      );
     });
 
     it('errors when specified when a subclass uses a bound method', () => {
-      assertError(`
+      assertError(
+        `
       class A extends B
         a: =>
           1
     `,
         'Cannot automatically convert a subclass that uses bound methods.',
         {
-          disallowInvalidConstructors: true,
-        });
+          disallowInvalidConstructors: true
+        }
+      );
     });
 
     it('errors when specified with an existing constructor and bound methods in a subclass', () => {
-      assertError(`
+      assertError(
+        `
       class A extends B
         a: =>
           1
@@ -256,54 +303,65 @@ describe('classes', () => {
     `,
         'Cannot automatically convert a subclass that uses bound methods.',
         {
-          disallowInvalidConstructors: true,
-        });
+          disallowInvalidConstructors: true
+        }
+      );
     });
 
     it('disables the babel workaround when using this before super in a constructor', () => {
-      checkCS1(`
+      checkCS1(
+        `
         class A extends B
           constructor: ->
             @a = 2
             super
-      `, `
+      `,
+        `
         class A extends B {
           constructor() {
             this.a = 2;
             super(...arguments);
           }
         }
-      `, {
-        options: {
-          disableBabelConstructorWorkaround: true,
+      `,
+        {
+          options: {
+            disableBabelConstructorWorkaround: true
+          }
         }
-      });
+      );
     });
 
     it('disables the babel workaround when a subclass constructor omits super', () => {
-      check(`
+      check(
+        `
         class A extends B
           constructor: ->
             @a = 2
-      `, `
+      `,
+        `
         class A extends B {
           constructor() {
             this.a = 2;
           }
         }
-      `, {
-        options: {
-          disableBabelConstructorWorkaround: true,
+      `,
+        {
+          options: {
+            disableBabelConstructorWorkaround: true
+          }
         }
-      });
+      );
     });
 
     it('creates a constructor for bound methods with a `super` call in extended classes when requested', () => {
-      check(`
+      check(
+        `
       class A extends B
         a: =>
           1
-    `, `
+    `,
+        `
       class A extends B {
         constructor(...args) {
           this.a = this.a.bind(this);
@@ -314,15 +372,18 @@ describe('classes', () => {
           return 1;
         }
       }
-    `, {
-        options: {
-          disableBabelConstructorWorkaround: true,
+    `,
+        {
+          options: {
+            disableBabelConstructorWorkaround: true
+          }
         }
-      });
+      );
     });
 
     it('adds to an existing constructor for bound methods before a `super` call when requested', () => {
-      check(`
+      check(
+        `
       class A extends B
         a: =>
           1
@@ -330,7 +391,8 @@ describe('classes', () => {
         constructor: ->
           super()
           this.b = 2;
-    `, `
+    `,
+        `
       class A extends B {
         a() {
           return 1;
@@ -342,20 +404,24 @@ describe('classes', () => {
           this.b = 2;
         }
       }
-    `, {
-        options: {
-          disableBabelConstructorWorkaround: true,
+    `,
+        {
+          options: {
+            disableBabelConstructorWorkaround: true
+          }
         }
-      });
+      );
     });
 
     it('generates workaround code when using this before super in a constructor', () => {
-      checkCS1(`
+      checkCS1(
+        `
         class A extends B
           constructor: ->
             @a = 2
             super
-      `, `
+      `,
+        `
         class A extends B {
           constructor() {
             {
@@ -369,15 +435,18 @@ describe('classes', () => {
             super(...arguments);
           }
         }
-      `);
+      `
+      );
     });
 
     it('generates workaround code when a subclass constructor omits super', () => {
-      check(`
+      check(
+        `
         class A extends B
           constructor: ->
             @a = 2
-      `, `
+      `,
+        `
         class A extends B {
           constructor() {
             {
@@ -390,15 +459,18 @@ describe('classes', () => {
             this.a = 2;
           }
         }
-      `);
+      `
+      );
     });
 
     it('generates workaround code when a subclass has a bound method and no constructor', () => {
-      check(`
+      check(
+        `
         class A extends B
           foo: =>
             null
-      `, `
+      `,
+        `
         class A extends B {
           constructor(...args) {
             {
@@ -416,11 +488,13 @@ describe('classes', () => {
             return null;
           }
         }
-      `);
+      `
+      );
     });
 
     it('generates workaround code when a subclass has a bound method and a normal constructor', () => {
-      checkCS1(`
+      checkCS1(
+        `
         class A extends B
           constructor: ->
             super
@@ -428,7 +502,8 @@ describe('classes', () => {
         
           foo: =>
             null
-      `, `
+      `,
+        `
         class A extends B {
           constructor() {
             {
@@ -447,17 +522,20 @@ describe('classes', () => {
             return null;
           }
         }
-      `);
+      `
+      );
     });
 
     it('generates workaround code when a subclass has a bound method and an empty constructor', () => {
-      check(`
+      check(
+        `
         class A extends B
           constructor: ->
         
           foo: =>
             null
-      `, `
+      `,
+        `
         class A extends B {
           constructor() {
             {
@@ -474,32 +552,38 @@ describe('classes', () => {
             return null;
           }
         }
-      `);
+      `
+      );
     });
 
     it('does not generate workaround code when the workaround is unnecessary', () => {
-      checkCS1(`
+      checkCS1(
+        `
         class A extends B
           constructor: ->
             super
             @x = 3
-      `, `
+      `,
+        `
         class A extends B {
           constructor() {
             super(...arguments);
             this.x = 3;
           }
         }
-      `);
+      `
+      );
     });
 
     it('properly generates workaround code when constructors have default parameters', () => {
-      checkCS1(`
+      checkCS1(
+        `
         class A extends B
           constructor: (c={}) ->
             @d = e
             super
-      `, `
+      `,
+        `
         class A extends B {
           constructor(c) {
             {
@@ -514,152 +598,191 @@ describe('classes', () => {
             super(...arguments);
           }
         }
-      `);
+      `
+      );
     });
 
     it('chooses variables that do not conflict', () => {
-      check(`
+      check(
+        `
         (@a) ->
           a = 1
-      `, `
+      `,
+        `
         (function(a1) {
           let a;
           this.a = a1;
           return a = 1;
         });
-      `);
+      `
+      );
     });
 
     it('prepends assignments in single-line methods', () => {
-      check(`
+      check(
+        `
         class A
           member: (@a) -> console.log(@a)
-      `, `
+      `,
+        `
         class A {
           member(a) { this.a = a; return console.log(this.a); }
         }
-      `);
+      `
+      );
     });
 
     it('handles property assignment parameter with default', () => {
-      check(`
+      check(
+        `
         (@a = 1) ->
-      `, `
+      `,
+        `
         (function(a) {
           if (a == null) { a = 1; }
           this.a = a;
         });
-      `);
+      `
+      );
     });
 
     it('handles destructured property assignment parameters', () => {
-      check(`
+      check(
+        `
         ({@a}) ->
-      `, `
+      `,
+        `
         (function({a}) {
           this.a = a;
         });
-      `);
+      `
+      );
     });
 
     it('handles named destructured property assignment parameters', () => {
-      check(`
+      check(
+        `
         ({a: @b}) ->
-      `, `
+      `,
+        `
         (function({a: b}) {
           this.b = b;
         });
-      `);
+      `
+      );
     });
 
     it('uses correct value for default param when using another member', () => {
-      check(`
+      check(
+        `
         (@a, b = @c) ->
-      `, `
+      `,
+        `
         (function(a, b) {
           this.a = a;
           if (b == null) { b = this.c; }
         });
-      `);
+      `
+      );
     });
 
     it('uses correct value for default param with loose params when using another member', () => {
-      check(`
+      check(
+        `
         (@a, b = @c) ->
-      `, `
+      `,
+        `
         (function(a, b = this.c) {
           this.a = a;
         });
-      `, {
-        options: {
-          looseDefaultParams: true
+      `,
+        {
+          options: {
+            looseDefaultParams: true
+          }
         }
-      });
+      );
     });
 
     it('uses correct value for default param when reusing an already implicitly assigned param', () => {
-      check(`
+      check(
+        `
         (@a, b = @a) ->
-      `, `
+      `,
+        `
         (function(a, b) {
           this.a = a;
           if (b == null) { b = this.a; }
         });
-      `);
+      `
+      );
     });
   });
 
   it('preserves class constructors extending superclasses', () => {
-    check(`
+    check(
+      `
       class A extends B
         constructor: ->
-    `, `
+    `,
+      `
       class A extends B {
         constructor() {}
       }
-    `, {
-      options: {
-        disableBabelConstructorWorkaround: true,
+    `,
+      {
+        options: {
+          disableBabelConstructorWorkaround: true
+        }
       }
-    });
+    );
   });
 
   it('preserves class constructors extending non-identifier superclasses', () => {
-    check(`
+    check(
+      `
       class A extends (class B extends C)
         constructor: ->
-    `, `
+    `,
+      `
       let B;
       class A extends (B = class B extends C {}) {
         constructor() {}
       }
-    `, {
-      options: {
-        disableBabelConstructorWorkaround: true,
+    `,
+      {
+        options: {
+          disableBabelConstructorWorkaround: true
+        }
       }
-    });
+    );
   });
 
   it('turns non-method properties into prototype assignments', () => {
-    check(`
+    check(
+      `
       class A
         b: 1
-    `, `
+    `,
+      `
       class A {
         static initClass() {
           this.prototype.b = 1;
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('creates a constructor for bound methods', () => {
-    check(`
+    check(
+      `
       class A
         a: =>
           1
-    `, `
+    `,
+      `
       class A {
         constructor() {
           this.a = this.a.bind(this);
@@ -669,28 +792,34 @@ describe('classes', () => {
           return 1;
         }
       }
-    `);
+    `
+    );
   });
 
   it('handles class properties', () => {
-    check(`
+    check(
+      `
       class A
         setup: _.once () ->
-    `, `
+    `,
+      `
       class A {
         static initClass() {
           this.prototype.setup = _.once(function() {});
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('handles bound methods with parameters', () => {
-    check(`
+    check(
+      `
       class a
         b: (c) =>
-    `, `
+    `,
+      `
       class a {
         constructor() {
           this.b = this.b.bind(this);
@@ -698,18 +827,21 @@ describe('classes', () => {
 
         b(c) {}
       }
-    `);
+    `
+    );
   });
 
   it('adds to an existing constructor for bound methods', () => {
-    check(`
+    check(
+      `
       class A
         a: =>
           1
 
         constructor: ->
           2
-    `, `
+    `,
+      `
       class A {
         a() {
           return 1;
@@ -720,122 +852,149 @@ describe('classes', () => {
           2;
         }
       }
-    `);
+    `
+    );
   });
 
   it('converts `super` inside non-constructor methods to a named lookup', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class A extends B
         a: ->
           super
-    `, `
+    `,
+      `
       class A extends B {
         a() {
           return super.a(...arguments);
         }
       }
-    `);
+    `
+    );
   });
 
   it('converts `super` with args inside non-constructor methods to a named lookup', () => {
-    check(`
+    check(
+      `
       class A extends B
         a: ->
           super 1, 2
-    `, `
+    `,
+      `
       class A extends B {
         a() {
           return super.a(1, 2);
         }
       }
-    `);
+    `
+    );
   });
 
   it('converts `super` inside static methods to a named lookup', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class A extends B
         @a: ->
           super
-    `, `
+    `,
+      `
       class A extends B {
         static a() {
           return super.a(...arguments);
         }
       }
-    `);
+    `
+    );
   });
 
   it('converts shorthand-this static methods correctly', () => {
-    check(`
+    check(
+      `
       class A
         @a: ->
           1
-    `, `
+    `,
+      `
       class A {
         static a() {
           return 1;
         }
       }
-    `);
+    `
+    );
   });
 
   it('converts longhand-this static methods correctly', () => {
-    check(`
+    check(
+      `
       class A
         this.a = ->
           1
-    `, `
+    `,
+      `
       class A {
         static a() {
           return 1;
         }
       }
-    `);
+    `
+    );
   });
 
   it('converts longhand static methods correctly', () => {
-    check(`
+    check(
+      `
       class A
         A.a = ->
           1
-    `, `
+    `,
+      `
       class A {
         static a() {
           return 1;
         }
       }
-    `);
+    `
+    );
   });
 
   it('converts member expression class names correctly', () => {
-    check(`
+    check(
+      `
       class A.B
         a: -> 1
-    `, `
+    `,
+      `
       A.B = class B {
         a() { return 1; }
       };
-    `);
+    `
+    );
   });
 
   it('converts dynamic member expression class names correctly', () => {
-    check(`
+    check(
+      `
       class A[B]
         a: -> 1
-    `, `
+    `,
+      `
       A[B] = class {
         a() { return 1; }
       };
-    `);
+    `
+    );
   });
 
   it('converts instance properties with multi-line object values correctly', () => {
-    check(`
+    check(
+      `
       class A
         a:
           b: c
           d: e
-    `, `
+    `,
+      `
       class A {
         static initClass() {
           this.prototype.a = {
@@ -845,11 +1004,13 @@ describe('classes', () => {
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('handles code in class bodies', () => {
-    check(`
+    check(
+      `
       class A
         doThing()
         a: ->
@@ -857,7 +1018,8 @@ describe('classes', () => {
         doOtherThing()
         b: ->
           7
-    `, `
+    `,
+      `
       class A {
         static initClass() {
           doThing();
@@ -871,16 +1033,19 @@ describe('classes', () => {
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('handles variables used within the class', () => {
-    check(`
+    check(
+      `
       class A
         x = 3
         a: ->
           x + 1
-    `, `
+    `,
+      `
       var A = (function() {
         let x = undefined;
         A = class A {
@@ -894,39 +1059,47 @@ describe('classes', () => {
         A.initClass();
         return A;
       })();
-    `);
+    `
+    );
   });
 
   it('handles class body code when the class has a superclass', () => {
-    check(`
+    check(
+      `
       class A extends B
         x: 3
-    `, `
+    `,
+      `
       class A extends B {
         static initClass() {
           this.prototype.x = 3;
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('handles assigning values to the constructor', () => {
-    check(`
+    check(
+      `
       class A
         @x: 3
-    `, `
+    `,
+      `
       class A {
         static initClass() {
           this.x = 3;
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('handles nested classes', () => {
-    check(`
+    check(
+      `
       class A
         class B
           classField: 2
@@ -940,7 +1113,8 @@ describe('classes', () => {
           new B()
         makeC: ->
           new C()
-    `, `
+    `,
+      `
       var A = (function() {
         let B = undefined;
         let C = undefined;
@@ -979,16 +1153,19 @@ describe('classes', () => {
         A.initClass();
         return A;
       })();
-    `);
+    `
+    );
   });
 
   it('handles an equals-style constructor assignment with a colon in the body', () => {
-    check(`
+    check(
+      `
       class A
         @values =
           'A': 1
           'B': 2
-    `, `
+    `,
+      `
       class A {
         static initClass() {
           this.values = {
@@ -998,17 +1175,20 @@ describe('classes', () => {
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('handles a bound method and an implicit super in the constructor', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class X extends Y
         constructor: ->
           super
       
         add: =>
-    `, `
+    `,
+      `
       class X extends Y {
         constructor() {
           this.add = this.add.bind(this);
@@ -1017,20 +1197,24 @@ describe('classes', () => {
       
         add() {}
       }
-    `, {
-      options: {
-        disableBabelConstructorWorkaround: true,
+    `,
+      {
+        options: {
+          disableBabelConstructorWorkaround: true
+        }
       }
-    });
+    );
   });
 
   it('handles a bound method and an empty constructor', () => {
-    check(`
+    check(
+      `
       class X
         constructor: ->
       
         add: =>
-    `, `
+    `,
+      `
       class X {
         constructor() {
           this.add = this.add.bind(this);
@@ -1038,16 +1222,19 @@ describe('classes', () => {
       
         add() {}
       }
-    `);
+    `
+    );
   });
 
   it('handles a bound method and an empty constructor with a parameter', () => {
-    check(`
+    check(
+      `
       class X
         constructor: (a, b) ->
       
         add: =>
-    `, `
+    `,
+      `
       class X {
         constructor(a, b) {
           this.add = this.add.bind(this);
@@ -1055,11 +1242,13 @@ describe('classes', () => {
       
         add() {}
       }
-    `);
+    `
+    );
   });
 
   it('places method bindings at the start of the constructor even if there is a super call', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class X extends Y
         constructor: ->
           if a
@@ -1069,7 +1258,8 @@ describe('classes', () => {
             d
       
         add: =>
-    `, `
+    `,
+      `
       class X extends Y {
         constructor() {
           this.add = this.add.bind(this);
@@ -1084,34 +1274,41 @@ describe('classes', () => {
       
         add() {}
       }
-    `, {
-      options: {
-        disableBabelConstructorWorkaround: true,
+    `,
+      {
+        options: {
+          disableBabelConstructorWorkaround: true
+        }
       }
-    });
+    );
   });
 
   it('places method bindings at the start of the constructor if there is no super', () => {
-    check(`
+    check(
+      `
       class X
         constructor: ->a
       
         add: =>
-    `, `
+    `,
+      `
       class X {
         constructor() { this.add = this.add.bind(this);   a; }
       
         add() {}
       }
-    `);
+    `
+    );
   });
 
   it('handles a default constructor parameter and a bound method', () => {
-    check(`
+    check(
+      `
       class Nukes
         constructor: (y = 'foo') ->
         launch: (x) => true
-    `, `
+    `,
+      `
       class Nukes {
         constructor(y) {
           this.launch = this.launch.bind(this);
@@ -1119,37 +1316,46 @@ describe('classes', () => {
         }
         launch(x) { return true; }
       }
-    `);
+    `
+    );
   });
 
   it('handles a single-line class', () => {
-    check(`
+    check(
+      `
       class A then b: -> c
-    `, `
+    `,
+      `
       class A {
         b() { return c; }
       }
-    `);
+    `
+    );
   });
 
   it('handles a single-line class that needs an initClass method', () => {
-    check(`
+    check(
+      `
       class A then b: c
-    `, `
+    `,
+      `
       class A {
         static initClass() {
           this.prototype.b = c;
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('handles a single-line class with an external constructor', () => {
-    check(`
+    check(
+      `
       f = ->
       class A then constructor: f
-    `, `
+    `,
+      `
       const f = function() {};
       let createA = undefined;
       class A {
@@ -1161,17 +1367,20 @@ describe('classes', () => {
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('allows super calls within nested functions', () => {
-    check(`
+    check(
+      `
       class B extends A
         foo : (cb) ->
           dolater =>
             dolater =>
               super cb
-    `, `
+    `,
+      `
       class B extends A {
         foo(cb) {
           return dolater(() => {
@@ -1181,18 +1390,21 @@ describe('classes', () => {
           });
         }
       }
-    `);
+    `
+    );
   });
 
   it('handles a super call on a method assigned directly to the prototype', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class A
         c: -> console.log 'Hello'
       class B extends A
       B::c = -> super
       b = new B()
       b.c()
-    `, `
+    `,
+      `
       let cls;
       class A {
         c() { return console.log('Hello'); }
@@ -1201,22 +1413,27 @@ describe('classes', () => {
       (cls = B).prototype.c = function() { return cls.prototype.__proto__.c.call(this, ...arguments); };
       const b = new B();
       b.c();
-    `);
+    `
+    );
   });
 
   it('has correct behavior with a standalone prototype super call', () => {
-    validateCS1(`
+    validateCS1(
+      `
       class A
         c: -> 3
       class B extends A
       B::c = -> super + 1
       b = new B()
       setResult(b.c())
-    `, 4);
+    `,
+      4
+    );
   });
 
   it('forwards function arguments on empty super, even if the arguments are for an inner function', () => {
-    validateCS1(`
+    validateCS1(
+      `
       class A
         c: (x) -> x + 5
       class B extends A
@@ -1226,14 +1443,18 @@ describe('classes', () => {
           f(x + 3)
       b = new B()
       setResult(b.c(1))
-    `, 9);
+    `,
+      9
+    );
   });
 
   it('handles a complex anonymous class in an expression context', () => {
-    check(`
+    check(
+      `
       A = class
         b: c
-    `, `
+    `,
+      `
       const A = (function() {
         const Cls = class {
           static initClass() {
@@ -1243,15 +1464,18 @@ describe('classes', () => {
         Cls.initClass();
         return Cls;
       })();
-    `);
+    `
+    );
   });
 
   it('handles a complex anonymous class with a variable in an expression context', () => {
-    check(`
+    check(
+      `
       A = class
         b: c
         d = e
-    `, `
+    `,
+      `
       const A = (function() {
         let d = undefined;
         const Cls = class {
@@ -1263,23 +1487,29 @@ describe('classes', () => {
         Cls.initClass();
         return Cls;
       })();
-    `);
+    `
+    );
   });
 
   it('generates an assignment for a named class in an expression context', () => {
-    check(`
+    check(
+      `
       A = class B
-    `, `
+    `,
+      `
       let B;
       const A = (B = class B {});
-    `);
+    `
+    );
   });
 
   it('generates an assignment for a complex named class in an expression context', () => {
-    check(`
+    check(
+      `
       A = class B
         c: d
-    `, `
+    `,
+      `
       let B;
       const A = (B = (function() {
         B = class B {
@@ -1290,22 +1520,28 @@ describe('classes', () => {
         B.initClass();
         return B;
       })());
-    `);
+    `
+    );
   });
 
   it('has the proper runtime behavior for a named class in an expression context', () => {
-    validate(`
+    validate(
+      `
       A = class B
       setResult(B.name)
-    `, 'B');
+    `,
+      'B'
+    );
   });
 
   it('handles a class expression in an implicit return context', () => {
-    check(`
+    check(
+      `
       f = ->
         class A
           b: c
-    `, `
+    `,
+      `
       const f = function() {
         let A;
         return A = (function() {
@@ -1318,17 +1554,20 @@ describe('classes', () => {
           return A;
         })();
       };
-    `);
+    `
+    );
   });
 
   it('handles a define call ending in a class (#625)', () => {
-    check(`
+    check(
+      `
       define (require) ->
         'use strict'
         
         class MainLayout extends BaseView
           container: 'body'
-    `, `
+    `,
+      `
       define(function(require) {
         'use strict';
         
@@ -1343,40 +1582,49 @@ describe('classes', () => {
           return MainLayout;
         })();
       });
-    `);
+    `
+    );
   });
 
   it('handles an inner class with a this-assignment', () => {
-    check(`
+    check(
+      `
       class Outer
         class @Inner
-    `, `
+    `,
+      `
       class Outer {
         static initClass() {
           this.Inner = class Inner {};
         }
       }
       Outer.initClass();
-    `);
+    `
+    );
   });
 
   it('handles a class this-assigned to a keyword name', () => {
-    check(`
+    check(
+      `
       ->
         class @for
-    `, `
+    `,
+      `
       (function() {
         return (this.for = class _for {});
       });
-    `);
+    `
+    );
   });
 
   it('allows an external constructor for a simple class', () => {
-    check(`
+    check(
+      `
       f = -> @x = 3
       class A
         constructor: f
-    `, `
+    `,
+      `
       const f = function() { return this.x = 3; };
       let createA = undefined;
       class A {
@@ -1388,16 +1636,19 @@ describe('classes', () => {
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('allows external constructors with bound methods', () => {
-    check(`
+    check(
+      `
       fn = ->
       class A
         constructor: fn
         method: =>
-    `, `
+    `,
+      `
       const fn = function() {};
       let createA = undefined;
       class A {
@@ -1411,77 +1662,101 @@ describe('classes', () => {
         method() {}
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('allows simple computed keys for class methods', () => {
-    check(`
+    check(
+      `
       class A
         "#{f()}": -> 'Hello'
-    `, `
+    `,
+      `
       class A {
         [f()]() { return 'Hello'; }
       }
-    `);
+    `
+    );
   });
 
   it('allows string interpolation keys for class methods', () => {
-    check(`
+    check(
+      `
       class A
         "#{f()}, World": -> 'Hello'
-    `, `
+    `,
+      `
       class A {
         [\`\${f()}, World\`]() { return 'Hello'; }
       }
-    `);
+    `
+    );
   });
 
   it('allows two class declarations with the same name', () => {
-    check(`
+    check(
+      `
       class A
       class A
-    `, `
+    `,
+      `
       class A {}
       A = class A {};
-    `);
+    `
+    );
   });
 
   it('assigns the right name to a normal class constructor', () => {
-    validate(`
+    validate(
+      `
       class A
       setResult(A.name)
-    `, 'A');
+    `,
+      'A'
+    );
   });
 
   it('assigns the right name to a class constructor for a property access', () => {
-    validate(`
+    validate(
+      `
       A = {}
       class A.B
       setResult(A.B.name)
-    `, 'B');
+    `,
+      'B'
+    );
   });
 
   it('assigns the right name to a class constructor for a keyword', () => {
-    validate(`
+    validate(
+      `
       A = {}
       class A.for
       setResult(A.for.name)
-    `, '_for');
+    `,
+      '_for'
+    );
   });
 
   it('does not modify the constructor name for a CoffeeScript keyword', () => {
-    validate(`
+    validate(
+      `
       A = {}
       class A.or
       setResult(A.or.name)
-    `, 'or');
+    `,
+      'or'
+    );
   });
 
   it('allows bound methods with non-identifier names that can be simplified', () => {
-    check(`
+    check(
+      `
       class A
         "#{b}": => c
-    `, `
+    `,
+      `
       class A {
         constructor() {
           this[b] = this[b].bind(this);
@@ -1489,14 +1764,17 @@ describe('classes', () => {
       
         [b]() { return c; }
       }
-    `);
+    `
+    );
   });
 
   it('allows bound methods with complex non-identifier names', () => {
-    check(`
+    check(
+      `
       class A
         "#{b}foo": => c
-    `, `
+    `,
+      `
       class A {
         constructor() {
           this[\`\${b}foo\`] = this[\`\${b}foo\`].bind(this);
@@ -1504,17 +1782,20 @@ describe('classes', () => {
       
         [\`\${b}foo\`]() { return c; }
       }
-    `);
+    `
+    );
   });
 
   it('allows bound methods with non-identifier names that can be simplified with an existing constructor', () => {
-    check(`
+    check(
+      `
       class A
         constructor: ->
           console.log 'got here'
       
         "#{b}": => c
-    `, `
+    `,
+      `
       class A {
         constructor() {
           this[b] = this[b].bind(this);
@@ -1523,17 +1804,20 @@ describe('classes', () => {
       
         [b]() { return c; }
       }
-    `);
+    `
+    );
   });
 
   it('allows bound methods with complex non-identifier names with an existing constructor', () => {
-    check(`
+    check(
+      `
       class A
         constructor: ->
           console.log 'got here'
       
         "#{b}foo": => c
-    `, `
+    `,
+      `
       class A {
         constructor() {
           this[\`\${b}foo\`] = this[\`\${b}foo\`].bind(this);
@@ -1542,15 +1826,18 @@ describe('classes', () => {
       
         [\`\${b}foo\`]() { return c; }
       }
-    `);
+    `
+    );
   });
 
   it('allows patching within an external constructor expression', () => {
-    check(`
+    check(
+      `
       makeCtor = ->
       class B
         constructor: makeCtor 1
-    `, `
+    `,
+      `
       const makeCtor = function() {};
       let createB = undefined;
       class B {
@@ -1562,32 +1849,38 @@ describe('classes', () => {
         }
       }
       B.initClass();
-    `);
+    `
+    );
   });
 
   it('handles a complex anonymous class in a statement context', () => {
-    check(`
+    check(
+      `
       class
         x: 1
-    `, `
+    `,
+      `
       const Cls = class {
         static initClass() {
           this.prototype.x = 1;
         }
       };
       Cls.initClass();
-    `);
+    `
+    );
   });
 
   it('handles inconsistent indentation in an expression-style complex class', () => {
-    check(`
+    check(
+      `
       x = class A
         constructor: ->
           b
          c: ->
            d
         e: f
-    `, `
+    `,
+      `
       let A;
       const x = (A = (function() {
         A = class A {
@@ -1604,13 +1897,16 @@ describe('classes', () => {
         A.initClass();
         return A;
       })());
-    `);
+    `
+    );
   });
 
   it('handles an inline class with comma-separated fields (#544)', () => {
-    check(`
+    check(
+      `
       rethinkdb.monday = new (class extends RDBConstant then tt: protoTermType.MONDAY, st: 'monday')()
-    `, `
+    `,
+      `
       rethinkdb.monday = new ((function() {
         const Cls = (class extends RDBConstant {
           static initClass() {
@@ -1621,39 +1917,48 @@ describe('classes', () => {
         Cls.initClass();
         return Cls();
       })());
-    `);
+    `
+    );
   });
 
   it('handles new directly called on a class', () => {
-    check(`
+    check(
+      `
       new class A
-    `, `
+    `,
+      `
       let A;
       new (A = class A {});
-    `);
+    `
+    );
   });
 
   it('handles an expression-style class ending in a comment', () => {
-    check(`
+    check(
+      `
       x = class A
         b: ->
           c # d
-    `, `
+    `,
+      `
       let A;
       const x = (A = class A {
         b() {
           return c; // d
         }
       });
-    `);
+    `
+    );
   });
 
   it('properly handles bound static methods', () => {
-    check(`
+    check(
+      `
       class A
         @b = =>
           @c
-    `, `
+    `,
+      `
       class A {
         static initClass() {
           this.b = () => {
@@ -1662,11 +1967,13 @@ describe('classes', () => {
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('has the right behavior with bound static methods', () => {
-    validate(`
+    validate(
+      `
       class A
         @b = =>
           @c
@@ -1674,17 +1981,21 @@ describe('classes', () => {
       
       b = A.b
       setResult(b())
-    `, 5);
+    `,
+      5
+    );
   });
 
   it('handles conditional prototype assignments', () => {
-    check(`
+    check(
+      `
       class A
         if b
           c: d
         else
           e: f
-    `, `
+    `,
+      `
       class A {
         static initClass() {
           if (b) {
@@ -1695,17 +2006,20 @@ describe('classes', () => {
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('handles conditional methods', () => {
-    check(`
+    check(
+      `
       class A
         if b
           c: -> d
         else
           e: -> f
-    `, `
+    `,
+      `
       class A {
         static initClass() {
           if (b) {
@@ -1716,20 +2030,25 @@ describe('classes', () => {
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('saves the method name for dynamic prototype method assignments', () => {
-    checkCS1(`
+    checkCS1(
+      `
       A::[m] = -> super
-    `, `
+    `,
+      `
       let cls, method;
       (cls = A).prototype[method = m] = function() { return cls.prototype.__proto__[method].call(this, ...arguments); };
-    `);
+    `
+    );
   });
 
   it('behaves correctly for dynamic prototype method assignments', () => {
-    validateCS1(`
+    validateCS1(
+      `
       class Base
         f: -> 1
         g: -> 2
@@ -1738,14 +2057,18 @@ describe('classes', () => {
       A::[m] = -> super
       m = 'g'
       setResult((new A).f())
-    `, 1);
+    `,
+      1
+    );
   });
 
   it('generates proper class accesses in super used in initClass', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class A extends B
         @::f = -> super
-    `, `
+    `,
+      `
       class A extends B {
         static initClass() {
           let cls;
@@ -1753,26 +2076,32 @@ describe('classes', () => {
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('properly saves the method name for computed methods using super', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class A extends B
         "#{m}": -> super
-    `, `
+    `,
+      `
       let method;
       class A extends B {
         [method = m]() { return super[method](...arguments); }
       }
-    `);
+    `
+    );
   });
 
   it('handles dynamically-added methods using super on other classes added within class bodies', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class A
         @b::m = -> super
-    `, `
+    `,
+      `
       class A {
         static initClass() {
           let cls;
@@ -1780,38 +2109,47 @@ describe('classes', () => {
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('converts dynamically-named static methods properly', () => {
-    check(`
+    check(
+      `
       class A
         @[b] = -> 'hello'
-    `, `
+    `,
+      `
       class A {
         static [b]() { return 'hello'; }
       }
-    `);
+    `
+    );
   });
 
   it('properly handles dynamic keys with static methods using super', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class A extends B
         @[c] = -> super
-    `, `
+    `,
+      `
       let method;
       class A extends B {
         static [method = c]() { return super[method](...arguments); }
       }
-    `);
+    `
+    );
   });
 
   it('properly handles static methods calling super from within initClass', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class A extends B
         if a
           @b = -> super
-    `, `
+    `,
+      `
       class A extends B {
         static initClass() {
           if (a) {
@@ -1821,15 +2159,18 @@ describe('classes', () => {
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('properly handles non-shorthand super in dynamically generated static methods', () => {
-    check(`
+    check(
+      `
       class A extends B
         if a
           @b = -> super(foo)
-    `, `
+    `,
+      `
       class A extends B {
         static initClass() {
           if (a) {
@@ -1839,15 +2180,18 @@ describe('classes', () => {
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('properly handles static methods with dynamic names calling super from within initClass', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class A extends B
         if a
           @[b] = -> super
-    `, `
+    `,
+      `
       class A extends B {
         static initClass() {
           if (a) {
@@ -1857,22 +2201,27 @@ describe('classes', () => {
         }
       }
       A.initClass();
-    `);
+    `
+    );
   });
 
   it('behaves properly with conditionally assigned static methods with super', () => {
-    validateCS1(`
+    validateCS1(
+      `
       class A
         @a = -> 3
       class B extends A
         if true
           @a = -> super
       setResult(B.a())
-    `, 3);
+    `,
+      3
+    );
   });
 
   it('behaves properly with conditionally assigned static methods with a dynamic name with super', () => {
-    validateCS1(`
+    validateCS1(
+      `
       class A
         @a = -> 3
       m = 'a'
@@ -1880,17 +2229,21 @@ describe('classes', () => {
         if true
           @[m] = -> super
       setResult(B.a())
-    `, 3);
+    `,
+      3
+    );
   });
 
   it('handles complex class expressions with trailing whitespace', () => {
-    check(`
+    check(
+      `
       A = class B
         c: d
         e: ->
           f 
       
-    `, `
+    `,
+      `
       let B;
       const A = (B = (function() {
         B = class B {
@@ -1905,41 +2258,51 @@ describe('classes', () => {
         return B; 
       })());
       
-    `, {shouldStripIndent: false});
+    `,
+      { shouldStripIndent: false }
+    );
   });
 
   it('handles static generator methods', () => {
-    check(`
+    check(
+      `
       class A
         @b: ->
           yield 1
-    `, `
+    `,
+      `
       class A {
         static *b() {
           return yield 1;
         }
       }
-    `);
+    `
+    );
   });
 
   it('handles static async methods', () => {
-    checkCS2(`
+    checkCS2(
+      `
       class A
         @b: ->
           await 1
-    `, `
+    `,
+      `
       class A {
         static async b() {
           return await 1;
         }
       }
-    `);
+    `
+    );
   });
 
   it('handles anonymous classes with inline bodies', () => {
-    check(`
+    check(
+      `
       class then a = 1
-    `, `
+    `,
+      `
       (function() {
         let a = undefined;
         const Cls = class {
@@ -1950,11 +2313,13 @@ describe('classes', () => {
         Cls.initClass();
         return Cls;
       })();
-    `);
+    `
+    );
   });
 
   it('it produces a Babel/TS constructor hack that allows this before super in a constructor and produces correct values', () => {
-    validateCS1(`
+    validateCS1(
+      `
     class A
       constructor: ->
         @value ?= 1
@@ -1966,6 +2331,9 @@ describe('classes', () => {
         super
     b = new B()
     setResult(b.value)
-  `, 4, {options: {}, skipNodeCheck: true});
+  `,
+      4,
+      { options: {}, skipNodeCheck: true }
+    );
   });
 });

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -14,7 +14,7 @@ function runCli(argStr: string, stdin: string, expectedStdout: string): void {
   }
 
   let stdout = execSync('./bin/decaffeinate ' + argStr, {
-    input: stdin,
+    input: stdin
   }).toString();
   equal(stdout.trim(), expectedStdout.trim());
 }
@@ -28,7 +28,7 @@ function runCliExpectError(argStr: string, stdin: string, expectedStderr: string
   }
 
   try {
-    execSync('./bin/decaffeinate ' + argStr, {input: stdin,});
+    execSync('./bin/decaffeinate ' + argStr, { input: stdin });
     ok(false, 'Expected the CLI to fail.');
   } catch (e) {
     equal(e.output[2].toString().trim(), expectedStderr.trim());
@@ -42,145 +42,200 @@ describe('decaffeinate CLI', () => {
   });
 
   it('accepts a file on stdin', () => {
-    runCli('', `
+    runCli(
+      '',
+      `
       a = require 'a'
       x = 1
       exports.b = 2
-    `, `
+    `,
+      `
       const a = require('a');
       const x = 1;
       exports.b = 2;
-    `);
+    `
+    );
   });
 
   it('respects the --use-cs2 flag', () => {
-    runCli('--use-cs2', `
+    runCli(
+      '--use-cs2',
+      `
       a = [...b, c]
-    `, `
+    `,
+      `
       const a = [...b, c];
-    `);
+    `
+    );
   });
 
   it('respects the --literate flag', () => {
-    runCli('--literate', `
+    runCli(
+      '--literate',
+      `
       This is a literate file.
       
           literate = true
-    `, `
+    `,
+      `
       // This is a literate file.
       const literate = true;
-    `);
+    `
+    );
   });
 
   it('keeps imports as commonjs by default', () => {
-    runCli('', `
+    runCli(
+      '',
+      `
       a = require 'a'
-    `, `
+    `,
+      `
       const a = require('a');
-    `);
+    `
+    );
   });
 
   it('treats the --keep-commonjs option as a no-op', () => {
-    runCli('--keep-commonjs', `
+    runCli(
+      '--keep-commonjs',
+      `
       a = require 'a'
-    `, `
+    `,
+      `
       const a = require('a');
-    `);
+    `
+    );
   });
 
   it('respects the --use-js-modules flag', () => {
-    runCli('--use-js-modules', `
+    runCli(
+      '--use-js-modules',
+      `
       exports.a = 1
       exports.b = 2
-    `, `
+    `,
+      `
       let defaultExport = {};
       defaultExport.a = 1;
       defaultExport.b = 2;
       export default defaultExport;
-    `);
+    `
+    );
   });
 
   it('treats the --force-default-export flag as an alias for --use-js-modules', () => {
-    runCli('--force-default-export', `
+    runCli(
+      '--force-default-export',
+      `
       exports.a = 1
       exports.b = 2
-    `, `
+    `,
+      `
       let defaultExport = {};
       defaultExport.a = 1;
       defaultExport.b = 2;
       export default defaultExport;
-    `);
+    `
+    );
   });
 
   it('respects the --safe-import-function-identifiers option', () => {
-    runCli('--use-js-modules --safe-import-function-identifiers foo', `
+    runCli(
+      '--use-js-modules --safe-import-function-identifiers foo',
+      `
       a = require 'a'
       foo()
       b = require 'b'
       bar()
       c = require 'c'
-    `, `
+    `,
+      `
       import a from 'a';
       foo();
       import b from 'b';
       bar();
       const c = require('c');
-    `);
+    `
+    );
   });
 
   it('respects the --loose-js-modules option', () => {
-    runCli('--use-js-modules --loose-js-modules', `
+    runCli(
+      '--use-js-modules --loose-js-modules',
+      `
       exports.a = 1
       exports.b = 2
-    `, `
+    `,
+      `
       export let a = 1;
       export let b = 2;
-    `);
+    `
+    );
   });
 
   it('respects the --no-array-includes option', () => {
-    runCli('--no-array-includes', `
+    runCli(
+      '--no-array-includes',
+      `
       a in b
-    `, `
+    `,
+      `
       __in__(a, b);
       function __in__(needle, haystack) {
         return Array.from(haystack).indexOf(needle) >= 0;
       }
-    `);
+    `
+    );
   });
 
   it('prefers const with no options specified', () => {
-    runCli('', `
+    runCli(
+      '',
+      `
       a = 1
-    `, `
+    `,
+      `
       const a = 1;
-    `);
+    `
+    );
   });
 
   it('allows the --prefer-const option, which is a no-op', () => {
-    runCli('--prefer-const', `
+    runCli(
+      '--prefer-const',
+      `
       a = 1
-    `, `
+    `,
+      `
       const a = 1;
-    `);
+    `
+    );
   });
 
   it('respects the --prefer-let option', () => {
-    runCli('--prefer-let', `
+    runCli(
+      '--prefer-let',
+      `
       a = 1
-    `, `
+    `,
+      `
       let a = 1;
-    `);
+    `
+    );
   });
 
   it('respects the --loose option', () => {
-    runCli('--loose', `
+    runCli(
+      '--loose',
+      `
       f = (x = 1) ->
         unless x < 0
           for a in b
             c
         return
-    `, `
+    `,
+      `
       const f = function(x = 1) {
         if (x >= 0) {
           for (let a of b) {
@@ -188,68 +243,92 @@ describe('decaffeinate CLI', () => {
           }
         }
       };
-    `);
+    `
+    );
   });
 
   it('respects the --loose-default-params option', () => {
-    runCli('--loose-default-params', `
+    runCli(
+      '--loose-default-params',
+      `
       f = (x = 1) ->
         2
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS102: Remove unnecessary code created because of implicit returns
        * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
        */
       const f = (x = 1) => 2;
-    `);
+    `
+    );
   });
 
   it('respects the --loose-for-expressions option', () => {
-    runCli('--loose-for-expressions', `
+    runCli(
+      '--loose-for-expressions',
+      `
       x = (a + 1 for a in b)
-    `, `
+    `,
+      `
       const x = (b.map((a) => a + 1));
-    `);
+    `
+    );
   });
 
   it('respects the --loose-for-of option', () => {
-    runCli('--loose-for-of', `
+    runCli(
+      '--loose-for-of',
+      `
       for a in b
         c
-    `, `
+    `,
+      `
       for (let a of b) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('respects the --loose-includes option', () => {
-    runCli('--loose-includes', `
+    runCli(
+      '--loose-includes',
+      `
       a in b
-    `, `
+    `,
+      `
       b.includes(a);
-    `);
+    `
+    );
   });
 
   it('respects the --loose-comparison-negation option', () => {
-    runCli('--loose-comparison-negation', `
+    runCli(
+      '--loose-comparison-negation',
+      `
       unless a > b
         c
-    `, `
+    `,
+      `
       if (a <= b) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('adds the Babel constructor workaround by default', () => {
-    runCli('', `
+    runCli(
+      '',
+      `
       class A extends B
         constructor: ->
           @a = 1
           super
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS001: Remove Babel/TypeScript constructor workaround
@@ -268,16 +347,20 @@ describe('decaffeinate CLI', () => {
           super(...arguments);
         }
       }
-    `);
+    `
+    );
   });
 
   it('treats the --enable-babel-constructor-workaround option as a no-op', () => {
-    runCli('--enable-babel-constructor-workaround', `
+    runCli(
+      '--enable-babel-constructor-workaround',
+      `
       class A extends B
         constructor: ->
           @a = 1
           super
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS001: Remove Babel/TypeScript constructor workaround
@@ -296,48 +379,60 @@ describe('decaffeinate CLI', () => {
           super(...arguments);
         }
       }
-    `);
+    `
+    );
   });
 
   it('respects the --disable-babel-constructor-workaround option', () => {
-    runCli('--disable-babel-constructor-workaround', `
+    runCli(
+      '--disable-babel-constructor-workaround',
+      `
       class A extends B
         constructor: ->
           @a = 1
           super
-    `, `
+    `,
+      `
       class A extends B {
         constructor() {
           this.a = 1;
           super(...arguments);
         }
       }
-    `);
+    `
+    );
   });
 
   it('respects the --allow-invalid-constructors option as an alias for --disable-babel-constructor-workaround', () => {
-    runCli('--allow-invalid-constructors', `
+    runCli(
+      '--allow-invalid-constructors',
+      `
       class A extends B
         constructor: ->
           @a = 1
           super
-    `, `
+    `,
+      `
       class A extends B {
         constructor() {
           this.a = 1;
           super(...arguments);
         }
       }
-    `);
+    `
+    );
   });
 
   it('respects the --disallow-invalid-constructors option', () => {
-    runCliExpectError('--disallow-invalid-constructors', `
+    runCliExpectError(
+      '--disallow-invalid-constructors',
+      `
       class A extends B
         constructor: ->
           @a = 1
           super
-    `, `
+    `,
+      `
       stdin: Cannot automatically convert a subclass with a constructor that uses \`this\` before \`super\`.
   
       JavaScript requires all subclass constructors to call \`super\` and to do so
@@ -353,67 +448,94 @@ describe('decaffeinate CLI', () => {
       > 2 |   constructor: ->
       > 3 |     @a = 1
       > 4 |     super(arguments...)
-    `);
+    `
+    );
   });
 
   it('enables suggestions by default', () => {
-    runCli('', `
+    runCli(
+      '',
+      `
       a?
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS207: Consider shorter variations of null checks
        * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
        */
       typeof a !== 'undefined' && a !== null;
-    `);
+    `
+    );
   });
 
-
   it('respects the --disable-suggestion-comment option', () => {
-    runCli('--disable-suggestion-comment', `
+    runCli(
+      '--disable-suggestion-comment',
+      `
       a?
-    `, `
+    `,
+      `
       typeof a !== 'undefined' && a !== null;
-    `);
+    `
+    );
   });
 
   it('discovers and converts CoffeeScript files when prompted', () => {
-    runCli('./test_fixtures', '', `
+    runCli(
+      './test_fixtures',
+      '',
+      `
       test_fixtures/A.coffee → test_fixtures/A.js
       test_fixtures/B.coffee.md → test_fixtures/B.js
       test_fixtures/C.litcoffee → test_fixtures/C.js
       test_fixtures/level1/level2/file.coffee → test_fixtures/level1/level2/file.js
-    `);
+    `
+    );
     ok(existsSync('test_fixtures/A.js'));
     ok(existsSync('test_fixtures/B.js'));
     ok(existsSync('test_fixtures/C.js'));
   });
 
   it('properly converts an unrecognized extension', () => {
-    runCli('./test_fixtures/D.cjsx', '', `
+    runCli(
+      './test_fixtures/D.cjsx',
+      '',
+      `
       ./test_fixtures/D.cjsx → test_fixtures/D.js
-    `);
+    `
+    );
     ok(existsSync('test_fixtures/D.js'));
   });
 
   it('properly converts an extensionless file', () => {
-    runCli('./test_fixtures/E', '', `
+    runCli(
+      './test_fixtures/E',
+      '',
+      `
       ./test_fixtures/E → test_fixtures/E.js
-    `);
+    `
+    );
     ok(existsSync('test_fixtures/E.js'));
   });
 
   it('properly modernizes a JS file', () => {
     copySync('./test_fixtures/F.js', './test_fixtures/F.tmp.js');
-    runCli('test_fixtures/F.tmp.js --modernize-js --use-js-modules', '', `
+    runCli(
+      'test_fixtures/F.tmp.js --modernize-js --use-js-modules',
+      '',
+      `
       test_fixtures/F.tmp.js → test_fixtures/F.tmp.js
-    `);
+    `
+    );
     let contents = readFileSync('./test_fixtures/F.tmp.js').toString();
-    equal(stripSharedIndent(contents), stripSharedIndent(`
+    equal(
+      stripSharedIndent(contents),
+      stripSharedIndent(`
       import path from 'path';
       const b = 1;
-    `));
+    `)
+    );
   });
 
   it('allows --modernize-js on stdin', () => {
@@ -422,23 +544,37 @@ describe('decaffeinate CLI', () => {
 
   it('discovers JS files with --modernize-js specified', () => {
     copySync('./test_fixtures/F.js', './test_fixtures/searchDir/F.js');
-    runCli('test_fixtures/searchDir --modernize-js --use-js-modules', '', `
+    runCli(
+      'test_fixtures/searchDir --modernize-js --use-js-modules',
+      '',
+      `
       test_fixtures/searchDir/F.js → test_fixtures/searchDir/F.js
-    `);
+    `
+    );
     let contents = readFileSync('./test_fixtures/searchDir/F.js').toString();
-    equal(stripSharedIndent(contents), stripSharedIndent(`
+    equal(
+      stripSharedIndent(contents),
+      stripSharedIndent(`
       import path from 'path';
       const b = 1;
-    `));
+    `)
+    );
   });
 
   it('recursively scans directories', () => {
-    runCli('test_fixtures/level1', '', `
+    runCli(
+      'test_fixtures/level1',
+      '',
+      `
       test_fixtures/level1/level2/file.coffee → test_fixtures/level1/level2/file.js 
-    `);
+    `
+    );
     let contents = readFileSync('./test_fixtures/level1/level2/file.js').toString();
-    equal(stripSharedIndent(contents), stripSharedIndent(`
+    equal(
+      stripSharedIndent(contents),
+      stripSharedIndent(`
       const a = 1;
-    `));
+    `)
+    );
   });
 });

--- a/test/comment_test.ts
+++ b/test/comment_test.ts
@@ -1,101 +1,125 @@
-import check, {checkCS1} from './support/check';
+import check, { checkCS1 } from './support/check';
 
 describe('comments', () => {
   it('converts line comments to // form', () => {
-    check(`
+    check(
+      `
       # foo
       1
-    `, `
+    `,
+      `
       // foo
       1;
-    `);
+    `
+    );
   });
 
   it('converts block comments to /* */', () => {
-    check(`
+    check(
+      `
       ###
       HEY
       ###
       1
-    `, `
+    `,
+      `
       /*
       HEY
       */
       1;
-    `);
+    `
+    );
   });
 
   it('turns leading hashes on block comment lines to leading asterisks', () => {
-    check(`
+    check(
+      `
       ###
       # HEY
       ###
       1
-    `, `
+    `,
+      `
       /*
        * HEY
        */
       1;
-    `);
+    `
+    );
   });
 
   it('converts mixed doc block comments to /** */', () => {
-    check(`
+    check(
+      `
       ###*
       @param {Buffer} un-hashed
       ###
       (buffer) ->
-    `, `
+    `,
+      `
       /**
       @param {Buffer} un-hashed
       */
       (function(buffer) {});
-    `);
+    `
+    );
   });
 
   it('converts single-line block comments to /* */', () => {
-    check(`
+    check(
+      `
       ### HEX ###
       a0
-    `, `
+    `,
+      `
       /* HEX */
       a0;
-    `);
+    `
+    );
   });
 
   it('preserves shebang lines but changes `coffee` to `node`', () => {
-    check(`
+    check(
+      `
       #!/usr/bin/env coffee
       console.log "Hello World!"
-    `, `
+    `,
+      `
       #!/usr/bin/env node
       console.log("Hello World!");
-    `);
+    `
+    );
   });
 
   it('preserves trailing comments in function bodies in CS1', () => {
-    checkCS1(`
+    checkCS1(
+      `
       a ->
         if b
           c
         ### d ###
-    `, `
+    `,
+      `
       a(function() {
         if (b) {
           return c;
         }
         /* d */
       });
-    `);
+    `
+    );
   });
 
   it.skip('preserves trailing comments in arrow function bodies', () => {
-    check(`
+    check(
+      `
       a ->
         b
         ### c ###
-    `, `
+    `,
+      `
       a(() => b /* c */);
-    `);
+    `
+    );
   });
 });

--- a/test/comparison_test.ts
+++ b/test/comparison_test.ts
@@ -12,63 +12,80 @@ describe('comparisons', () => {
   });
 
   it('flips comparisons when used with an `unless` when the loose option is specified', () => {
-    check(`
+    check(
+      `
       unless a < b
         c
-    `, `
+    `,
+      `
       if (a >= b) {
         c;
       }
-    `, {
-      options: {
-        looseComparisonNegation: true
+    `,
+      {
+        options: {
+          looseComparisonNegation: true
+        }
       }
-    });
+    );
   });
 
   it('does not flip comparisons when used with an `unless` by default', () => {
-    check(`
+    check(
+      `
       unless a < b
         c
-    `, `
+    `,
+      `
       if (!(a < b)) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('flips nested comparisons when used with an `unless` when loose is specified', () => {
-    check(`
+    check(
+      `
       unless a < b && b > c
         d
-    `, `
+    `,
+      `
       if ((a >= b) || (b <= c)) {
         d;
       }
-    `, {
-      options: {
-        looseComparisonNegation: true
+    `,
+      {
+        options: {
+          looseComparisonNegation: true
+        }
       }
-    });
+    );
   });
 
   it('does not flip nested comparisons when used with an `unless` by default', () => {
-    check(`
+    check(
+      `
       unless a < b && b > c
         d
-    `, `
+    `,
+      `
       if (!(a < b) || !(b > c)) {
         d;
       }
-    `);
+    `
+    );
   });
 
   it('puts parens around an assignment within a comparison operator', () => {
-    check(`
+    check(
+      `
       a is b = c
-    `, `
+    `,
+      `
       let b;
       a === (b = c);
-    `);
+    `
+    );
   });
 });

--- a/test/compound_assignment_test.ts
+++ b/test/compound_assignment_test.ts
@@ -30,47 +30,61 @@ describe('compound assignment', () => {
   });
 
   it('handles compound modulo assignment', () => {
-    check(`
+    check(
+      `
       a %%= b
-    `, `
+    `,
+      `
       var a = __mod__(a, b);
       function __mod__(a, b) {
         a = +a;
         b = +b;
         return (a % b + b) % b;
       }
-    `);
+    `
+    );
   });
 
   it('handles compound floor division assignment', () => {
-    check(`
+    check(
+      `
       a //= b
-    `, `
+    `,
+      `
       var a = Math.floor(a / b);
-    `);
+    `
+    );
   });
 
   it('handles precedence for floor division assignment', () => {
-    check(`
+    check(
+      `
       a //= b + c
-    `, `
+    `,
+      `
       var a = Math.floor(a / (b + c));
-    `);
+    `
+    );
   });
 
   it('handles a repeated LHS in floor division assignment', () => {
-    check(`
+    check(
+      `
       a[b()] //= c
-    `, `
+    `,
+      `
       let name;
       a[name = b()] = Math.floor(a[name] / c);
-    `);
+    `
+    );
   });
 
   it('handles compound modulo assignment with a non-repeatable LHS', () => {
-    check(`
+    check(
+      `
       a[b()] %%= c
-    `, `
+    `,
+      `
       let name;
       a[name = b()] = __mod__(a[name], c);
       function __mod__(a, b) {
@@ -78,250 +92,331 @@ describe('compound assignment', () => {
         b = +b;
         return (a % b + b) % b;
       }
-    `);
+    `
+    );
   });
 
   describe('patching as expressions', () => {
     it('supports LHS identifiers in logical OR', () => {
-      check(`
+      check(
+        `
         [a ||= b]
-      `, `
+      `,
+        `
         let a;
         [a || (a = b)];
-      `);
+      `
+      );
     });
 
     it('supports LHS identifiers in logical AND', () => {
-      check(`
+      check(
+        `
         [a &&= b]
-      `, `
+      `,
+        `
         let a;
         [a && (a = b)];
-      `);
+      `
+      );
     });
 
     it('supports LHS static member access in logical OR', () => {
-      check(`
+      check(
+        `
         [a.b ||= c]
-      `, `
+      `,
+        `
         [a.b || (a.b = c)];
-      `);
+      `
+      );
     });
 
     it('supports LHS static member access in logical AND', () => {
-      check(`
+      check(
+        `
         [a.b &&= c]
-      `, `
+      `,
+        `
         [a.b && (a.b = c)];
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic identifier member access in logical OR', () => {
-      check(`
+      check(
+        `
         [a[b] ||= c]
-      `, `
+      `,
+        `
         [a[b] || (a[b] = c)];
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic identifier member access in logical AND', () => {
-      check(`
+      check(
+        `
         [a[b] &&= c]
-      `, `
+      `,
+        `
         [a[b] && (a[b] = c)];
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic int member access in logical OR', () => {
-      check(`
+      check(
+        `
         [a[0] ||= c]
-      `, `
+      `,
+        `
         [a[0] || (a[0] = c)];
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic int member access in logical AND', () => {
-      check(`
+      check(
+        `
         [a[0] &&= c]
-      `, `
+      `,
+        `
         [a[0] && (a[0] = c)];
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic float member access in logical OR', () => {
-      check(`
+      check(
+        `
         [a[0.9] ||= c]
-      `, `
+      `,
+        `
         [a[0.9] || (a[0.9] = c)];
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic float member access in logical AND', () => {
-      check(`
+      check(
+        `
         [a[0.9] &&= c]
-      `, `
+      `,
+        `
         [a[0.9] && (a[0.9] = c)];
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic index side-effect member access in logical OR', () => {
-      check(`
+      check(
+        `
         [a[b()] ||= c]
-      `, `
+      `,
+        `
         let name;
         [a[name = b()] || (a[name] = c)];
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic index side-effect member access in logical AND', () => {
-      check(`
+      check(
+        `
         [a[b()] &&= c]
-      `, `
+      `,
+        `
         let name;
         [a[name = b()] && (a[name] = c)];
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic base side-effect member access in logical OR', () => {
-      check(`
+      check(
+        `
         [a()[c] ||= d]
-      `, `
+      `,
+        `
         let base;
         [(base = a())[c] || (base[c] = d)];
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic base side-effect member access in logical AND', () => {
-      check(`
+      check(
+        `
         [a()[c] &&= d]
-      `, `
+      `,
+        `
         let base;
         [(base = a())[c] && (base[c] = d)];
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic base and index side-effect member access in logical OR', () => {
-      check(`
+      check(
+        `
         [a()[b()] ||= c]
-      `, `
+      `,
+        `
         let base, name;
         [(base = a())[name = b()] || (base[name] = c)];
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic base and index side-effect member access in logical AND', () => {
-      check(`
+      check(
+        `
         [a()[b()] &&= c]
-      `, `
+      `,
+        `
         let base, name;
         [(base = a())[name = b()] && (base[name] = c)];
-      `);
+      `
+      );
     });
 
     it('ensures names do not collide when introducing new variables', () => {
-      check(`
+      check(
+        `
         name = 'abc'
         [a[b()] ||= c]
-      `, `
+      `,
+        `
         let name1;
         const name = 'abc';
         [a[name1 = b()] || (a[name1] = c)];
-      `);
+      `
+      );
     });
 
     it('handles simple existence assignment of a bound variable', () => {
-      check(`
+      check(
+        `
         a = 1
         [a ?= 2]
-      `, `
+      `,
+        `
         let a = 1;
         [a != null ? a : (a = 2)];
-      `);
+      `
+      );
     });
 
     it('handles simple member expression existence assignment', () => {
-      check(`
+      check(
+        `
         [a.b ?= 1]
-      `, `
+      `,
+        `
         [a.b != null ? a.b : (a.b = 1)];
-      `);
+      `
+      );
     });
 
     it('handles simple computed member expression existence assignment', () => {
-      check(`
+      check(
+        `
         [a[b] ?= 1]
-      `, `
+      `,
+        `
         [a[b] != null ? a[b] : (a[b] = 1)];
-      `);
+      `
+      );
     });
 
     it('handles computed member expression existence assignment with unsafe-to-repeat key', () => {
-      check(`
+      check(
+        `
         [a[b()] ?= 1]
-      `, `
+      `,
+        `
         let name;
         [a[name = b()] != null ? a[name] : (a[name] = 1)];
-      `);
+      `
+      );
     });
 
     it('handles member expression existence assignment with unsafe-to-repeat object', () => {
-      check(`
+      check(
+        `
         [a()[b] ?= 1]
-      `, `
+      `,
+        `
         let base;
         [(base = a())[b] != null ? base[b] : (base[b] = 1)];
-      `);
+      `
+      );
     });
 
     it('handles member expression existence assignment with unsafe-to-repeat key and object', () => {
-      check(`
+      check(
+        `
         [a()[b()] ?= 1]
-      `, `
+      `,
+        `
         let base, name;
         [(base = a())[name = b()] != null ? base[name] : (base[name] = 1)];
-      `);
+      `
+      );
     });
 
     it('handles `this` as a safe-to-repeat base', () => {
-      check(`
+      check(
+        `
         [@a or= 0]
-      `, `
+      `,
+        `
         [this.a || (this.a = 0)];
-      `);
+      `
+      );
     });
 
     it('handles negated logical compound assignments', () => {
-      check(`
+      check(
+        `
         a = 1
         unless a ||= b
           c
-      `, `
+      `,
+        `
         let a = 1;
         if (!(a || (a = b))) {
           c;
         }
-      `);
+      `
+      );
     });
 
     it('handles negated exists compound assignments', () => {
-      check(`
+      check(
+        `
         a = 1
         unless a ?= b
           c
-      `, `
+      `,
+        `
         let a = 1;
         if (!(a != null ? a : (a = b))) {
           c;
         }
-      `);
+      `
+      );
     });
 
     it('handles negated modulo compound assignments', () => {
-      check(`
+      check(
+        `
         a = 1
         unless a %%= b
           c
-      `, `
+      `,
+        `
         let a = 1;
         if (!(a = __mod__(a, b))) {
           c;
@@ -331,261 +426,349 @@ describe('compound assignment', () => {
           b = +b;
           return (a % b + b) % b;
         }
-      `);
+      `
+      );
     });
   });
 
   describe('patching as statements', () => {
     it('supports LHS identifiers in logical OR', () => {
-      check(`
+      check(
+        `
         a ||= b
-      `, `
+      `,
+        `
         if (!a) { var a = b; }
-      `);
+      `
+      );
     });
 
     it('supports LHS identifiers in logical AND', () => {
-      check(`
+      check(
+        `
         a &&= b
-      `, `
+      `,
+        `
         if (a) { var a = b; }
-      `);
+      `
+      );
     });
 
     it('supports LHS static member access in logical OR', () => {
-      check(`
+      check(
+        `
         a.b ||= c
-      `, `
+      `,
+        `
         if (!a.b) { a.b = c; }
-      `);
+      `
+      );
     });
 
     it('supports LHS static member access in logical AND', () => {
-      check(`
+      check(
+        `
         a.b &&= c
-      `, `
+      `,
+        `
         if (a.b) { a.b = c; }
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic identifier member access in logical OR', () => {
-      check(`
+      check(
+        `
         a[b] ||= c
-      `, `
+      `,
+        `
         if (!a[b]) { a[b] = c; }
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic identifier member access in logical AND', () => {
-      check(`
+      check(
+        `
         a[b] &&= c
-      `, `
+      `,
+        `
         if (a[b]) { a[b] = c; }
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic int member access in logical OR', () => {
-      check(`
+      check(
+        `
         a[0] ||= c
-      `, `
+      `,
+        `
         if (!a[0]) { a[0] = c; }
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic int member access in logical AND', () => {
-      check(`
+      check(
+        `
         a[0] &&= c
-      `, `
+      `,
+        `
         if (a[0]) { a[0] = c; }
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic float member access in logical OR', () => {
-      check(`
+      check(
+        `
         a[0.9] ||= c
-      `, `
+      `,
+        `
         if (!a[0.9]) { a[0.9] = c; }
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic float member access in logical AND', () => {
-      check(`
+      check(
+        `
         a[0.9] &&= c
-      `, `
+      `,
+        `
         if (a[0.9]) { a[0.9] = c; }
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic index side-effect member access in logical OR', () => {
-      check(`
+      check(
+        `
         a[b()] ||= c
-      `, `
+      `,
+        `
         let name;
         if (!a[name = b()]) { a[name] = c; }
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic index side-effect member access in logical AND', () => {
-      check(`
+      check(
+        `
         a[b()] &&= c
-      `, `
+      `,
+        `
         let name;
         if (a[name = b()]) { a[name] = c; }
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic base side-effect member access in logical OR', () => {
-      check(`
+      check(
+        `
         a()[c] ||= d
-      `, `
+      `,
+        `
         let base;
         if (!(base = a())[c]) { base[c] = d; }
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic base side-effect member access in logical AND', () => {
-      check(`
+      check(
+        `
         a()[c] &&= d
-      `, `
+      `,
+        `
         let base;
         if ((base = a())[c]) { base[c] = d; }
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic base and index side-effect member access in logical OR', () => {
-      check(`
+      check(
+        `
         a()[b()] ||= c
-      `, `
+      `,
+        `
         let base, name;
         if (!(base = a())[name = b()]) { base[name] = c; }
-      `);
+      `
+      );
     });
 
     it('supports LHS dynamic base and index side-effect member access in logical AND', () => {
-      check(`
+      check(
+        `
         a()[b()] &&= c
-      `, `
+      `,
+        `
         let base, name;
         if ((base = a())[name = b()]) { base[name] = c; }
-      `);
+      `
+      );
     });
 
     it('ensures names do not collide when introducing new variables', () => {
-      check(`
+      check(
+        `
         name = 'abc'
         a[b()] ||= c
-      `, `
+      `,
+        `
         let name1;
         const name = 'abc';
         if (!a[name1 = b()]) { a[name1] = c; }
-      `);
+      `
+      );
     });
 
     it('handles simple existence assignment', () => {
-      check(`
+      check(
+        `
         a = 1
         a ?= 2
-      `, `
+      `,
+        `
         let a = 1;
         if (a == null) { a = 2; }
-      `);
+      `
+      );
     });
 
     it('handles simple existence assignment to an undeclared variable', () => {
-      check(`
+      check(
+        `
         a ?= 2
         console.log a
-      `, `
+      `,
+        `
         let a;
         if (typeof a === 'undefined' || a === null) { a = 2; }
         console.log(a);
-      `);
+      `
+      );
     });
 
     it('handles simple member expression existence assignment', () => {
-      check(`
+      check(
+        `
         a.b ?= 1
-      `, `
+      `,
+        `
         if (a.b == null) { a.b = 1; }
-      `);
+      `
+      );
     });
 
     it('handles existence assignment within a conditional', () => {
-      check(`
+      check(
+        `
         if a then b ?= c
-      `, `
+      `,
+        `
         if (a) { if (typeof b === 'undefined' || b === null) { var b = c; } }
-      `);
+      `
+      );
     });
 
     it('handles simple computed member expression existence assignment', () => {
-      check(`
+      check(
+        `
         a[b] ?= 1
-      `, `
+      `,
+        `
         if (a[b] == null) { a[b] = 1; }
-      `);
+      `
+      );
     });
 
     it('handles computed member expression existence assignment with unsafe-to-repeat key', () => {
-      check(`
+      check(
+        `
         a[b()] ?= 1
-      `, `
+      `,
+        `
         let name;
         if (a[name = b()] == null) { a[name] = 1; }
-      `);
+      `
+      );
     });
 
     it('handles member expression existence assignment with unsafe-to-repeat object', () => {
-      check(`
+      check(
+        `
         a()[b] ?= 1
-      `, `
+      `,
+        `
         let base;
         if ((base = a())[b] == null) { base[b] = 1; }
-      `);
+      `
+      );
     });
 
     it('handles member expression existence assignment with unsafe-to-repeat key and object', () => {
-      check(`
+      check(
+        `
         a()[b()] ?= 1
-      `, `
+      `,
+        `
         let base, name;
         if ((base = a())[name = b()] == null) { base[name] = 1; }
-      `);
+      `
+      );
     });
 
     it('handles existence assignment with a soak lhs', () => {
-      check(`
+      check(
+        `
         a.b?.c ?= d
-      `, `
+      `,
+        `
         if (a.b != null) {
           a.b.c != null ? a.b.c : (a.b.c = d);
         }
-      `);
+      `
+      );
     });
 
     it('patches children', () => {
-      check(`
+      check(
+        `
         (a or b).c or= d or e
-      `, `
+      `,
+        `
         let base;
         if (!((base = a || b)).c) { base.c = d || e; }
-      `);
+      `
+      );
     });
 
     it('handles `this` as a safe-to-repeat base', () => {
-      check(`
+      check(
+        `
         @a or= 0
-      `, `
+      `,
+        `
         if (!this.a) { this.a = 0; }
-      `);
+      `
+      );
     });
 
     it('handles logical operators with a function on the right side', () => {
-      check(`
+      check(
+        `
         a or= -> b
-      `, `
+      `,
+        `
         if (!a) { var a = () => b; }
-      `);
+      `
+      );
     });
   });
 });

--- a/test/conditional_test.ts
+++ b/test/conditional_test.ts
@@ -3,173 +3,216 @@ import validate from './support/validate';
 
 describe('conditionals', () => {
   it('surrounds `if` conditions in parentheses and bodies in curly braces', () => {
-    check(`
+    check(
+      `
       if a
         b
-    `, `
+    `,
+      `
       if (a) {
         b;
       }
-    `);
+    `
+    );
   });
 
   it('surrounds `unless` conditions in parentheses and precedes it with a `!` operator', () => {
-    check(`
+    check(
+      `
       unless a
         b
-    `, `
+    `,
+      `
       if (!a) {
         b;
       }
-    `);
+    `
+    );
   });
 
   it('surrounds `unless` conditions in additional parentheses if needed for the `!` operator', () => {
-    check(`
+    check(
+      `
       unless a == b
         c
-    `, `
+    `,
+      `
       if (a !== b) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('does not add parentheses if the condition is already surrounded by them', () => {
-    check(`
+    check(
+      `
       if (a)
         b
-    `, `
+    `,
+      `
       if (a) {
         b;
       }
-    `);
-    check(`
+    `
+    );
+    check(
+      `
       unless (a)
         b
-    `, `
+    `,
+      `
       if (!a) {
         b;
       }
-    `);
+    `
+    );
   });
 
   it('causes the condition not to add parentheses even if it normally would', () => {
-    check(`
+    check(
+      `
       a = b
       if a?
         c
-    `, `
+    `,
+      `
       const a = b;
       if (a != null) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('correctly inserts parentheses when an `unless` condition requires them when it was surrounded by parentheses', () => {
-    check(`
+    check(
+      `
       unless (a == b)
         c
-    `, `
+    `,
+      `
       if (a !== b) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('adds parentheses when `unless` is used with an assignment', () => {
-    check(`
+    check(
+      `
       unless a = b
         c
-    `, `
+    `,
+      `
       let a;
       if (!(a = b)) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('keeps parentheses when `unless` is used with an assignment', () => {
-    check(`
+    check(
+      `
       unless (a = b)
         c
-    `, `
+    `,
+      `
       let a;
       if (!(a = b)) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('adds parentheses when `unless` is used with a normal binary operator', () => {
-    check(`
+    check(
+      `
       unless a + b
         c
-    `, `
+    `,
+      `
       if (!(a + b)) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('keeps parentheses when `unless` is used with a normal binary operator', () => {
-    check(`
+    check(
+      `
       unless (a + b)
         c
-    `, `
+    `,
+      `
       if (!(a + b)) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('handles indented `if` statements correctly', () => {
-    check(`
+    check(
+      `
       if a
         if b
           c
-    `, `
+    `,
+      `
       if (a) {
         if (b) {
           c;
         }
       }
-    `);
+    `
+    );
   });
 
   it('surrounds the `else` clause of an `if` statement in curly braces', () => {
-    check(`
+    check(
+      `
       if a
         b
       else
         c
-    `, `
+    `,
+      `
       if (a) {
         b;
       } else {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('surrounds the `else if` condition in parentheses', () => {
-    check(`
+    check(
+      `
       if a
         b
       else if c
         d
-    `, `
+    `,
+      `
       if (a) {
         b;
       } else if (c) {
         d;
       }
-    `);
+    `
+    );
   });
 
   it('works with several `else if` clauses and an `else`', () => {
-    check(`
+    check(
+      `
       if a
         b
       else if c
@@ -178,7 +221,8 @@ describe('conditionals', () => {
         f
       else
         g
-    `, `
+    `,
+      `
       if (a) {
         b;
       } else if (c) {
@@ -188,23 +232,27 @@ describe('conditionals', () => {
       } else {
         g;
       }
-    `);
+    `
+    );
   });
 
   it('works with `if` with immediate return', () => {
-    check(`
+    check(
+      `
       ->
         if a
           b
       c
-    `, `
+    `,
+      `
       (function() {
         if (a) {
           return b;
         }
       });
       c;
-    `);
+    `
+    );
   });
 
   it('keeps single-line `if` statements on one line', () => {
@@ -232,7 +280,8 @@ describe('conditionals', () => {
   });
 
   it('turns multi-line `if` into an IIFE with statements', () => {
-    check(`
+    check(
+      `
       ->
         z(if a
           c = a
@@ -240,7 +289,8 @@ describe('conditionals', () => {
         else
           d = a
           a - d)
-    `, `
+    `,
+      `
       () =>
         z((() => {
           if (a) {
@@ -252,29 +302,36 @@ describe('conditionals', () => {
         }
         })())
       ;
-    `);
+    `
+    );
   });
 
   it('keeps single-line POST-`if`', () => {
     check(`a if b`, `if (b) { a; }`);
-    check(`
+    check(
+      `
       ->
         return if a is b
         null
-      `, `
+      `,
+      `
         (function() {
           if (a === b) { return; }
           return null;
         });
-    `);
+    `
+    );
   });
 
   it('keeps single-line POST-`if` with implicit call as the condition', () => {
-    check(`
+    check(
+      `
       a if b c
-    `, `
+    `,
+      `
       if (b(c)) { a; }
-    `);
+    `
+    );
   });
 
   it('keeps single-line POST-`unless`', () => {
@@ -286,27 +343,32 @@ describe('conditionals', () => {
   });
 
   it('pushes returns into `if` statements', () => {
-    check(`
+    check(
+      `
       ->
         if a
           b
-    `, `
+    `,
+      `
       (function() {
         if (a) {
           return b;
         }
       });
-    `);
+    `
+    );
   });
 
   it('pushes returns into `else if` blocks', () => {
-    check(`
+    check(
+      `
       ->
         if a
           b
         else if c
           d
-    `, `
+    `,
+      `
       (function() {
         if (a) {
           return b;
@@ -314,7 +376,8 @@ describe('conditionals', () => {
           return d;
         }
       });
-    `);
+    `
+    );
   });
 
   it('works with if then throw inline', () => {
@@ -326,115 +389,149 @@ describe('conditionals', () => {
   });
 
   it('works with nested POST-`if`', () => {
-    check(`
+    check(
+      `
       a(b) if c(d) unless e(f)
-    `, `
+    `,
+      `
       if (!e(f)) { if (c(d)) { a(b); } }
-    `);
+    `
+    );
   });
 
   it('works with nested POST-`if` with implicit calls', () => {
-    check(`
+    check(
+      `
       a b if c d unless e f
-    `, `
+    `,
+      `
       if (!e(f)) { if (c(d)) { a(b); } }
-    `);
+    `
+    );
   });
 
   it('works with `unless` in an expression context', () => {
-    check(`
+    check(
+      `
       x = (a unless b)
-    `, `
+    `,
+      `
       const x = (!b ? a : undefined);
-    `);
+    `
+    );
   });
 
   it('works with `unless` in an object value (#566)', () => {
-    check(`
+    check(
+      `
       isValid = true
 
       testing = {
           test: "Hello world" unless isValid
       }
-    `, `
+    `,
+      `
       const isValid = true;
 
       const testing = {
           test: !isValid ? "Hello world" : undefined
       };
-    `);
+    `
+    );
   });
 
   it('surrounds the conditional expression in parens as part of a binary expression', () => {
-    check(`
+    check(
+      `
       a + if b then c else d
-    `, `
+    `,
+      `
       a + (b ? c : d);
-    `);
+    `
+    );
   });
 
   it('surrounds the conditional expression in parens as part of a unary expression', () => {
-    check(`
+    check(
+      `
       -if b then c else d
-    `, `
+    `,
+      `
       -(b ? c : d);
-    `);
+    `
+    );
   });
 
   it('does not add extra parens to a conditional expression', () => {
-    check(`
+    check(
+      `
       a + (if b then c else d)
-    `, `
+    `,
+      `
       a + (b ? c : d);
-    `);
+    `
+    );
   });
 
   it('does not add unnecessary parens to a conditional expression', () => {
-    check(`
+    check(
+      `
       a ** if b then c else d
-    `, `
+    `,
+      `
       Math.pow(a, b ? c : d);
-    `);
+    `
+    );
   });
 
   it('adds parenthesis if needed', () => {
-    check(`
+    check(
+      `
       alert if (a) and (b)
-    `, `
+    `,
+      `
       if ((a) && (b)) { alert; }
-    `);
+    `
+    );
   });
 
   it('does not remove parentheses around conditions in conditional expressions', () => {
-    check(`
+    check(
+      `
       r = if (f is 0.5) then a else b
-    `, `
+    `,
+      `
       const r = (f === 0.5) ? a : b;
-    `);
+    `
+    );
   });
 
   it('handles implicit function calls in the else clause', () =>
-    check(`
+    check(
+      `
       if a
         b
       else
         c d
-    `, `
+    `,
+      `
       if (a) {
         b;
       } else {
         c(d);
       }
-    `)
-  );
+    `
+    ));
 
   it('creates an IIFE when a complicated condition is used in an expression context', () =>
-    check(`
+    check(
+      `
       a = if b
           c
         else if d
           e
-    `, `
+    `,
+      `
       const a = (() => {
         if (b) {
           return c;
@@ -442,15 +539,17 @@ describe('conditionals', () => {
           return e;
         }
       })();
-    `)
-  );
+    `
+    ));
 
   it('creates a properly-formatted IIFE for nested `if`s in a function body', () =>
-    check(`
+    check(
+      `
       a(if b
           if c
             null)
-    `, `
+    `,
+      `
       a((() => {
         if (b) {
           if (c) {
@@ -458,11 +557,12 @@ describe('conditionals', () => {
           }
         }
       })());
-    `)
-  );
+    `
+    ));
 
   it('creates a properly-formatted IIFE with the `if` on the next line', () =>
-    check(`
+    check(
+      `
       c =
         if a
           x = 0
@@ -470,7 +570,8 @@ describe('conditionals', () => {
           x
         else
           1
-    `, `
+    `,
+      `
       const c =
         (() => {
         if (a) {
@@ -481,81 +582,92 @@ describe('conditionals', () => {
           return 1;
         }
       })();
-    `)
-  );
+    `
+    ));
 
   it('allows a missing consequent in an if-else', () =>
-    check(`
+    check(
+      `
       if a
         # Do nothing
       else
         b
-    `, `
+    `,
+      `
       if (a) {
         // Do nothing
       } else {
         b;
       }
-    `)
-  );
+    `
+    ));
 
   it('allows a missing consequent in an expression-style if-else', () =>
-    check(`
+    check(
+      `
       x =
         if a
           # Do nothing
         else
           b
-    `, `
+    `,
+      `
       const x =
         a ?
           // Do nothing
         undefined :
           b;
-    `)
-  );
+    `
+    ));
 
   it('allows a condition with an else token but not an alternate', () =>
-    check(`
+    check(
+      `
       if a
         b
       else
         # Do nothing
-    `, `
+    `,
+      `
       if (a) {
         b;
       }
       else {}
         // Do nothing
-    `)
-  );
+    `
+    ));
 
   it('allows an expression-style condition with an else token but not an alternate', () =>
-    check(`
+    check(
+      `
       x =
         if a
           b
         else
           # Do nothing
-    `, `
+    `,
+      `
       const x =
         a ?
           b
          : undefined;
           // Do nothing
-    `)
-  );
+    `
+    ));
 
   it('handles a conditional without a space before the `else` token', () =>
-    check(`
+    check(
+      `
       if a then (b)else c
-    `, `
+    `,
+      `
       if (a) { b;} else { c; }
-    `)
-  );
+    `
+    ));
 
   it('handles an IIFE conditional within an IIFE for loop', () =>
-    check(`
+    check(
+      `
       x = for a in b by 1
         y = 
           if a
@@ -564,7 +676,8 @@ describe('conditionals', () => {
           else
             d
         y
-    `, `
+    `,
+      `
       const x = (() => {
         const result = [];
         for (let i = 0; i < b.length; i++) {
@@ -583,30 +696,37 @@ describe('conditionals', () => {
         }
         return result;
       })();
-    `)
-  );
+    `
+    ));
 
   it('handles a multiline condition in a postfix conditional', () => {
-    check(`
+    check(
+      `
       a if do ->
         b
-    `, `
+    `,
+      `
       if ((() => b)()) { a; }
-    `);
+    `
+    );
   });
 
   it('handles a conditional with no consequent or alternate', () => {
-    check(`
+    check(
+      `
       if a
       else
-    `, `
+    `,
+      `
       if (a) {} 
       else {}
-    `);
+    `
+    );
   });
 
   it('handles a conditional with only a comment for the consequent and alternate', () => {
-    check(`
+    check(
+      `
       ->
         if false
           # comment
@@ -615,7 +735,8 @@ describe('conditionals', () => {
           block comment
           ###
         else
-    `, `
+    `,
+      `
       (function() {
         if (false) {
           // comment
@@ -625,31 +746,37 @@ describe('conditionals', () => {
           */
         else {}
       });
-    `);
+    `
+    );
   });
 
   it('handles a parenthesized empty condition with only a block comment for its body', () => {
-    check(`
+    check(
+      `
       x = (if true
         ### a ###
       else
       )
-    `, `
+    `,
+      `
       const x = (true ?
         /* a */
       undefined : undefined
       );
-    `);
+    `
+    );
   });
 
   it('handles an IIFE-style conditional containing a yield', () => {
-    check(`
+    check(
+      `
       ->
         x = if a
           if b
             c
           yield d
-    `, `
+    `,
+      `
       (function*() {
         let x;
         return x = yield* (function*() {
@@ -661,79 +788,103 @@ describe('conditionals', () => {
         }
         }).call(this);
       });
-    `);
+    `
+    );
   });
 
   it('handles a post-while as a function argument', () => {
-    check(`
+    check(
+      `
       a(b if c, d)
-    `, `
+    `,
+      `
       a((c ? b : undefined), d);
-    `);
+    `
+    );
   });
 
   it('handles a post-while as an array element', () => {
-    check(`
+    check(
+      `
       [a if b, c]
-    `, `
+    `,
+      `
       [(b ? a : undefined), c];
-    `);
+    `
+    );
   });
 
   it('handles a post-while as an object element', () => {
-    check(`
+    check(
+      `
       {a: b if c, d}
-    `, `
+    `,
+      `
       ({a: (c ? b : undefined), d});
-    `);
+    `
+    );
   });
 
   it('handles an assignment within an expression-style conditional', () => {
-    validate(`
+    validate(
+      `
       a =
         if b = 1
           2
         else
           3
       setResult(b)
-    `, 1);
+    `,
+      1
+    );
   });
 
   it('properly handles an expression-style conditional in an implicit return context', () => {
-    check(`
+    check(
+      `
       ->
         x = (if a then b else c)
-    `, `
+    `,
+      `
       (function() {
         let x;
         return x = (a ? b : c);
       });
-    `);
+    `
+    );
   });
 
   it('handles a postfix loop within a postfix conditional', () => {
-    check(`
+    check(
+      `
       a for a in b if b
-    `, `
+    `,
+      `
       if (b) { for (let a of Array.from(b)) { a; } }
-    `);
+    `
+    );
   });
 
   it('handles negated parenthesized conditionals', () => {
-    check(`
+    check(
+      `
       a unless (b if c)
-    `, `
+    `,
+      `
       if (!(c ? b : undefined)) { a; }
-    `);
+    `
+    );
   });
 
   it('handles negated IIFE-style conditionals', () => {
-    check(`
+    check(
+      `
       a unless (
         if b
           if c
             d)
-    `, `
+    `,
+      `
       if (!(() => {
         
         if (b) {
@@ -742,108 +893,135 @@ describe('conditionals', () => {
           }
         }
       })()) { a; }
-    `);
+    `
+    );
   });
 
   it('handles a postfix conditional followed by a semicolon', () => {
-    check(`
+    check(
+      `
       a if b; c
-    `, `
+    `,
+      `
       if (b) { a; } c;
-    `);
+    `
+    );
   });
 
   it('handles a return within a returned conditional', () => {
-    check(`
+    check(
+      `
       ->
         return if a
           return b
-    `, `
+    `,
+      `
       (function() {
         if (a) {
           return b;
         }
       });
-    `);
+    `
+    );
   });
 
   it('handles a conditional with an inline empty body', () => {
-    check(`
+    check(
+      `
       if a then
-    `, `
+    `,
+      `
       if (a) {}  
-    `);
+    `
+    );
   });
 
   it('allows falling through an empty conditional in a return statement', () => {
-    check(`
+    check(
+      `
       ->
         return if a
           b
         c
-    `, `
+    `,
+      `
       (function() {
         if (a) {
           return b;
         }
         return c;
       });
-    `);
+    `
+    );
   });
 
   it('gives the correct result when returning an incomplete conditional', () => {
-    validate(`
+    validate(
+      `
       f = ->
         return if 0
           1
         2
       setResult(f())
-    `, 2);
+    `,
+      2
+    );
   });
 
   it('gives the correct result when returning a parenthesized incomplete conditional', () => {
-    validate(`
+    validate(
+      `
       f = ->
         return (if 0
           1)
         2
       setResult('' + f())
-    `, 'undefined');
+    `,
+      'undefined'
+    );
   });
 
   it('handles an expression-style conditional ending in a semicolon', () => {
-    check(`
+    check(
+      `
       x = if a
         ;
-    `, `
+    `,
+      `
       const x = a ? undefined : undefined
         ;
-    `);
+    `
+    );
   });
 
   it('handles an expression-style conditional with semicolon consequent', () => {
-    check(`
+    check(
+      `
       x = if a
         ;
       else
         b
-    `, `
+    `,
+      `
       const x = a ?
         
       undefined :
         b;
-    `);
+    `
+    );
   });
 
   it('handles an IIFE conditional with an assigned variable used later', () => {
-    check(`
+    check(
+      `
       a =
         if b
           c = d
         else if e
           f
       c
-    `, `
+    `,
+      `
       let c;
       const a =
         (() => {
@@ -854,11 +1032,13 @@ describe('conditionals', () => {
         }
       })();
       c;
-    `);
+    `
+    );
   });
 
   it('produces the right result with an IIFE conditional with assignment followed by access', () => {
-    validate(`
+    validate(
+      `
       value = 3
       
       result =
@@ -869,17 +1049,22 @@ describe('conditionals', () => {
       
       if value == 3
         setResult(x)
-    `, 1);
+    `,
+      1
+    );
   });
 
   it('handles multiline inline conditionals with an existential operator condition (#1230)', () => {
-    check(`
+    check(
+      `
       test  = if \\
         cond? \\
         then 'true' else 'no'
-    `, `
+    `,
+      `
       const test  = (typeof cond !== 'undefined' && cond !== null) 
         ? 'true' : 'no';
-    `);
+    `
+    );
   });
 });

--- a/test/continuation_test.ts
+++ b/test/continuation_test.ts
@@ -2,22 +2,28 @@ import check from './support/check';
 
 describe('continuation', () => {
   it('is removed when continuing a binary operator', () => {
-    check(`
+    check(
+      `
       a \\
         + 1
-    `, `
+    `,
+      `
       a 
         + 1;
-    `);
+    `
+    );
   });
 
   it('is removed when continuing a function call', () => {
-    check(`
+    check(
+      `
       a \\
         b
-    `, `
+    `,
+      `
       a( 
         b);
-    `);
+    `
+    );
   });
 });

--- a/test/continue_test.ts
+++ b/test/continue_test.ts
@@ -2,13 +2,16 @@ import check from './support/check';
 
 describe('continue', () => {
   it('is passed through as-is', () => {
-    check(`
+    check(
+      `
       for a in b
         continue
-    `, `
+    `,
+      `
       for (let a of Array.from(b)) {
         continue;
       }
-    `);
+    `
+    );
   });
 });

--- a/test/csx_test.ts
+++ b/test/csx_test.ts
@@ -1,196 +1,263 @@
-import {checkCS2} from './support/check';
+import { checkCS2 } from './support/check';
 
 // These tests are taken from csx.coffee in the CoffeeScript test suite.
 describe('csx', () => {
   it('self closing', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div />
-    `, `
+    `,
+      `
       <div />;
-    `);
+    `
+    );
   });
 
   it('regex attribute', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div x={/>asds/} />
-    `, `
+    `,
+      `
       <div x={/>asds/} />;
-    `);
+    `
+    );
   });
 
   it('string attribute', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div x="a" />
-    `, `
+    `,
+      `
       <div x="a" />;
-    `);
+    `
+    );
   });
 
   it('simple attribute', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div x={42} />
-    `, `
+    `,
+      `
       <div x={42} />;
-    `);
+    `
+    );
   });
 
   it('assignment attribute', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div x={y = 42} />
-    `, `
+    `,
+      `
       let y;
       <div x={(y = 42)} />;
-    `);
+    `
+    );
   });
 
   it('object attribute', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div x={{y: 42}} />
-    `, `
+    `,
+      `
       <div x={{y: 42}} />;
-    `);
+    `
+    );
   });
 
   it('attribute without value', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div checked x="hello" />
-    `, `
+    `,
+      `
       <div checked x="hello" />;
-    `);
+    `
+    );
   });
 
   it('paired', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div></div>
-    `, `
+    `,
+      `
       <div></div>;
-    `);
+    `
+    );
   });
 
   it('simple content', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div>Hello world</div>
-    `, `
+    `,
+      `
       <div>Hello world</div>;
-    `);
+    `
+    );
   });
 
   it('content interpolation', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div>Hello {42}</div>
-    `, `
+    `,
+      `
       <div>Hello {42}</div>;
-    `);
+    `
+    );
   });
 
   it('nested tag', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div><span /></div>
-    `, `
+    `,
+      `
       <div><span /></div>;
-    `);
+    `
+    );
   });
 
   it('tag inside interpolation formatting', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div>Hello {<span />}</div>
-    `, `
+    `,
+      `
       <div>Hello {<span />}</div>;
-    `);
+    `
+    );
   });
 
   it('tag inside interpolation, tags are callable', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div>Hello {<span /> x}</div>
-    `, `
+    `,
+      `
       <div>Hello {(<span />)(x)}</div>;
-    `);
+    `
+    );
   });
 
   it('tags inside interpolation, tags trigger implicit calls', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div>Hello {f <span />}</div>
-    `, `
+    `,
+      `
       <div>Hello {f(<span />)}</div>;
-    `);
+    `
+    );
   });
 
   it('regex in interpolation', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div x={/>asds/}><div />{/>asdsad</}</div>
-    `, `
+    `,
+      `
       <div x={/>asds/}><div />{/>asdsad</}</div>;
-    `);
+    `
+    );
   });
 
   it('interpolation in string attribute value', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div x="Hello #{world}" />
-    `, `
+    `,
+      `
       <div x={\`Hello \${world}\`} />;
-    `);
+    `
+    );
   });
 
   it('complex interpolation in string attribute value', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div x="Hello #{a b}" />
-    `, `
+    `,
+      `
       <div x={\`Hello \${a(b)}\`} />;
-    `);
+    `
+    );
   });
 
   it('complex interpolation in string attribute value in braces', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div x={"Hello #{a b}"} />
-    `, `
+    `,
+      `
       <div x={\`Hello \${a(b)}\`} />;
-    `);
+    `
+    );
   });
 
   it('complex interpolation in herestring attribute value', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div x="""Hello #{a b}""" />
-    `, `
+    `,
+      `
       <div x={\`Hello \${a(b)}\`} />;
-    `);
+    `
+    );
   });
 
   it('ambiguous tag', () => {
-    checkCS2(`
+    checkCS2(
+      `
       a <b > c </b>
-    `, `
+    `,
+      `
       a(<b > c </b>);
-    `);
+    `
+    );
   });
 
   it('escaped CoffeeScript attribute', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Person name={if test() then 'yes' else 'no'} />
-    `, `
+    `,
+      `
       <Person name={test() ? 'yes' : 'no'} />;
-    `);
+    `
+    );
   });
 
   it('escaped CoffeeScript attribute over multiple lines', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Person name={
         if test()
           'yes'
         else
           'no'
       } />
-    `, `
+    `,
+      `
       <Person name={
         test() ?
           'yes'
         :
           'no'
       } />;
-    `);
+    `
+    );
   });
 
   it('multiple line escaped CoffeeScript with nested CSX', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Person name={
         if test()
           'yes'
@@ -207,7 +274,8 @@ describe('csx', () => {
       }
   
       </Person>
-    `, `
+    `,
+      `
       <Person name={
         test() ?
           'yes'
@@ -224,31 +292,39 @@ describe('csx', () => {
       }
       
       </Person>;
-    `);
+    `
+    );
   });
 
   it('nested CSX within an attribute, with object attr value', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Company>
         <Person name={<NameComponent attr3={ {'a': {}, b: '{'} } />} />
       </Company>
-    `, `
+    `,
+      `
       <Company>
         <Person name={<NameComponent attr3={ {'a': {}, b: '{'} } />} />
       </Company>;
-    `);
+    `
+    );
   });
 
   it('complex nesting', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div code={someFunc({a:{b:{}, C:'}{}{'}})} />
-    `, `
+    `,
+      `
       <div code={someFunc({a:{b:{}, C:'}{}{'}})} />;
-    `);
+    `
+    );
   });
 
   it('multiline tag with nested CSX within an attribute', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Person
         name={
           name = formatName(user.name)
@@ -257,7 +333,8 @@ describe('csx', () => {
       >
         blah blah blah
       </Person>
-    `, `
+    `,
+      `
       let name;
       <Person
         name={
@@ -267,59 +344,73 @@ describe('csx', () => {
       >
         blah blah blah
       </Person>;
-    `);
+    `
+    );
   });
 
   it('escaped CoffeeScript with nested object literals', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Person>
         blah blah blah {
           {'a' : {}, 'asd': 'asd'}
         }
       </Person>
-    `, `
+    `,
+      `
       <Person>
         blah blah blah {
           {'a' : {}, 'asd': 'asd'}
         }
       </Person>;
-    `);
+    `
+    );
   });
 
   it('multiline tag attributes with escaped CoffeeScript', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Person name={if isActive() then 'active' else 'inactive'}
       someattr='on new line' />
-    `, `
+    `,
+      `
       <Person name={isActive() ? 'active' : 'inactive'}
       someattr='on new line' />;
-    `);
+    `
+    );
   });
 
   it('lots of attributes', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Person eyes={2} friends={getFriends()} popular = "yes"
       active={ if isActive() then 'active' else 'inactive' } data-attr='works' checked check={me_out}
       />
-    `, `
+    `,
+      `
       <Person eyes={2} friends={getFriends()} popular = "yes"
       active={ isActive() ? 'active' : 'inactive' } data-attr='works' checked check={me_out}
       />;
-    `);
+    `
+    );
   });
 
   it('complex regex', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Person />
       /\\/\\/<Person \\/>\\>\\//
-    `, `
+    `,
+      `
       <Person />;
       /\\/\\/<Person \\/>\\>\\//;
-    `);
+    `
+    );
   });
 
   it('heregex', () => {
-    checkCS2(`
+    checkCS2(
+      `
       test = /432/gm # this is a regex
       6 /432/gm # this is division
       <Tag>
@@ -342,7 +433,8 @@ describe('csx', () => {
         /) ([imgy]{0,4}) (?!\\w)
       ///
       <Person />
-    `, `
+    `,
+      `
       let test = /432/gm; // this is a regex
       6 /432/gm; // this is division
       <Tag>
@@ -365,139 +457,180 @@ describe('csx', () => {
       /)([imgy]{0,4})(?!\\\\w)\\
       \`);
       <Person />;
-    `);
+    `
+    );
   });
 
   it('comment within CSX is not treated as comment', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Person>
       # i am not a comment
       </Person>
-    `, `
+    `,
+      `
       <Person>
       # i am not a comment
       </Person>;
-    `);
+    `
+    );
   });
 
   it('comment at start of CSX escape', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Person>
       {# i am a comment
         "i am a string"
       }
       </Person>
-    `, `
+    `,
+      `
       <Person>
       {// i am a comment
         "i am a string"
       }
       </Person>;
-    `);
+    `
+    );
   });
 
   it('comment at end of CSX escape', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Person>
       {"i am a string"
       # i am a comment
       }
       </Person>
-    `, `
+    `,
+      `
       <Person>
       {"i am a string"
       // i am a comment
       }
       </Person>;
-    `);
+    `
+    );
   });
 
   it('string within CSX is ignored', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Person> "i am not a string" 'nor am i' </Person>
-    `, `
+    `,
+      `
       <Person> "i am not a string" 'nor am i' </Person>;
-    `);
+    `
+    );
   });
 
   it('special chars within CSX are ignored', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Person> a,/';][' a\\''@$%^&˚¬∑˜˚∆å∂¬˚*()*&^%$>> '"''"'''\\'\\'m' i </Person>
-    `, `
+    `,
+      `
       <Person> a,/';][' a\\''@$%^&˚¬∑˜˚∆å∂¬˚*()*&^%$>> '"''"'''\\'\\'m' i </Person>;
-    `);
+    `
+    );
   });
 
   it('html entities (name, decimal, hex) within CSX', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Person>  &&&&euro;  &#8364; &#x20AC;;; </Person>
-    `, `
+    `,
+      `
       <Person>  &&&&euro;  &#8364; &#x20AC;;; </Person>;
-    `);
+    `
+    );
   });
 
   it('tag with {{}}', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Person name={{value: item, key, item}} />
-    `, `
+    `,
+      `
       <Person name={{value: item, key, item}} />;
-    `);
+    `
+    );
   });
 
   it('tag with namespace', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Something.Tag></Something.Tag>
-    `, `
+    `,
+      `
       <Something.Tag></Something.Tag>;
-    `);
+    `
+    );
   });
 
   it('tag with lowercase namespace', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <something.tag></something.tag>
-    `, `
+    `,
+      `
       <something.tag></something.tag>;
-    `);
+    `
+    );
   });
 
   it('self closing tag with namespace', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Something.Tag />
-    `, `
+    `,
+      `
       <Something.Tag />;
-    `);
+    `
+    );
   });
 
   it('self closing tag with spread attribute', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Component a={b} {x...} b="c" />
-    `, `
+    `,
+      `
       <Component a={b} {...x} b="c" />;
-    `);
+    `
+    );
   });
 
   it('complex spread attribute', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Component {x...} a={b} {x...} b="c" {$my_xtraCoolVar123...} />
-    `, `
+    `,
+      `
       <Component {...x} a={b} {...x} b="c" {...$my_xtraCoolVar123} />;
-    `);
+    `
+    );
   });
 
   it('multiline spread attribute', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Component {
         x...} a={b} {x...} b="c" {z...}>
       </Component>
-    `, `
+    `,
+      `
       <Component {
         ...x} a={b} {...x} b="c" {...z}>
       </Component>;
-    `);
+    `
+    );
   });
 
   it('multiline tag with spread attribute', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Component
         z="1"
         {x...}
@@ -505,7 +638,8 @@ describe('csx', () => {
         b="c"
       >
       </Component>
-    `, `
+    `,
+      `
       <Component
         z="1"
         {...x}
@@ -513,11 +647,13 @@ describe('csx', () => {
         b="c"
       >
       </Component>;
-    `);
+    `
+    );
   });
 
   it('multiline tag with spread attribute first', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Component
         {x...}
         z="1"
@@ -525,7 +661,8 @@ describe('csx', () => {
         b="c"
       >
       </Component>
-    `, `
+    `,
+      `
       <Component
         {...x}
         z="1"
@@ -533,211 +670,264 @@ describe('csx', () => {
         b="c"
       >
       </Component>;
-    `);
+    `
+    );
   });
 
   it('complex multiline spread attribute', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Component
         {y...
         } a={b} {x...} b="c" {z...}>
         <div code={someFunc({a:{b:{}, C:'}'}})} />
       </Component>
-    `, `
+    `,
+      `
       <Component
         {...y
         } a={b} {...x} b="c" {...z}>
         <div code={someFunc({a:{b:{}, C:'}'}})} />
       </Component>;
-    `);
+    `
+    );
   });
 
   it('self closing spread attribute on single line', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Component a="b" c="d" {@props...} />
-    `, `
+    `,
+      `
       <Component a="b" c="d" {...this.props} />;
-    `);
+    `
+    );
   });
 
   it('self closing spread attribute on new line', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Component
         a="b"
         c="d"
         {@props...}
       />
-    `, `
+    `,
+      `
       <Component
         a="b"
         c="d"
         {...this.props}
       />;
-    `);
+    `
+    );
   });
 
   it('self closing spread attribute on same line', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Component
         a="b"
         c="d"
         {@props...} />
-    `, `
+    `,
+      `
       <Component
         a="b"
         c="d"
         {...this.props} />;
-    `);
+    `
+    );
   });
 
   it('self closing spread attribute on next line', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Component
         a="b"
         c="d"
         {@props...}
   
       />
-    `, `
+    `,
+      `
       <Component
         a="b"
         c="d"
         {...this.props}
       
       />;
-    `);
+    `
+    );
   });
 
   it('empty strings are not converted to true', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <Component val="" />
-    `, `
+    `,
+      `
       <Component val="" />;
-    `);
+    `
+    );
   });
 
   it('hyphens in tag names', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <paper-button className="button">{text}</paper-button>
-    `, `
+    `,
+      `
       <paper-button className="button">{text}</paper-button>;
-    `);
+    `
+    );
   });
 
   it('tag inside CSX works following: identifier', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <span>a<div /></span>
-    `, `
+    `,
+      `
       <span>a<div /></span>;
-    `);
+    `
+    );
   });
 
   it('tag inside CSX works following: number', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <span>3<div /></span>
-    `, `
+    `,
+      `
       <span>3<div /></span>;
-    `);
+    `
+    );
   });
 
   it('tag inside CSX works following: paren', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <span>(3)<div /></span>
-    `, `
+    `,
+      `
       <span>(3)<div /></span>;
-    `);
+    `
+    );
   });
 
   it('tag inside CSX works following: square bracket', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <span>]<div /></span>
-    `, `
+    `,
+      `
       <span>]<div /></span>;
-    `);
+    `
+    );
   });
 
   it('unspaced less than inside CSX works but is not encouraged', () => {
-    checkCS2(`
+    checkCS2(
+      `
       a = 3
       div = 5
       html = <span>{a<div}</span>
-    `, `
+    `,
+      `
       const a = 3;
       const div = 5;
       const html = <span>{a<div}</span>;
-    `);
+    `
+    );
   });
 
   it('unspaced less than before CSX works but is not encouraged', () => {
-    checkCS2(`
+    checkCS2(
+      `
       div = 5
       res = 2<div
       html = <span />
-    `, `
+    `,
+      `
       const div = 5;
       const res = 2<div;
       const html = <span />;
-    `);
+    `
+    );
   });
 
   it('unspaced less than after CSX works but is not encouraged', () => {
-    checkCS2(`
+    checkCS2(
+      `
       div = 5
       html = <span />
       res = 2<div
-    `, `
+    `,
+      `
       const div = 5;
       const html = <span />;
       const res = 2<div;
-    `);
+    `
+    );
   });
 
   it('comments inside interpolations that also contain CSX tags', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div>
         {
           # comment
           <div />
         }
       </div>
-    `, `
+    `,
+      `
       <div>
         {
           // comment
           <div />
         }
       </div>;
-    `);
+    `
+    );
   });
 
   it('comments inside interpolations that also contain CSX attributes', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <div>
         <div anAttr={
           # comment
           "value"
         } />
       </div>
-    `, `
+    `,
+      `
       <div>
         <div anAttr={
           // comment
           "value"
         } />
       </div>;
-    `);
+    `
+    );
   });
 
   it('JSX fragments: empty fragment', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <></>
-    `, `
+    `,
+      `
       <></>;
-    `);
+    `
+    );
   });
 
   it('JSX fragments: fragment with text nodes', () => {
-    checkCS2(`
+    checkCS2(
+      `
       <>
         Some text.
         <h2>A heading</h2>
@@ -745,7 +935,8 @@ describe('csx', () => {
         <h2>Another heading</h2>
         Even more text.
       </>
-    `, `
+    `,
+      `
       <>
         Some text.
         <h2>A heading</h2>
@@ -753,23 +944,27 @@ describe('csx', () => {
         <h2>Another heading</h2>
         Even more text.
       </>;
-    `);
+    `
+    );
   });
 
   it('JSX fragments: fragment with component nodes', () => {
-    checkCS2(`
+    checkCS2(
+      `
      Component = (props) =>
        <Fragment>
          <OtherComponent />
          <OtherComponent />
        </Fragment>
-    `, `
+    `,
+      `
       const Component = props => {
         return <Fragment>
           <OtherComponent />
           <OtherComponent />
         </Fragment>;
       };
-    `);
+    `
+    );
   });
 });

--- a/test/decaffeinate_test.ts
+++ b/test/decaffeinate_test.ts
@@ -21,7 +21,8 @@ describe('decaffeinate', () => {
 describe('automatic conversions', () => {
   describe('inserting commas', () => {
     it('does not add commas after block comments', () => {
-      check(`
+      check(
+        `
         {
           a: b
           ###
@@ -29,7 +30,8 @@ describe('automatic conversions', () => {
           ###
           c: d
         }
-      `, `
+      `,
+        `
         ({
           a: b,
           /*
@@ -43,31 +45,37 @@ describe('automatic conversions', () => {
 
     describe('in objects', () => {
       it('inserts commas after properties if they are not there', () => {
-        check(`
+        check(
+          `
           {
             a: b
             c: d
           }
-        `, `
+        `,
+          `
           ({
             a: b,
             c: d
           });
-        `);
+        `
+        );
       });
 
       it('does not insert commas if there already is one', () => {
-        check(`
+        check(
+          `
           {
             a: b,
             c: d
           }
-        `, `
+        `,
+          `
           ({
             a: b,
             c: d
           });
-        `);
+        `
+        );
       });
 
       it('does not insert commas in single-line objects', () => {
@@ -75,59 +83,71 @@ describe('automatic conversions', () => {
       });
 
       it('inserts commas only for objects that end a line', () => {
-        check(`
+        check(
+          `
           {
             a: b, c: d
             e: f
             g: h
           }
-        `, `
+        `,
+          `
           ({
             a: b, c: d,
             e: f,
             g: h
           });
-        `);
+        `
+        );
       });
 
       it('inserts commas immediately after the element if followed by a comment', () => {
-        check(`
+        check(
+          `
           {
             a: b # hi!
             c: d
           }
-        `, `
+        `,
+          `
           ({
             a: b, // hi!
             c: d
           });
-        `);
+        `
+        );
       });
 
       it('inserts commas after shorthand properties', () => {
-        check(`
+        check(
+          `
           {
             a
             c
           }
-        `, `
+        `,
+          `
           ({
             a,
             c
           });
-        `);
+        `
+        );
       });
 
       it('inserts commas for braceless objects', () => {
-        check(`
+        check(
+          `
           a: b
           c: d
-        `, `
+        `,
+          `
           ({
             a: b,
             c: d
           });
-        `);
+        `
+        );
       });
     });
   });
@@ -142,16 +162,19 @@ describe('automatic conversions', () => {
     });
 
     it('does not add parentheses to objects that are implicit returns', () => {
-      check(`
+      check(
+        `
         ->
           a = 1
           {a}
-      `, `
+      `,
+        `
         (function() {
           const a = 1;
           return {a};
         });
-      `);
+      `
+      );
     });
 
     it('preserves statements on one line separated by a semicolon', () => {
@@ -159,13 +182,15 @@ describe('automatic conversions', () => {
     });
 
     it('handles object literals with function property values', () => {
-      check(`
+      check(
+        `
         a
           b: ->
             c
 
           d: 1
-      `, `
+      `,
+        `
         a({
           b() {
             return c;
@@ -173,18 +198,21 @@ describe('automatic conversions', () => {
 
           d: 1
         });
-      `);
+      `
+      );
     });
 
     it('handles object literals with function property values followed by comments', () => {
-      check(`
+      check(
+        `
         a
           b: ->
             c
 
         # FOO
         d e
-      `, `
+      `,
+        `
         a({
           b() {
             return c;
@@ -193,16 +221,19 @@ describe('automatic conversions', () => {
 
         // FOO
         d(e);
-      `);
+      `
+      );
     });
   });
 });
 
 describe('runToStage', () => {
   it('allows displaying the decaffeinate-parser AST', () => {
-    check(`
+    check(
+      `
       @a b
-    `, `
+    `,
+      `
       Program [1:1(0)-1:5(4)] {
         body: Block [1:1(0)-1:5(4)] {
           inline: false
@@ -224,22 +255,28 @@ describe('runToStage', () => {
           ]
         }
       }
-    `, {
-      options: {
-        runToStage: 'decaffeinate-parser',
+    `,
+      {
+        options: {
+          runToStage: 'decaffeinate-parser'
+        }
       }
-    });
+    );
   });
 
   it('allows running to an intermediate stage', () => {
-    check(`
+    check(
+      `
       @a b
-    `, `
+    `,
+      `
       @a(b)
-    `, {
-      options: {
-        runToStage: 'NormalizeStage',
+    `,
+      {
+        options: {
+          runToStage: 'NormalizeStage'
+        }
       }
-    });
+    );
   });
 });

--- a/test/declaration_test.ts
+++ b/test/declaration_test.ts
@@ -1,4 +1,4 @@
-import check, {checkCS1, checkCS2} from './support/check';
+import check, { checkCS1, checkCS2 } from './support/check';
 
 describe('declarations', () => {
   it('adds inline declarations for assignments as statements', () => {
@@ -6,80 +6,101 @@ describe('declarations', () => {
   });
 
   it('adds separate declarations for assignments as expressions', () => {
-    check(`
+    check(
+      `
       a(b = 1)
-    `, `
+    `,
+      `
       let b;
       a(b = 1);
-    `);
+    `
+    );
   });
 
   it('does not add declarations for subsequent assignments to the same binding', () => {
-    check(`
+    check(
+      `
       a = 1
       a = 2
-    `, `
+    `,
+      `
       let a = 1;
       a = 2;
-    `);
+    `
+    );
   });
 
   it('does not add declarations for assignments to a declared binding', () => {
-    check(`
+    check(
+      `
       (a) ->
         a = 1
-    `, `
+    `,
+      `
       a => a = 1;
-    `);
+    `
+    );
   });
 
   it('adds separate declarations at the top of the current scope if they cannot be inline', () => {
-    check(`
+    check(
+      `
       ->
         a = 1
-    `, `
+    `,
+      `
       (function() {
         let a;
         return a = 1;
       });
-    `);
+    `
+    );
   });
 
   it('does not add declarations for assignments to a binding if the parent scope defines the binding', () => {
-    check(`
+    check(
+      `
       a = 1
       ->
         a = 2
-    `, `
+    `,
+      `
       let a = 1;
       () => a = 2;
-    `);
+    `
+    );
   });
 
   it('adds declarations at the top of the block in which they are defined', () => {
-    check(`
+    check(
+      `
       if a
         if b
           c = 1
-    `, `
+    `,
+      `
       if (a) {
         if (b) {
           const c = 1;
         }
       }
-    `);
+    `
+    );
   });
 
   it('does not add multiple declarations when the assignment happens at the top of a block', () => {
-    check(`
+    check(
+      `
       if a = 1
         b
-    `, `
+    `,
+      `
       let a;
       if (a = 1) {
         b;
       }
-    `);
+    `
+    );
   });
 
   it('does not add variable declarations when the LHS is a member expression', () => {
@@ -96,49 +117,64 @@ describe('declarations', () => {
   });
 
   it('does not add variable declarations for destructuring array assignment with previously declared bindings', () => {
-    checkCS1(`
+    checkCS1(
+      `
       a = 1
       [a] = b
-    `, `
+    `,
+      `
       let a = 1;
       [a] = Array.from(b);
-    `);
-    checkCS2(`
+    `
+    );
+    checkCS2(
+      `
       a = 1
       [a] = b
-    `, `
+    `,
+      `
       let a = 1;
       [a] = b;
-    `);
+    `
+    );
   });
 
   it('wraps object destructuring that is not part of a variable declaration in parentheses', () => {
-    check(`
+    check(
+      `
       a = 1
       {a} = b
-    `, `
+    `,
+      `
       let a = 1;
       ({a} = b);
-    `);
+    `
+    );
   });
 
   it('does not add inline variable declarations when the destructuring is mixed', () => {
-    checkCS1(`
+    checkCS1(
+      `
       a = 1
       [a, b] = c
-    `, `
+    `,
+      `
       let b;
       let a = 1;
       [a, b] = Array.from(c);
-    `);
-    checkCS2(`
+    `
+    );
+    checkCS2(
+      `
       a = 1
       [a, b] = c
-    `, `
+    `,
+      `
       let b;
       let a = 1;
       [a, b] = c;
-    `);
+    `
+    );
   });
 
   it('adds pre-declarations when the assignment is in an expression context', () => {
@@ -154,14 +190,17 @@ describe('declarations', () => {
   });
 
   it('adds pre-declarations and regular declarations together properly', () => {
-    check(`
+    check(
+      `
       a = 1
       b = c = 2
-    `, `
+    `,
+      `
       let c;
       const a = 1;
       const b = (c = 2);
-    `);
+    `
+    );
   });
 
   it('uses let rather than const if specified', () => {

--- a/test/default_param_test.ts
+++ b/test/default_param_test.ts
@@ -4,7 +4,7 @@ describe('default params', () => {
   it('keeps default value with loose mode enabled', () => {
     check(`(a=2) ->`, `(function(a=2) {});`, {
       options: {
-        looseDefaultParams: true,
+        looseDefaultParams: true
       }
     });
   });
@@ -12,7 +12,7 @@ describe('default params', () => {
   it('ensures transforms happen on the default value in loose mode', () => {
     check(`(a=b c) ->`, `(function(a=b(c)) {});`, {
       options: {
-        looseDefaultParams: true,
+        looseDefaultParams: true
       }
     });
   });
@@ -20,7 +20,7 @@ describe('default params', () => {
   it('ensures @foo is transformed correctly in loose mode', () => {
     check(`(a=@b) ->`, `(function(a=this.b) {});`, {
       options: {
-        looseDefaultParams: true,
+        looseDefaultParams: true
       }
     });
   });
@@ -28,68 +28,82 @@ describe('default params', () => {
   it('patches value as an expression in loose mode', () => {
     check(`(a=b: c) ->`, `(function(a={b: c}) {});`, {
       options: {
-        looseDefaultParams: true,
+        looseDefaultParams: true
       }
     });
   });
 
   it('changes default params to conditional assignments by default', () => {
-    check(`
+    check(
+      `
       (a=b()) ->
         return
-    `, `
+    `,
+      `
       (function(a) {
         if (a == null) { a = b(); }
       });
-    `);
+    `
+    );
   });
 
   it('ensures transforms happen on the default value', () => {
-    check(`
+    check(
+      `
       (a=b c) ->
-    `, `
+    `,
+      `
       (function(a) {
         if (a == null) { a = b(c); }
       });
-    `);
+    `
+    );
   });
 
   it('handles a `this` assignment and a default param assignment in the same param', () => {
-    check(`
+    check(
+      `
       a = 3
       (@a=b()) ->
         console.log a
         return
-    `, `
+    `,
+      `
       const a = 3;
       (function(a1) {
         if (a1 == null) { a1 = b(); }
         this.a = a1;
         console.log(a);
       });
-    `);
+    `
+    );
   });
 
   it('handles a destructure with a default param', () => {
-    check(`
+    check(
+      `
       ({a}={}) ->
         return
-    `, `
+    `,
+      `
       (function(param) {
         if (param == null) { param = {}; }
         const {a} = param;
       });
-    `);
+    `
+    );
   });
 
   it('handles a multiline destructure with a default param with the expression indented', () => {
-    check(`
+    check(
+      `
       ->
         a = ({
           b,
         } = {}) ->
           return c
-    `, `
+    `,
+      `
       (function() {
         let a;
         return a = function(param) {
@@ -100,16 +114,19 @@ describe('default params', () => {
           return c;
         };
       });
-    `);
+    `
+    );
   });
 
   it('handles a multiline destructure with a default param', () => {
-    check(`
+    check(
+      `
       a = ({
         b,
       } = {}) ->
         return c
-    `, `
+    `,
+      `
       const a = function(param) {
         if (param == null) { param = {}; }
         const {
@@ -117,23 +134,30 @@ describe('default params', () => {
         } = param;
         return c;
       };
-    `);
+    `
+    );
   });
 
   it('handles a function as a default value (#729)', () => {
-    check(`
+    check(
+      `
       filter = (items, predicate = (-> true)) -> items.filter(predicate)
-    `, `
+    `,
+      `
       const filter = function(items, predicate) { if (predicate == null) { predicate = () => true; } return items.filter(predicate); };
-    `);
+    `
+    );
   });
 
   it('does not defensively convert default params that default to null', () => {
-    check(`
+    check(
+      `
       (a = null) ->
         console.log a
-    `, `
+    `,
+      `
       (a = null) => console.log(a);
-    `);
+    `
+    );
   });
 });

--- a/test/do_test.ts
+++ b/test/do_test.ts
@@ -5,7 +5,7 @@ describe('`do`', () => {
   it('becomes a normal call expression when not given a function expression', () => {
     check(`do foo`, `foo();`);
   });
-  
+
   it('creates an IIFE returning the last value', () => {
     check(`one = do -> 1`, `const one = (() => 1)();`);
   });
@@ -31,97 +31,125 @@ describe('`do`', () => {
   });
 
   it('create a multi-line IIFE', () => {
-    check(`
+    check(
+      `
       do (i, n=0) ->
         result = i + n
         result
-    `, `
+    `,
+      `
       (function(i, n) {
         const result = i + n;
         return result;
       })(i, 0);
-    `);
+    `
+    );
   });
 
   it('creates a multi-line IIFE surrounded by parentheses', () => {
-    check(`
+    check(
+      `
       (do ->
         a = 1
         b = a) + 1
-    `, `
+    `,
+      `
       ((function() {
         let b;
         const a = 1;
         return b = a;
       })()) + 1;
-    `);
+    `
+    );
   });
 
   it('allows an assignment within a do operation on a fat arrow function (#784)', () => {
-    check(`
+    check(
+      `
       do a = =>
         b
-    `, `
+    `,
+      `
       let a;
       (a = () => {
         return b;
       })();
-    `);
+    `
+    );
   });
 
   it('allows an assignment within a do operation with defaults (#637)', () => {
-    check(`
+    check(
+      `
       do a = (b = c, d) ->
         e
-    `, `
+    `,
+      `
       let a;
       (a = (b, d) => e)(c, d);
-    `);
+    `
+    );
   });
 
   it('properly converts do expressions on a normal assignment', () => {
-    check(`
+    check(
+      `
       do a = b
-    `, `
+    `,
+      `
       let a;
       (a = b)();
-    `);
+    `
+    );
   });
 
   it('properly converts negated do expressions', () => {
-    check(`
+    check(
+      `
       do !a
-    `, `
+    `,
+      `
       (!a)();
-    `);
+    `
+    );
   });
 
   it('places the function call properly for parenthesized do expressions', () => {
-    check(`
+    check(
+      `
       (do => 1)
-    `, `
+    `,
+      `
       (() => 1)();
-    `);
+    `
+    );
   });
 
   it('properly handles a complex nested do use case (#1189)', () => {
-    validate(`
+    validate(
+      `
       setTimeout = (f, n) -> f()
       arr = []
       for i in [0...5]
         setTimeout((do (i) => => arr.push(i)), 0);
       setResult(arr)
-    `, [0, 1, 2, 3, 4]);
+    `,
+      [0, 1, 2, 3, 4]
+    );
   });
 
   it('handles a do expression with trailing whitespace', () => {
-    check(`
+    check(
+      `
       do ->
         return b 
       
-    `, `
+    `,
+      `
       (() => b)();
       
-    `, {shouldStripIndent: false});
+    `,
+      { shouldStripIndent: false }
+    );
   });
 });

--- a/test/expansion_test.ts
+++ b/test/expansion_test.ts
@@ -1,212 +1,277 @@
-import check, {checkCS1, checkCS2} from './support/check';
-import validate, {validateCS1} from './support/validate';
+import check, { checkCS1, checkCS2 } from './support/check';
+import validate, { validateCS1 } from './support/validate';
 
 describe('expansion', () => {
   it('allows getting the last elements of an array', () => {
-    check(`
+    check(
+      `
       [..., a, b] = arr
-    `, `
+    `,
+      `
       const a = arr[arr.length - 2], b = arr[arr.length - 1];
-    `);
+    `
+    );
   });
 
   it('allows getting the first part and last elements of an array', () => {
-    check(`
+    check(
+      `
       [a..., b, c] = arr
-    `, `
+    `,
+      `
       const adjustedLength = Math.max(arr.length, 2),
         a = arr.slice(0, adjustedLength - 2),
         b = arr[adjustedLength - 2],
         c = arr[adjustedLength - 1];
-    `);
+    `
+    );
   });
 
   it('allows a rest destructure in the middle of an array', () => {
-    check(`
+    check(
+      `
       [a, b..., c] = arr
-    `, `
+    `,
+      `
       const a = arr[0],
         adjustedLength = Math.max(arr.length, 2),
         b = arr.slice(1, adjustedLength - 1),
         c = arr[adjustedLength - 1];
-    `);
+    `
+    );
   });
 
   it('does not generate special assignment code when the rest is at the end', () => {
-    checkCS1(`
+    checkCS1(
+      `
       [a, b, c...] = arr
-    `, `
+    `,
+      `
       const [a, b, ...c] = Array.from(arr);
-    `);
-    checkCS2(`
+    `
+    );
+    checkCS2(
+      `
       [a, b, c...] = arr
-    `, `
+    `,
+      `
       const [a, b, ...c] = arr;
-    `);
+    `
+    );
   });
 
   it('allows getting the last elements of a parameter list', () => {
-    checkCS1(`
+    checkCS1(
+      `
       (..., a, b) ->
-    `, `
+    `,
+      `
       (function(...args) {
         const a = args[args.length - 2], b = args[args.length - 1];
       });
-    `);
+    `
+    );
   });
 
   it('allows default params for expansion params', () => {
-    checkCS1(`
+    checkCS1(
+      `
       (..., a = 1) ->
-    `, `
+    `,
+      `
       (function(...args) {
         const val = args[args.length - 1], a = val != null ? val : 1;
       });
-    `);
+    `
+    );
   });
 
   it('allows this assignment for expansion params', () => {
-    checkCS1(`
+    checkCS1(
+      `
       (..., @a) ->
-    `, `
+    `,
+      `
       (function(...args) {
         this.a = args[args.length - 1];
       });
-    `);
+    `
+    );
   });
 
   it('does not create name conflicts in the expansion param case', () => {
-    checkCS1(`
+    checkCS1(
+      `
       a = 1
       (..., @a) ->
         console.log a
         return
-    `, `
+    `,
+      `
       const a = 1;
       (function(...args) {
         this.a = args[args.length - 1];
         console.log(a);
       });
-    `);
+    `
+    );
   });
 
   it('allows getting the initial array and last elements of a parameter list', () => {
-    check(`
+    check(
+      `
       (a..., b, c) ->
-    `, `
+    `,
+      `
       (function(...args) {
         const adjustedLength = Math.max(args.length, 2),
           a = args.slice(0, adjustedLength - 2),
           b = args[adjustedLength - 2],
           c = args[adjustedLength - 1];
       });
-    `);
+    `
+    );
   });
 
   it('is removed at the end of an array', () => {
-    checkCS1(`
+    checkCS1(
+      `
       [a, b, ...] = arr
-    `, `
+    `,
+      `
       const [a, b] = Array.from(arr);
-    `);
-    checkCS2(`
+    `
+    );
+    checkCS2(
+      `
       [a, b, ...] = arr
-    `, `
+    `,
+      `
       const [a, b] = arr;
-    `);
+    `
+    );
   });
 
   it('is removed at the end of a parameter list', () => {
-    check(`
+    check(
+      `
       (a, b, ...) ->
-    `, `
+    `,
+      `
       (function(a, b) {});
-    `);
+    `
+    );
   });
 
   it('converts rest params at the end to JS rest params', () => {
-    check(`
+    check(
+      `
       (a, b, c...) ->
-    `, `
+    `,
+      `
       (function(a, b, ...c) {});
-    `);
+    `
+    );
   });
 
   it('allows getting the first and last elements of an array', () => {
-    checkCS1(`
+    checkCS1(
+      `
       [a, b, ..., c, d] = arr
-    `, `
+    `,
+      `
       const a = arr[0], b = arr[1], c = arr[arr.length - 2], d = arr[arr.length - 1];
-    `);
+    `
+    );
   });
 
   it('allows getting the first and last elements of a parameter list', () => {
-    checkCS1(`
+    checkCS1(
+      `
       (a, b, ..., c, d) ->
-    `, `
+    `,
+      `
       (function(...args) {
         const a = args[0], b = args[1], c = args[args.length - 2], d = args[args.length - 1];
       });
-    `);
+    `
+    );
   });
 
   it('allows interior rest params, using the "rest" name', () => {
-    check(`
+    check(
+      `
       (a, b, c..., d, e) ->
-    `, `
+    `,
+      `
       (function(a, b, ...rest) {
         const adjustedLength = Math.max(rest.length, 2),
           c = rest.slice(0, adjustedLength - 2),
           d = rest[adjustedLength - 2],
           e = rest[adjustedLength - 1];
       });
-    `);
+    `
+    );
   });
 
   it('allows getting the first and last elements of a parameter list in a bound function', () => {
-    checkCS1(`
+    checkCS1(
+      `
       (a, b, ..., c, d) =>
-    `, `
+    `,
+      `
       (...args) => {
         const a = args[0], b = args[1], c = args[args.length - 2], d = args[args.length - 1];
       };
-    `);
+    `
+    );
   });
 
   it('handles an expansion node in a parameter array destructure', () => {
-    checkCS1(`
+    checkCS1(
+      `
       (a, [..., b], c) ->
         d
-    `, `
+    `,
+      `
       (function(a, ...rest) {
         const array = rest[0], b = array[array.length - 1], c = rest[1];
         return d;
       });
-    `);
+    `
+    );
   });
 
   it('handles a complex single argument', () => {
-    checkCS1(`
+    checkCS1(
+      `
       fn = ([a,b]) -> {a:a,b:b}
-    `, `
+    `,
+      `
       const fn = function(...args) { const [a,b] = Array.from(args[0]); return {a,b}; };
-    `);
-    checkCS2(`
+    `
+    );
+    checkCS2(
+      `
       fn = ([a,b]) -> {a:a,b:b}
-    `, `
+    `,
+      `
       const fn = ([a,b]) => ({a,b});
-    `);
+    `
+    );
   });
 
   it('handles a complex parameter list with varying indentation', () => {
-    checkCS1(`
+    checkCS1(
+      `
       f = (a, b, ..., {
         c,
         d,
         e,
       }) ->
         f
-    `, `
+    `,
+      `
       var f = function(...args) {
         const a = args[0], b = args[1], {
           c,
@@ -215,25 +280,31 @@ describe('expansion', () => {
         } = args[args.length - 1];
         return f;
       };
-    `);
+    `
+    );
   });
 
   it('allows getting elements from an unsafe-to-repeat list', () => {
-    checkCS1(`
+    checkCS1(
+      `
       [a, b, ..., c, d] = getArray()
-    `, `
+    `,
+      `
       const array = getArray(),
         a = array[0],
         b = array[1],
         c = array[array.length - 2],
         d = array[array.length - 1];
-    `);
+    `
+    );
   });
 
   it('allows getting elements and an intermediate rest from an unsafe-to-repeat list', () => {
-    check(`
+    check(
+      `
       [a, b, c..., d, e] = getArray()
-    `, `
+    `,
+      `
       const array = getArray(),
         a = array[0],
         b = array[1],
@@ -241,230 +312,314 @@ describe('expansion', () => {
         c = array.slice(2, adjustedLength - 2),
         d = array[adjustedLength - 2],
         e = array[adjustedLength - 1];
-    `);
+    `
+    );
   });
 
   it('handles expansions and object destructures', () => {
-    checkCS1(`
+    checkCS1(
+      `
       [..., {a, b}] = arr
-    `, `
+    `,
+      `
       const {a, b} = arr[arr.length - 1];
-    `);
+    `
+    );
   });
 
   it('handles expansions and object destructures with renaming', () => {
-    checkCS1(`
+    checkCS1(
+      `
       [..., {a: b, c: d}] = arr
-    `, `
+    `,
+      `
       const {a: b, c: d} = arr[arr.length - 1];
-    `);
+    `
+    );
   });
 
   it('handles nested expansions', () => {
-    checkCS1(`
+    checkCS1(
+      `
       [..., [..., a]] = arr
-    `, `
+    `,
+      `
       const array = arr[arr.length - 1], a = array[array.length - 1];
-    `);
+    `
+    );
   });
 
   it('handles a deeply-nested non-repeatable expression', () => {
-    checkCS1(`
+    checkCS1(
+      `
       [..., [..., a[b()]]] = arr
-    `, `
+    `,
+      `
       let array;
       array = arr[arr.length - 1], a[b()] = array[array.length - 1];
-    `);
+    `
+    );
   });
 
   it('handles an array destructure within a rest destructure', () => {
-    checkCS1(`
+    checkCS1(
+      `
       [a, [b]..., c] = arr
-    `, `
+    `,
+      `
       const a = arr[0],
         adjustedLength = Math.max(arr.length, 2),
         [b] = Array.from(arr.slice(1, adjustedLength - 1)),
         c = arr[adjustedLength - 1];
-    `);
+    `
+    );
   });
 
   it('handles an expansion and a default param', () => {
-    checkCS1(`
+    checkCS1(
+      `
       [..., a = 1] = arr
-    `, `
+    `,
+      `
       const val = arr[arr.length - 1], a = val != null ? val : 1;
-    `);
+    `
+    );
   });
 
   it('handles a this-assign with default in an object destructure', () => {
-    checkCS1(`
+    checkCS1(
+      `
       {@a = b} = c
-    `, `
+    `,
+      `
       let val;
       val = c.a, this.a = val != null ? val : b;
-    `);
-    checkCS2(`
+    `
+    );
+    checkCS2(
+      `
       {@a = b} = c
-    `, `
+    `,
+      `
       ({a: this.a = b} = c);
-    `);
+    `
+    );
   });
 
   it('handles a default destructure assign', () => {
-    checkCS1(`
+    checkCS1(
+      `
       {a = 1} = {}
-    `, `
+    `,
+      `
       const obj = {}, val = obj.a, a = val != null ? val : 1;
-    `);
-    checkCS2(`
+    `
+    );
+    checkCS2(
+      `
       {a = 1} = {}
-    `, `
+    `,
+      `
       ({a = 1} = {});
-    `);
+    `
+    );
   });
 
   it('handles a string key with a default assignment', () => {
-    checkCS1(`
+    checkCS1(
+      `
       {"#{a b}": c = d} = e
-    `, `
+    `,
+      `
       const val = e[\`\${a(b)}\`], c = val != null ? val : d;
-    `);
-    checkCS2(`
+    `
+    );
+    checkCS2(
+      `
       {"#{a b}": c = d} = e
-    `, `
+    `,
+      `
       ({[a(b)]: c = d} = e);
-    `);
+    `
+    );
   });
 
   it('has the right semantics for nested rest destructures', () => {
     // CS2 appears to be buggy in this case, at least 2.2.1 is.
-    validateCS1(`
+    validateCS1(
+      `
       arr = [1, 2, 3, 4, 5, 6]
       [a, [b, c..., d]..., e] = arr
       setResult(a + b + d + e + c.length)
-    `, 16);
+    `,
+      16
+    );
   });
 
   it('properly destructures array-like objects', () => {
-    validate(`
+    validate(
+      `
       arr = {length: 1, 0: 'Hello'}
       try
         [value] = arr
         setResult(value)
       catch
         setResult('Fails in CS2')
-    `, {cs1: 'Hello', cs2: 'Fails in CS2'});
+    `,
+      { cs1: 'Hello', cs2: 'Fails in CS2' }
+    );
   });
 
   it('properly destructures nested array-like objects', () => {
-    validate(`
+    validate(
+      `
       arr = {length: 1, 0: 'World'}
       try
         [[value]] = [arr]
         setResult(value)
       catch
         setResult('Fails in CS2')
-    `, {cs1: 'World', cs2: 'Fails in CS2'});
+    `,
+      { cs1: 'World', cs2: 'Fails in CS2' }
+    );
   });
 
   it('properly destructures array-like objects with an expansion destructure', () => {
-    validate(`
+    validate(
+      `
       arr = {length: 2, 0: 'Hello', 1: 'World'}
       [..., secondWord] = arr
       setResult(secondWord)
-    `, 'World');
+    `,
+      'World'
+    );
   });
 
   it('allows an empty destructure', () => {
-    validate(`
+    validate(
+      `
       setResult([] = 3)
-    `, 3);
+    `,
+      3
+    );
   });
 
   it('does not call Array.from for an empty destructure', () => {
-    check(`
+    check(
+      `
       [] = undefined
-    `, '');
+    `,
+      ''
+    );
   });
 
   it('does not call Array.from for an empty destructure of a non-repeatable value', () => {
-    check(`
+    check(
+      `
       [] = a()
-    `, `
+    `,
+      `
       const array = a();
-    `);
+    `
+    );
   });
 
   it('returns the RHS for a simple expression-style array destructure', () => {
-    validate(`
+    validate(
+      `
       b = [1, 2, 3]
       c = [a] = b
       setResult(b == c)
-    `, true);
+    `,
+      true
+    );
   });
 
   it('properly returns the RHS for a complex assignment', () => {
-    validate(`
+    validate(
+      `
       a = [1]
       o = [[]] = a
       setResult(o)
-    `, [1]);
+    `,
+      [1]
+    );
   });
 
   it('does not generate crashing code when doing a destructure on undefined', () => {
-    validate(`
+    validate(
+      `
       try
         {} = undefined
         setResult(true)
       catch
         setResult('Fails in CS2')
-    `, {cs1: true, cs2: 'Fails in CS2'});
+    `,
+      { cs1: true, cs2: 'Fails in CS2' }
+    );
   });
 
   it('handles an object default within an array rest', () => {
-    checkCS1(`
+    checkCS1(
+      `
       [{a = 1}...] = b
-    `, `
+    `,
+      `
       const obj = b.slice(0, b.length - 0), val = obj.a, a = val != null ? val : 1;
-    `);
+    `
+    );
   });
 
   it('handles expansion params with not enough values specified', () => {
     // https://github.com/decaffeinate/decaffeinate/issues/1283
-    validateCS1(`
+    validateCS1(
+      `
       f = (a, ..., b, c, d) ->
         return [a, b, c, d]
       setResult(f(1, 2))
-    `, [1, undefined, 1, 2]);
+    `,
+      [1, undefined, 1, 2]
+    );
   });
 
   it('handles an expansion destructure with not enough values specified', () => {
     // https://github.com/decaffeinate/decaffeinate/issues/1283
-    validateCS1(`
+    validateCS1(
+      `
       [a, ..., b, c, d] = [1, 2]
       setResult([a, b, c, d])
-    `, [1, undefined, 1, 2]);
+    `,
+      [1, undefined, 1, 2]
+    );
   });
 
   it('handles rest params with not enough values specified', () => {
-    validate(`
+    validate(
+      `
       f = (a, b..., c, d) ->
         return [a, b, c, d]
       setResult(f(1, 2))
-    `, [1, [], 2, undefined]);
+    `,
+      [1, [], 2, undefined]
+    );
   });
 
   it('handles a rest destructure with not enough values specified', () => {
-    validate(`
+    validate(
+      `
       [a, b..., c, d] = [1, 2]
       setResult([a, b, c, d])
-    `, [1, [], 2, undefined]);
+    `,
+      [1, [], 2, undefined]
+    );
   });
 
   it('handles nested rest after an array expansion ', () => {
-    checkCS2(`
+    checkCS2(
+      `
       [...,{a, r..., b = c}] = arr
-    `, `
+    `,
+      `
       const obj = arr[arr.length - 1],
         { a } = obj,
         r = __objectWithoutKeys__(obj, ['a', 'b']),
@@ -477,30 +632,39 @@ describe('expansion', () => {
         }
         return result;
       }
-    `);
+    `
+    );
   });
 
   it('emits JS object rest when possible ', () => {
-    checkCS2(`
+    checkCS2(
+      `
       [...,{a, r...}] = arr
-    `, `
+    `,
+      `
       const {a, ...r} = arr[arr.length - 1];
-    `);
+    `
+    );
   });
 
   it('allows array elisions', () => {
-    checkCS2(`
+    checkCS2(
+      `
       [a, , b] = [1, , 3]
-    `, `
+    `,
+      `
       let a, b;
       [a, , b] = [1, , 3];
-    `);
+    `
+    );
   });
 
   it('does not convert nested object rest operations to JS', () => {
-    checkCS2(`
+    checkCS2(
+      `
       {...{...a}} = b
-    `, `
+    `,
+      `
       const {...a} = __objectWithoutKeys__(b, []);
       function __objectWithoutKeys__(object, keys) {
         const result = {...object};
@@ -509,14 +673,18 @@ describe('expansion', () => {
         }
         return result;
       }
-    `);
+    `
+    );
   });
 
   it('allows array elisions in complex assignments', () => {
-    checkCS2(`
+    checkCS2(
+      `
       [a,,...,b] = arr
-    `, `
+    `,
+      `
       const a = arr[0], b = arr[arr.length - 1];
-    `);
+    `
+    );
   });
 });

--- a/test/function_call_test.ts
+++ b/test/function_call_test.ts
@@ -1,18 +1,21 @@
-import check, {checkCS1, checkCS2} from './support/check';
+import check, { checkCS1, checkCS2 } from './support/check';
 
 describe('function calls', () => {
   it('inserts commas after arguments if they are not there', () => {
-    check(`
+    check(
+      `
       a(
         1
         2
       )
-    `, `
+    `,
+      `
       a(
         1,
         2
       );
-    `);
+    `
+    );
   });
 
   it('does not insert commas in single-line calls', () => {
@@ -20,105 +23,132 @@ describe('function calls', () => {
   });
 
   it('inserts commas only for arguments that end a line', () => {
-    check(`
+    check(
+      `
       a(
         1, 2
         3, 4)
-    `, `
+    `,
+      `
       a(
         1, 2,
         3, 4);
-    `);
+    `
+    );
   });
 
   it('inserts commas immediately after the element if followed by a comment', () => {
-    check(`
+    check(
+      `
       a(
         1 # hi
         2
       )
-    `, `
+    `,
+      `
       a(
         1, // hi
         2
       );
-    `);
+    `
+    );
   });
 
   it('inserts commas on the same line when the property value is an interpolated string', () => {
-    check(`
+    check(
+      `
       a
         b: "#{c}"
         d: e
-    `, `
+    `,
+      `
       a({
         b: \`\${c}\`,
         d: e
       });
-    `);
+    `
+    );
   });
 
   it('works when the first argument is parenthesized', () => {
-    check(`
+    check(
+      `
       f (1+1),2+2
-    `, `
+    `,
+      `
       f((1+1),2+2);
-    `);
+    `
+    );
   });
 
   it('works when the last argument is parenthesized', () => {
-    check(`
+    check(
+      `
       f 1+1,(2+2)
-    `, `
+    `,
+      `
       f(1+1,(2+2));
-    `);
+    `
+    );
   });
 
   it('works with `new` when the first argument is parenthesized', () => {
-    check(`
+    check(
+      `
       a= new c ([b()])
-    `, `
+    `,
+      `
       const a= new c(([b()]));
-    `);
+    `
+    );
   });
 
   it('places parentheses in calls with multi-line function arguments after the closing brace', () => {
-    check(`
+    check(
+      `
       promise.then ->
         a()
         b # c
       d
-    `, `
+    `,
+      `
       promise.then(function() {
         a();
         return b;
       }); // c
       d;
-    `);
+    `
+    );
   });
 
   it('places parentheses in calls with single line that short hand into fat arrow function', () => {
-    check(`
+    check(
+      `
       promise.then (a)->
         b
       c
-    `, `
+    `,
+      `
       promise.then(a=> b);
       c;
-    `);
+    `
+    );
   });
 
   it.skip('preserves comments in functions that will become arrow functions', () => {
-    check(`
+    check(
+      `
       promise.then (a) ->
         b # c
       d
-    `, `
+    `,
+      `
       promise.then(a =>
         b // c
       );
       d;
-    `);
+    `
+    );
   });
 
   it('replaces the space between the callee and the first argument for first arg on same line', () => {
@@ -135,27 +165,33 @@ describe('function calls', () => {
   });
 
   it('works with a multi-line callee', () => {
-    check(`
+    check(
+      `
       x = (->
         1
       )()
-    `, `
+    `,
+      `
       const x = (() => 1)();
-    `);
+    `
+    );
   });
 
   it('works with a callee enclosed in parentheses and including a comment', () => {
-    check(`
+    check(
+      `
       (
         # HEY
         foo
       ) 0
-    `, `
+    `,
+      `
       (
         // HEY
         foo
       )(0);
-    `);
+    `
+    );
   });
 
   it('adds parens for nested function calls', () => {
@@ -175,28 +211,34 @@ describe('function calls', () => {
   });
 
   it.skip('adds parens without messing up multi-line calls', () => {
-    check(`
+    check(
+      `
       a
         b: c
-    `, `
+    `,
+      `
       a({
         b: c
       });
-    `);
+    `
+    );
   });
 
   it.skip('adds parens to multi-line calls with the right indentation', () => {
-    check(`
+    check(
+      `
       ->
         a
           b: c
-    `, `
+    `,
+      `
       (function() {
         return a({
           b: c
         });
       });
-    `);
+    `
+    );
   });
 
   it('converts rest params in function calls', () => {
@@ -204,72 +246,94 @@ describe('function calls', () => {
   });
 
   it('works when the entire span of arguments is replaced', () => {
-    check(`
+    check(
+      `
       a yes
-    `, `
+    `,
+      `
       a(true);
-    `);
+    `
+    );
   });
 
   it('works with a call that returns a function that is immediately called', () => {
-    check(`
+    check(
+      `
       a()()
-    `, `
+    `,
+      `
       a()();
-    `);
+    `
+    );
   });
 
   it('deletes trailing comma after the last argument', () => {
-    check(`
+    check(
+      `
       x(1,)
-    `, `
+    `,
+      `
       x(1);
-    `);
+    `
+    );
   });
 
   it('places the closing braces for a multi-line function argument', () => {
-    check(`
+    check(
+      `
       a(() ->
         0)
-    `, `
+    `,
+      `
       a(() => 0);
-    `);
+    `
+    );
   });
 
   it('keeps commas immediately after function applications', () => {
-    check(`
+    check(
+      `
       a(b(c), d)
-    `, `
+    `,
+      `
       a(b(c), d);
-    `);
+    `
+    );
   });
 
   it('puts the close-paren in a nice place for implicit calls on objects', () => {
-    check(`
+    check(
+      `
       a {
       }
-    `, `
+    `,
+      `
       a({
       });
-    `);
+    `
+    );
   });
 
   it('handles implicit calls nested in another function call', () => {
-    check(`
+    check(
+      `
       a(
         b {
         }
       )
-    `, `
+    `,
+      `
       a(
         b({
         })
       );
-    `);
+    `
+    );
   });
 
   it('handles implicit calls across OUTDENT tokens', () => {
-    check(`
+    check(
+      `
       a {
         b: ->
           return c d,
@@ -277,7 +341,8 @@ describe('function calls', () => {
               f
       }
       g
-    `, `
+    `,
+      `
       a({
         b() {
           return c(d,
@@ -287,15 +352,18 @@ describe('function calls', () => {
         }
       });
       g;
-    `);
+    `
+    );
   });
 
   it('handles a multi-line callback as the second arg within a function body (#412)', () => {
-    check(`
+    check(
+      `
       _authenticate: (authKey, cb) ->
         @_getSession authKey, (err, {person, user, authKey, org} = {}) ->
             return cb null, {person, authKey, user, org}
-    `, `
+    `,
+      `
       ({
           _authenticate(authKey, cb) {
             return this._getSession(authKey, function(err, param) {
@@ -307,47 +375,59 @@ describe('function calls', () => {
         });
         }
       });
-    `);
+    `
+    );
   });
 
   it('handles a multi-line callback ending in an object as the second arg (#410)', () => {
-    check(`
+    check(
+      `
       @server.on 'sioDisconnect', =>
         @_statuses = {}
-    `, `
+    `,
+      `
       this.server.on('sioDisconnect', () => {
         return this._statuses = {};
       });
-    `);
+    `
+    );
   });
 
   it('handles a multi-line explicit return callback as the second arg (#405)', () => {
-    check(`
+    check(
+      `
       Teacher.hasClass classId, () ->
         return cb null, {}
-    `, `
+    `,
+      `
       Teacher.hasClass(classId, () => cb(null, {}));
-    `);
+    `
+    );
   });
 
   it('handles unit test style multi-line callbacks (#379)', () => {
-    check(`
+    check(
+      `
       it "should foo", ->
         expect( bar ).to.eql [1]
-    `, `
+    `,
+      `
       it("should foo", () => expect( bar ).to.eql([1]));
-    `);
+    `
+    );
   });
 
   it('handles nested multi-line callbacks with inconsistent spacing (#370)', () => {
-    checkCS1(`
+    checkCS1(
+      `
       define [
       ], () ->
       
         somefunc 'something', ['something', (ContactService) ->
       
         ]
-    `, `
+    `,
+      `
       define([
       ], () =>
       
@@ -355,62 +435,77 @@ describe('function calls', () => {
       
         ])
       );
-    `);
+    `
+    );
   });
 
   it('handles a multi-line callback within a map call (#276)', () => {
-    check(`
+    check(
+      `
       (a) ->
         (a not in b.map(a, (e) -> 
           e)
         )
-    `, `
+    `,
+      `
       (function(a) {
         let needle;
         return ((needle = a, !Array.from(b.map(a, e => e)).includes(needle))
         );
       });
-    `);
+    `
+    );
   });
 
   it('handles soaked implicit function calls', () => {
-    check(`
+    check(
+      `
       a? b
-    `, `
+    `,
+      `
       if (typeof a === 'function') {
         a(b);
       }
-    `);
+    `
+    );
   });
 
   it.skip('handles soaked implicit new expressions', () => {
-    check(`
+    check(
+      `
       new A? b
-    `, `
+    `,
+      `
       __guardFunc__(A, f => new f(b));
       function __guardFunc__(func, transform) {
         return typeof func === 'function' ? transform(func) : undefined;
       }
-    `);
+    `
+    );
   });
 
   it('handles implicit calls ending in a postfix conditional (#479)', () => {
-    check(`
+    check(
+      `
       baz () =>
         foo if bar
-    `, `
+    `,
+      `
       baz(() => {
         if (bar) { return foo; }
       });
-    `);
+    `
+    );
   });
 
   it('handles nested implicit calls ending in a postfix conditional (#459)', () => {
-    check(`
+    check(
+      `
       define [], ->
         something: ->
           $.on 'click', assignThis if someCondition
-    `, `
+    `,
+      `
       define([], () =>
         ({
           something() {
@@ -418,44 +513,55 @@ describe('function calls', () => {
           }
         })
       );
-    `);
+    `
+    );
   });
 
   it('handles single-line implicit calls ending in a postfix conditional (#419)', () => {
-    check(`
+    check(
+      `
       @someMethod => 'returnValue' if condition
-    `, `
+    `,
+      `
       this.someMethod(() => { if (condition) { return 'returnValue'; } });
-    `);
+    `
+    );
   });
 
   it('handles simple implicit calls ending in a postfix conditional (#378)', () => {
-    check(`
+    check(
+      `
       a => b if c
-    `, `
+    `,
+      `
       a(() => { if (c) { return b; } });
-    `);
+    `
+    );
   });
 
-
   it('handles implicit method calls with a postfix conditional (#334)', () => {
-    check(`
+    check(
+      `
       a.then () ->
         b if c
-    `, `
+    `,
+      `
       a.then(function() {
         if (c) { return b; }
       });
-    `);
+    `
+    );
   });
 
   it('handles an implicit call with nested function expressions', () => {
-    check(`
+    check(
+      `
       a b, ->
         c: () ->
           if d
             e
-    `, `
+    `,
+      `
       a(b, () =>
         ({
           c() {
@@ -465,126 +571,150 @@ describe('function calls', () => {
           }
         })
       );
-    `);
+    `
+    );
   });
 
   it('handles an implicit call before a close-paren with different indentation', () => {
-    check(`
+    check(
+      `
       (a ->
         null
         )
-    `, `
+    `,
+      `
       a(() => null);
-    `);
+    `
+    );
   });
 
   it('handles an implicit call before a call end with different indentation', () => {
-    check(`
+    check(
+      `
       a(b, c ->
         null
         )
-    `, `
+    `,
+      `
       a(b, c(() => null));
-    `);
+    `
+    );
   });
 
   it('handles an implicit call at the end of an argument list of a multiline function call', () => {
-    check(`
+    check(
+      `
       x(
         if a
           b c
         if d
           e f
       )
-    `, `
+    `,
+      `
       x(
         a ?
           b(c) : undefined,
         d ?
           e(f) : undefined
       );
-    `);
+    `
+    );
   });
 
   it('handles an implicit call followed by an unnecessary comma in an array literal', () => {
-    check(`
+    check(
+      `
       [
         if a
           b c,
         if d
           e f
       ]
-    `, `
+    `,
+      `
       [
         a ?
           b(c) : undefined,
         d ?
           e(f) : undefined
       ];
-    `);
+    `
+    );
   });
 
   it('handles an implicit call followed by an unnecessary comma in a function call', () => {
-    check(`
+    check(
+      `
       x(
         if a
           b c,
         if d
           e f
       )
-    `, `
+    `,
+      `
       x(
         a ?
           b(c) : undefined,
         d ?
           e(f) : undefined
       );
-    `);
+    `
+    );
   });
 
   it('handles an implicit call followed by an unnecessary comma in an object literal', () => {
-    check(`
+    check(
+      `
       {
         x: if a
           b c,
         y: if d
           e f
       }
-    `, `
+    `,
+      `
       ({
         x: a ?
           b(c) : undefined,
         y: d ?
           e(f) : undefined
       });
-    `);
+    `
+    );
   });
 
   it('properly places implicit parens for multiline method calls', () => {
-    check(`
+    check(
+      `
       a
         .b(c, ->
           d
             .e f
         )
-    `, `
+    `,
+      `
       a
         .b(c, () =>
           d
             .e(f)
         );
-    `);
+    `
+    );
   });
 
   it('maintains CALL_END location for a nested dynamic member access', () => {
-    check(`
+    check(
+      `
       a ->
         for b in c
           if d
             e[f]
       
       g
-    `, `
+    `,
+      `
       a(() =>
         (() => {
           const result = [];
@@ -599,18 +729,21 @@ describe('function calls', () => {
         })());
       
       g;
-    `);
+    `
+    );
   });
 
   it('maintains CALL_END location around a nested conditional', () => {
-    check(`
+    check(
+      `
       a(->
         for b in c
           if d
             e)
       
       f
-    `, `
+    `,
+      `
       a(() =>
         (() => {
           const result = [];
@@ -625,129 +758,161 @@ describe('function calls', () => {
         })());
       
       f;
-    `);
+    `
+    );
   });
 
   it('allows semicolon delimiters between arguments', () => {
-    check(`
+    check(
+      `
       a(b, c; d, e;)
-    `, `
+    `,
+      `
       a(b, c, d, e);
-    `);
+    `
+    );
   });
 
   it('allows a trailing comma for an object in a function arg', () => {
-    check(`
+    check(
+      `
       a
         b: c,
       , d
-    `, `
+    `,
+      `
       a(
         {b: c}
       , d);
-    `);
+    `
+    );
   });
 
   it('properly inserts implicit parens within a block (#727)', () => {
-    check(`
+    check(
+      `
       launchMissile(->
         setTimeout (->
           launch()
         ), 5000
       )
-    `, `
+    `,
+      `
       launchMissile(() =>
         setTimeout((() => launch()), 5000)
       );
-    `);
+    `
+    );
   });
 
   it('properly inserts implicit parens in a nested call within a block', () => {
-    check(`
+    check(
+      `
       launchMissile(->
         1 + setTimeout (->
           launch()
         ), 5000
       )
-    `, `
+    `,
+      `
       launchMissile(() =>
         1 + setTimeout((() => launch()), 5000)
       );
-    `);
+    `
+    );
   });
 
   it('handles a function call on a multiline string surrounded by parens', () => {
-    check(`
+    check(
+      `
       a
       (
         a '
         '
       )
-    `, `
+    `,
+      `
       a;
       
         a(\`\\
       \`)
       ;
-    `);
+    `
+    );
   });
 
   it('handles a multiline implicit call followed by CALL_END', () => {
-    check(`
+    check(
+      `
       a(
         b c,
         d
       )
-    `, `
+    `,
+      `
       a(
         b(c,
         d)
       );
-    `);
+    `
+    );
   });
 
   it('handles a multiline implicit call with an object literal', () => {
-    check(`
+    check(
+      `
       a(
         b -> c {
         },
           d
       )
-    `, `
+    `,
+      `
       a(
         b(() => c({
         },
           d) )
       );
-    `);
+    `
+    );
   });
 
   it('wraps parens around comma-separated simple assignments in an argument position', () => {
-    checkCS1(`
+    checkCS1(
+      `
       a([b] = c)
-    `, `
+    `,
+      `
       let b;
       a(([b] = Array.from(c), c));
-    `);
-    checkCS2(`
+    `
+    );
+    checkCS2(
+      `
       a([b] = c)
-    `, `
+    `,
+      `
       let b;
       a(([b] = c));
-    `);
+    `
+    );
   });
 
   it('wraps parens around comma-separated complex assignments in an argument position', () => {
-    check(`
+    check(
+      `
       a([b, ..., c] = d)
-    `, `
+    `,
+      `
       let b, c;
       a((b = d[0], c = d[d.length - 1], d));
-    `);
+    `
+    );
   });
 
   it('properly handles a semicolon-terminated function followed by a comma', () => {
-    check(`
+    check(
+      `
       fn1((done) ->
         fn2('string', (object) ->
           ;
@@ -756,7 +921,8 @@ describe('function calls', () => {
           done(err)
         )
       )
-    `, `
+    `,
+      `
       fn1(done =>
         fn2('string', function(object) {
           }
@@ -765,14 +931,18 @@ describe('function calls', () => {
           return done(err);
         })
       );
-    `);
+    `
+    );
   });
 
   it('properly handles empty function expressions surrounded by parens', () => {
-    check(`
+    check(
+      `
       middleware.execute {}, (->), (->)
-    `, `
+    `,
+      `
       middleware.execute({}, (function() {}), (function() {}));
-    `);
+    `
+    );
   });
 });

--- a/test/function_test.ts
+++ b/test/function_test.ts
@@ -7,63 +7,79 @@ describe('functions', () => {
   });
 
   it('put the closing curly brace on a new line', () => {
-    check(`
+    check(
+      `
       ->
         0
         return 0
-    `, `
+    `,
+      `
       (function() {
         0;
         return 0;
       });
-    `);
+    `
+    );
   });
 
   it('put the closing curly brace on the same line if the original is a single line', () => {
-    check(`
+    check(
+      `
       -> 0; return 0
-    `, `
+    `,
+      `
       (function() { 0; return 0; });
-    `);
+    `
+    );
   });
 
   it('puts the closing curly brace before any trailing comments on the last statement in the body', () => {
-    check(`
+    check(
+      `
       ->
         0
         return 0 # hey
       b
-    `, `
+    `,
+      `
       (function() {
         0;
         return 0; // hey
       });
       b;
-    `);
+    `
+    );
   });
 
   it('puts the closing punctuation before trailing comments for one-line functions', () => {
-    check(`
+    check(
+      `
       -> 0; return 0 # b
-    `, `
+    `,
+      `
       (function() { 0; return 0; }); // b
-    `);
+    `
+    );
   });
 
   it('puts the closing punctuation before trailing comments for parentheses-wrapped functions', () => {
-    check(`
+    check(
+      `
       (->
         0
         return 0) # b
-    `, `
+    `,
+      `
       (function() {
         0;
         return 0;}); // b
-    `);
+    `
+    );
   });
 
   it('puts the closing punctuation after trailing comments for multi-line bodies', () => {
-    check(`
+    check(
+      `
       validExpirationDate = (month, year) ->
         today = new Date()
         fullYear = 2000 + parseInt(year)
@@ -73,7 +89,8 @@ describe('functions', () => {
           (fullYear isnt today.getFullYear() or month > today.getMonth()) # Date.month is 0 indexed
 
       module.exports = { validExpirationDate }
-    `, `
+    `,
+      `
       const validExpirationDate = function(month, year) {
         const today = new Date();
         const fullYear = 2000 + parseInt(year);
@@ -84,19 +101,23 @@ describe('functions', () => {
       };
 
       module.exports = { validExpirationDate };
-    `);
+    `
+    );
   });
 
   it('puts closing curly brace just inside loosely-wrapped function parens', () => {
-    check(`
+    check(
+      `
       (->
         @get('delegateEmail') or @get('email')
       ).property('delegateEmail', 'email')
-    `, `
+    `,
+      `
       (function() {
         return this.get('delegateEmail') || this.get('email');
       }).property('delegateEmail', 'email');
-    `);
+    `
+    );
   });
 
   it('handles fat arrow functions without a body', () => {
@@ -108,14 +129,17 @@ describe('functions', () => {
   });
 
   it('adds a block to fat arrow functions if their body is a block', () => {
-    check(`
+    check(
+      `
       add = (a, b) =>
         a + b
-    `, `
+    `,
+      `
       const add = (a, b) => {
         return a + b;
       };
-    `);
+    `
+    );
   });
 
   it('uses curly braces for fat arrow functions if the body is a sequence', () => {
@@ -127,52 +151,66 @@ describe('functions', () => {
   });
 
   it('turns fat arrow functions referencing `arguments` into regular functions with a `bind` call', () => {
-    check(`
+    check(
+      `
       => arguments[0]
-    `, `
+    `,
+      `
       (function() { return arguments[0]; }.bind(this));
-    `);
+    `
+    );
   });
 
   it('handles a nested conditional in a fat arrow function referencing arguments', () => {
-    check(`
+    check(
+      `
       a =>
         if b
           c arguments
-    `, `
+    `,
+      `
       a(function() {
         if (b) {
           return c(arguments);
         }
       }.bind(this));
-    `);
+    `
+    );
   });
 
   it('turns expression-style fat arrow functions referencing `arguments` into regular functions with a `bind` call', () => {
-    check(`
+    check(
+      `
       x = => arguments[0] + this
-    `, `
+    `,
+      `
       const x = function() { return arguments[0] + this; }.bind(this);
-    `);
+    `
+    );
   });
 
   it('turns fat arrow object methods referencing `arguments` into regular functions with a `bind` call', () => {
-    check(`
+    check(
+      `
       {
         x: => arguments[0] + this
       }
-    `, `
+    `,
+      `
       ({
         x: function() { return arguments[0] + this; }.bind(this)
       });
-    `);
+    `
+    );
   });
 
   it('turns fat arrow class methods referencing `arguments` into methods bound in the constructor', () => {
-    check(`
+    check(
+      `
       class A
         x: => arguments[0] + this
-    `, `
+    `,
+      `
       class A {
         constructor() {
           this.x = this.x.bind(this);
@@ -180,118 +218,151 @@ describe('functions', () => {
       
         x() { return arguments[0] + this; }
       }
-    `);
+    `
+    );
   });
 
   it('turns functions containing a `yield` statement into generator functions', () => {
-    check(`
+    check(
+      `
       -> yield fn()
-    `, `
+    `,
+      `
       (function*() { return yield fn(); });
-    `);
+    `
+    );
   });
 
   it('turns functions containing a `yield from` statement into generator functions', () => {
-    check(`
+    check(
+      `
       -> yield from fn()
-    `, `
+    `,
+      `
       (function*() { return yield* fn(); });
-    `);
+    `
+    );
   });
 
   it('wraps parens around yield in a normal expression context', () => {
-    check(`
+    check(
+      `
       -> 1 + yield 2
-    `, `
+    `,
+      `
       (function*() { return 1 + (yield 2); });
-    `);
+    `
+    );
   });
 
   it('wraps parens around yield* in a normal expression context', () => {
-    check(`
+    check(
+      `
       -> 1 + yield from 2
-    `, `
+    `,
+      `
       (function*() { return 1 + (yield* 2); });
-    `);
+    `
+    );
   });
 
   it('does not wrap parens around yield in an assignment', () => {
-    check(`
+    check(
+      `
       ->
         x = yield 2
         return x
-    `, `
+    `,
+      `
       (function*() {
         const x = yield 2;
         return x;
       });
-    `);
+    `
+    );
   });
 
   it('does not wrap parens around yield* in an assignment', () => {
-    check(`
+    check(
+      `
       ->
         x = yield from 2
         return x
-    `, `
+    `,
+      `
       (function*() {
         const x = yield* 2;
         return x;
       });
-    `);
+    `
+    );
   });
 
   it('does not wrap parens around yield in an explicit return', () => {
-    check(`
+    check(
+      `
       ->
         return yield 2
-    `, `
+    `,
+      `
       (function*() {
         return yield 2;
       });
-    `);
+    `
+    );
   });
 
   it('does not wrap parens around yield* in an explicit return', () => {
-    check(`
+    check(
+      `
       ->
         return yield from 2
-    `, `
+    `,
+      `
       (function*() {
         return yield* 2;
       });
-    `);
+    `
+    );
   });
 
   it('turns fat arrow function containing a `yield` statement into a generator function with bind', () => {
-    check(`
+    check(
+      `
       => yield fn()
-    `, `
+    `,
+      `
       (function*() { return yield fn(); }.bind(this));
-    `);
+    `
+    );
   });
 
   it('correctly handles fat arrow object function values containing yield ', () => {
-    check(`
+    check(
+      `
       {
         x: =>
           yield fn()
       }
-    `, `
+    `,
+      `
       ({
         x: function*() {
           return yield fn();
         }.bind(this)
       });
-    `);
+    `
+    );
   });
 
   it('correctly handles fat arrow class methods containing yield', () => {
-    check(`
+    check(
+      `
       class C
         x: =>
           yield fn()
-    `, `
+    `,
+      `
       class C {
         constructor() {
           this.x = this.x.bind(this);
@@ -301,40 +372,50 @@ describe('functions', () => {
           return yield fn();
         }
       }
-    `);
+    `
+    );
   });
 
   it('correctly handles `yield return` with an expression', () => {
-    check(`
+    check(
+      `
       ->
         yield return 3
-    `, `
+    `,
+      `
       (function*() {
         return 3;
       });
-    `);
+    `
+    );
   });
 
   it('correctly handles `yield return` without an expression', () => {
-    check(`
+    check(
+      `
       ->
         yield return
-    `, `
+    `,
+      `
       (function*() {
       });
-    `);
+    `
+    );
   });
 
   it('allows bare `yield`', () => {
-    check(`
+    check(
+      `
       ->
         yield
         return
-    `, `
+    `,
+      `
       (function*() {
         yield;
       });
-    `);
+    `
+    );
   });
 
   it('keeps function with a spread in braces', () => {
@@ -344,13 +425,14 @@ describe('functions', () => {
   it('keeps function with a single assignment as a parameter in braces in loose param mode', () => {
     check(`(args=false) =>`, `(args=false) => {};`, {
       options: {
-        looseDefaultParams: true,
+        looseDefaultParams: true
       }
     });
   });
 
   it('places the function end in the right place when ending in an implicit function call', () =>
-    check(`
+    check(
+      `
       A = {
         b: ->
           return c d,
@@ -358,7 +440,8 @@ describe('functions', () => {
               f
       }
       G
-    `, `
+    `,
+      `
       const A = {
         b() {
           return c(d,
@@ -367,197 +450,234 @@ describe('functions', () => {
         }
       };
       G;
-    `)
-  );
+    `
+    ));
 
   it('puts parens around an arrow function returning a single-element object', () =>
-    check(`
+    check(
+      `
       => {a: b}
-    `, `
+    `,
+      `
       () => ({a: b});
-    `)
-  );
+    `
+    ));
 
   it('puts parens around an arrow function returning a multi-element object', () =>
-    check(`
+    check(
+      `
       => {a: b, c: d}
-    `, `
+    `,
+      `
       () => ({a: b, c: d});
-    `)
-  );
+    `
+    ));
 
   it('properly closes a function as the only argument to a function', () =>
-    check(`
+    check(
+      `
       it ->
         a
         return
-    `, `
+    `,
+      `
       it(function() {
         a;
       });
-    `)
-  );
+    `
+    ));
 
   it('properly closes a function as the second argument to a function', () =>
-    check(`
+    check(
+      `
       it a, ->
         b
         return
-    `, `
+    `,
+      `
       it(a, function() {
         b;
       });
-    `)
-  );
+    `
+    ));
 
   it('handles functions that omit commas in the parameter list', () =>
-    check(`
+    check(
+      `
       (foo
       bar) ->
         return baz
-    `, `
+    `,
+      `
       (foo,
       bar) => baz;
-    `)
-  );
+    `
+    ));
 
   it('handles a this-assign parameter with a reserved word name', () =>
-    check(`
+    check(
+      `
       (@case) ->
-    `, `
+    `,
+      `
       (function(case1) {
         this.case = case1;
       });
-    `)
-  );
+    `
+    ));
 
   it('allows semicolon delimiters between parameters', () =>
-    check(`
+    check(
+      `
       (a, b; c, d;) ->
-    `, `
+    `,
+      `
       (function(a, b, c, d) {});
-    `)
-  );
+    `
+    ));
 
   it('handles a complex fat arrow function body starting with an open-brace', () =>
-    check(`
+    check(
+      `
       x => {a: 'b'}['a']
-    `, `
+    `,
+      `
       x(() => ({a: 'b'}['a']));
-    `)
-  );
+    `
+    ));
 
   it('handles a fat arrow function with an implicit object body', () =>
-    check(`
+    check(
+      `
       x => a: b
-    `, `
+    `,
+      `
       x(() => ({a: b}));
-    `)
-  );
+    `
+    ));
 
   it('handles nested functions surrounded in parens', () =>
-    check(`
+    check(
+      `
       (->
         a ->
           b ->
             c
       )
-    `, `
+    `,
+      `
       () =>
         a(() =>
           b(() => c))
       ;
-    `)
-  );
+    `
+    ));
 
   it('generates nice-looking code for a function call around an arrow function', () =>
-    check(`
+    check(
+      `
       f () =>
         a = 1
         a
-    `, `
+    `,
+      `
       f(() => {
         const a = 1;
         return a;
       });
-    `)
-  );
+    `
+    ));
 
   it('handles an arrow function argument that is wrapped in parens', () =>
-    check(`
+    check(
+      `
       a((=>
         b
       ))
-    `, `
+    `,
+      `
       a((() => {
         return b;
       }));
-    `)
-  );
+    `
+    ));
 
   it('handles an implicit return wrapped in multiline parens', () =>
-    check(`
+    check(
+      `
       -> (
         true
       )
-    `, `
+    `,
+      `
       () => true;
-    `)
-  );
+    `
+    ));
 
   it('has the correct result for an implicit return wrapped in multiline parens', () =>
-    validate(`
+    validate(
+      `
       f = -> (
         true
       )
       setResult(f())
-    `, true)
-  );
+    `,
+      true
+    ));
 
   it('does not overwrite outer variables when doing parameter array destructuring', () =>
-    validate(`
+    validate(
+      `
       x = 'original'
       f = ([x]) -> x
       f(['new'])
       setResult(x)
-    `, 'original')
-  );
+    `,
+      'original'
+    ));
 
   it('does not overwrite outer variables when doing parameter object destructuring', () =>
-    validate(`
+    validate(
+      `
       a = 1
       f = ({a} = {a: 2}) ->
         return
       f({a: 3})
       setResult(a)
-    `, 1)
-  );
+    `,
+      1
+    ));
 
   it('handles a default param and a parenthesized body', () =>
-    check(`
+    check(
+      `
       (a = 1) ->
         (a)
-    `, `
+    `,
+      `
       (function(a) {
         if (a == null) { a = 1; }
         return (a);
       });
-    `)
-  );
+    `
+    ));
 
   it('handles a function call with a lambda as the first arg', () =>
-    check(`
+    check(
+      `
       a ->
         b
       , c
-    `, `
+    `,
+      `
       a(() => b
       , c);
-    `)
-  );
+    `
+    ));
 
   it('applies proper variable scopes with sibling arrow functions (#1201)', () =>
-    check(`
+    check(
+      `
       () =>
         a = 1
         return
@@ -565,7 +685,8 @@ describe('functions', () => {
       () =>
         a = 2
         return
-    `, `
+    `,
+      `
       () => {
         const a = 1;
       };
@@ -573,27 +694,31 @@ describe('functions', () => {
       () => {
         const a = 2;
       };
-    `)
-  );
+    `
+    ));
 
   it('applies proper variable scopes with sibling blockless arrow functions (#1202)', () =>
-    check(`
+    check(
+      `
       () => a = 1
       () => a = 2
-    `, `
+    `,
+      `
       () => { let a;
       return a = 1; };
       () => { let a;
       return a = 2; };
-    `)
-  );
+    `
+    ));
 
   it('correctly handles scoping for an assignment in an inline arrow function', () =>
-    validate(`
+    validate(
+      `
       f = => a = 1
       a = 2
       f()
       setResult(a)
-    `, 2)
-  );
+    `,
+      2
+    ));
 });

--- a/test/implicit_return_test.ts
+++ b/test/implicit_return_test.ts
@@ -2,15 +2,18 @@ import check from './support/check';
 
 describe('implicit return', () => {
   it('is added for the last expression in a typical function', () => {
-    check(`
+    check(
+      `
       ->
         a = 1
-    `, `
+    `,
+      `
       (function() {
         let a;
         return a = 1;
       });
-    `);
+    `
+    );
   });
 
   it('is not added when one is already there', () => {
@@ -22,75 +25,93 @@ describe('implicit return', () => {
   });
 
   it('adds a return for the final expression in functions', () => {
-    check(`
+    check(
+      `
       ->
         1
         2
-    `, `
+    `,
+      `
       (function() {
         1;
         return 2;
       });
-    `);
+    `
+    );
   });
 
   it('is added for the last expression of a block-body bound function', () => {
-    check(`
+    check(
+      `
       =>
         1
-    `, `
+    `,
+      `
       () => {
         return 1;
       };
-    `);
+    `
+    );
   });
 
   it('is added for the last expression in a class method', () => {
-    check(`
+    check(
+      `
       class Foo
         a: ->
           1
-    `, `
+    `,
+      `
       class Foo {
         a() {
           return 1;
         }
       }
-    `);
+    `
+    );
   });
 
   it('is not added for the last expression in a class constructor method', () => {
-    check(`
+    check(
+      `
       class Foo
         constructor: ->
           @a = 1
-    `, `
+    `,
+      `
       class Foo {
         constructor() {
           this.a = 1;
         }
       }
-    `);
+    `
+    );
   });
 
   it('is not added for throws as the last statement', () => {
-    check(`
+    check(
+      `
       ->
         throw 1
-    `, `
+    `,
+      `
       (function() {
         throw 1;
       });
-    `);
+    `
+    );
 
     check(`-> throw 1`, `(function() { throw 1; });`);
   });
 
   it('adds it outside a conditional that turns into a ternary expression', () => {
-    check(`
+    check(
+      `
       -> if a then b else c
-    `, `
+    `,
+      `
       (function() { if (a) { return b; } else { return c; } });
-    `);
+    `
+    );
   });
 });

--- a/test/import_test.ts
+++ b/test/import_test.ts
@@ -2,134 +2,173 @@ import check from './support/check';
 
 describe('imports', () => {
   it('converts commonjs code to JS modules with named exports when specified', () => {
-    check(`
+    check(
+      `
       x = require('x');
       module.exports.y = 3;
-    `, `
+    `,
+      `
       import x from 'x';
       export let y = 3;
-    `, {
-      options: {
-        useJSModules: true,
-        looseJSModules: true,
-      },
-    });
+    `,
+      {
+        options: {
+          useJSModules: true,
+          looseJSModules: true
+        }
+      }
+    );
   });
 
   it('keeps commonjs by default', () => {
-    check(`
+    check(
+      `
       x = require('x');
       module.exports.y = 3;
-    `, `
+    `,
+      `
       const x = require('x');
       module.exports.y = 3;
-    `);
+    `
+    );
   });
 
   it('properly passes down function identifiers', () => {
-    check(`
+    check(
+      `
       x = require('x');
       foo()
       y = require('y');
       bar()
       z = require('z');
-    `, `
+    `,
+      `
       import x from 'x';
       foo();
       import y from 'y';
       bar();
       const z = require('z');
-    `, {
-      options: {
-        useJSModules: true,
-        safeImportFunctionIdentifiers: ['foo'],
-      },
-    });
+    `,
+      {
+        options: {
+          useJSModules: true,
+          safeImportFunctionIdentifiers: ['foo']
+        }
+      }
+    );
   });
 
   it('forces a default export by default', () => {
-    check(`
+    check(
+      `
       exports.a = b;
       exports.c = d;
-    `, `
+    `,
+      `
       let defaultExport = {};
       defaultExport.a = b;
       defaultExport.c = d;
       export default defaultExport;
-    `, {
-      options: {
-        useJSModules: true,
-      },
-    });
+    `,
+      {
+        options: {
+          useJSModules: true
+        }
+      }
+    );
   });
 
   it('handles ES module default import', () => {
-    check(`
+    check(
+      `
       import a from 'b'
-    `, `
+    `,
+      `
       import a from 'b';
-    `);
+    `
+    );
   });
 
   it('handles ES module namespace import', () => {
-    check(`
+    check(
+      `
       import * as a from 'b'
-    `, `
+    `,
+      `
       import * as a from 'b';
-    `);
+    `
+    );
   });
 
   it('handles ES module aliased named import', () => {
-    check(`
+    check(
+      `
       import {a as b, c} from 'd'
-    `, `
+    `,
+      `
       import {a as b, c} from 'd';
-    `);
+    `
+    );
   });
 
   it('handles ES module export binding list', () => {
-    check(`
+    check(
+      `
       export {a as b, c}
-    `, `
+    `,
+      `
       export {a as b, c};
-    `);
+    `
+    );
   });
 
   it('handles ES module default export', () => {
-    check(`
+    check(
+      `
       export default a b
-    `, `
+    `,
+      `
       export default a(b);
-    `);
+    `
+    );
   });
 
   it('handles ES module star export', () => {
-    check(`
+    check(
+      `
       export * from 'a'
-    `, `
+    `,
+      `
       export * from 'a';
-    `);
+    `
+    );
   });
 
   it('handles ES module assignment named export', () => {
-    check(`
+    check(
+      `
       export a = 1
-    `, `
+    `,
+      `
       export var a = 1;
-    `);
+    `
+    );
   });
 
   it('handles ES module class named export', () => {
-    check(`
+    check(
+      `
       export class A
         b: ->
           c
-    `, `
+    `,
+      `
       export class A {
         b() {
           return c;
         }
       }
-    `);
+    `
+    );
   });
 });

--- a/test/in_test.ts
+++ b/test/in_test.ts
@@ -3,238 +3,309 @@ import validate from './support/validate';
 
 describe('in operator', () => {
   it('handles the simple identifier case', () => {
-    check(`
+    check(
+      `
       a in b
-    `, `
+    `,
+      `
       Array.from(b).includes(a);
-    `);
+    `
+    );
   });
 
   it('skips Array.from in loose mode', () => {
-    check(`
+    check(
+      `
       a in b
-    `, `
+    `,
+      `
       b.includes(a);
-    `, {
-      options: {
-        looseIncludes: true,
+    `,
+      {
+        options: {
+          looseIncludes: true
+        }
       }
-    });
+    );
   });
 
   it('handles a property access as the LHS', () => {
-    check(`
+    check(
+      `
       a.b in c
-    `, `
+    `,
+      `
       Array.from(c).includes(a.b);
-    `);
+    `
+    );
   });
 
   it('wraps element in parentheses if needed in a function argument', () => {
-    check(`
+    check(
+      `
       a(b, c.d in e)
-    `, `
+    `,
+      `
       a(b, Array.from(e).includes(c.d));
-    `);
+    `
+    );
   });
 
   it('wraps list in parentheses if needed', () => {
-    check(`
+    check(
+      `
       a in b + c
-    `, `
+    `,
+      `
       Array.from(b + c).includes(a);
-    `);
+    `
+    );
   });
 
   it('works with a crazy case in an `if` statement', () => {
-    check(`
+    check(
+      `
       if a + b in c + d
         e
-    `, `
+    `,
+      `
       if (Array.from(c + d).includes(a + b)) {
         e;
       }
-    `);
+    `
+    );
   });
 
   it('works with negated `in`', () => {
-    check(`
+    check(
+      `
       a not in b
       a ! in b
       a !in b
-    `, `
+    `,
+      `
       !Array.from(b).includes(a);
       !Array.from(b).includes(a);
       !Array.from(b).includes(a);
-    `);
+    `
+    );
   });
 
   it('works with negated `in` in compound `or` expression', () => {
-    check(`
+    check(
+      `
       a or a not in b
-    `, `
+    `,
+      `
       a || !Array.from(b).includes(a);
-    `);
+    `
+    );
   });
 
   it('works with negated `in` in compound `and` expression', () => {
-    check(`
+    check(
+      `
       a and a not in b
-    `, `
+    `,
+      `
       a && !Array.from(b).includes(a);
-    `);
+    `
+    );
   });
 
   it('handles negation with `unless`', () => {
-    check(`
+    check(
+      `
       unless a in b
         c
-    `, `
+    `,
+      `
       if (!Array.from(b).includes(a)) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('handles negation with `if not`', () => {
-    check(`
+    check(
+      `
       if not (a in b)
         c
-    `, `
+    `,
+      `
       if (!(Array.from(b).includes(a))) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('handles double negation with `unless`', () => {
-    check(`
+    check(
+      `
       unless a not in b
         c
-    `, `
+    `,
+      `
       if (Array.from(b).includes(a)) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('uses includes without Array.from for literal arrays', () => {
-    check(`
+    check(
+      `
       if a in [yes, no]
         b
-    `, `
+    `,
+      `
       if ([true, false].includes(a)) {
         b;
       }
-    `);
+    `
+    );
   });
 
   it('uses includes without Array.from for literal arrays with negation', () => {
-    check(`
+    check(
+      `
       if a not in [yes, no]
         b
-    `, `
+    `,
+      `
       if (![true, false].includes(a)) {
         b;
       }
-    `);
+    `
+    );
   });
 
   it('uses includes for a single element', () => {
-    check(`
+    check(
+      `
       if a in [yes]
         b
-    `, `
+    `,
+      `
       if ([true].includes(a)) {
         b;
       }
-    `);
+    `
+    );
   });
 
   it('extracts a variable when the left side is not repeatable', () => {
-    check(`
+    check(
+      `
       if a() in [yes, no]
         b
-    `, `
+    `,
+      `
       let needle;
       if ((needle = a(), [true, false].includes(needle))) {
         b;
       }
-    `);
+    `
+    );
   });
 
   it('extracts a variable when the right side is not repeatable', () => {
-    check(`
+    check(
+      `
       a in b()
-    `, `
+    `,
+      `
       let needle;
       (needle = a, Array.from(b()).includes(needle));
-    `);
+    `
+    );
   });
 
   it('extracts a variable correctly for `not in` operations', () => {
-    check(`
+    check(
+      `
       a() not in b
-    `, `
+    `,
+      `
       let needle;
       (needle = a(), !Array.from(b).includes(needle));
-    `);
+    `
+    );
   });
 
   it('uses includes with complicated expressions in the array', () => {
-    check(`
+    check(
+      `
       if a in [b and c, +d]
         e
-    `, `
+    `,
+      `
       if ([b && c, +d].includes(a)) {
         e;
       }
-    `);
+    `
+    );
   });
 
   it('uses includes for empty arrays', () => {
-    check(`
+    check(
+      `
       if a in []
         b
-    `, `
+    `,
+      `
       if ([].includes(a)) {
         b;
       }
-    `);
+    `
+    );
   });
 
   it('evaluates the expressions in order', () => {
-    validate(`
+    validate(
+      `
       arr = []
       arr.push('first') in [arr.push('second')]
       setResult(arr)
-    `, ['first', 'second']);
+    `,
+      ['first', 'second']
+    );
   });
 
   it('handles an impure soak LHS', () => {
-    check(`
+    check(
+      `
       if a?.b() in c
         d
-    `, `
+    `,
+      `
       let needle;
       if ((needle = typeof a !== 'undefined' && a !== null ? a.b() : undefined, Array.from(c).includes(needle))) {
         d;
       }
-    `);
+    `
+    );
   });
 
   it('respects the noArrayIncludes option', () => {
-    check(`
+    check(
+      `
       a in b
-    `, `
+    `,
+      `
       __in__(a, b);
       function __in__(needle, haystack) {
         return Array.from(haystack).indexOf(needle) >= 0;
       }
-    `, {
-      options: {
-        noArrayIncludes: true,
+    `,
+      {
+        options: {
+          noArrayIncludes: true
+        }
       }
-    });
+    );
   });
 });

--- a/test/indentation_test.ts
+++ b/test/indentation_test.ts
@@ -18,47 +18,58 @@ describe('indentation', () => {
   });
 
   it('matches indentation when adding standalone lines', () => {
-    check(`if a\n\tswitch b\n\t\twhen c\n\t\t\td`, `if (a) {\n\tswitch (b) {\n\t\tcase c:\n\t\t\td;\n\t\t\tbreak;\n\t}\n}`);
+    check(
+      `if a\n\tswitch b\n\t\twhen c\n\t\t\td`,
+      `if (a) {\n\tswitch (b) {\n\t\tcase c:\n\t\t\td;\n\t\t\tbreak;\n\t}\n}`
+    );
   });
 
   it('handles valid inconsistent indentation', () => {
-    check(`
+    check(
+      `
       a ->
         return
        b
-    `, `
+    `,
+      `
       a(function() {
       });
       b;
-    `);
+    `
+    );
   });
 
   it('handles deeply nested inconsistent indentation', () => {
-    check(`
+    check(
+      `
       ->
         a
           .b =>
             return
           return 3
-    `, `
+    `,
+      `
       (function() {
         a
           .b(() => {
         });
         return 3;
       });
-    `);
+    `
+    );
   });
 
   it('handles a file with mixed tabs and spaces', () => {
-    check(`
+    check(
+      `
       while a
         b
       
       while c
       \tif d
       \t\te
-    `, `
+    `,
+      `
       while (a) {
         b;
       }
@@ -68,6 +79,7 @@ describe('indentation', () => {
       \t\te;
       \t}
       }
-    `);
+    `
+    );
   });
 });

--- a/test/instanceof_test.ts
+++ b/test/instanceof_test.ts
@@ -22,24 +22,30 @@ describe('instanceof', () => {
   });
 
   it('works with double-negated `instanceof`', () => {
-    check(`
+    check(
+      `
       unless a not instanceof b
         c
-    `, `
+    `,
+      `
       if (a instanceof b) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('works with instanceof that already has parens', () => {
-    check(`
+    check(
+      `
       if (a not instanceof b)
         c
-    `, `
+    `,
+      `
       if (!(a instanceof b)) {
         c;
       }
-    `);
+    `
+    );
   });
 });

--- a/test/literate_test.ts
+++ b/test/literate_test.ts
@@ -2,7 +2,8 @@ import check from './support/check';
 
 describe('literate mode', () => {
   it('handles a simple case', () => {
-    check(`
+    check(
+      `
       This is a *thing*.
       It doesn't do much.
       
@@ -13,7 +14,8 @@ describe('literate mode', () => {
           otherThing = for foo in stuff
             if foo % 2 == 0
               foo + 1
-    `, `
+    `,
+      `
       // This is a *thing*.
       // It doesn't do much.
       const thing = 1;
@@ -30,54 +32,65 @@ describe('literate mode', () => {
         }
         return result;
       })();
-    `, {
-      options: {
-        literate: true,
+    `,
+      {
+        options: {
+          literate: true
+        }
       }
-    });
+    );
   });
 
   it('handles a file starting with code and ending with a comment', () => {
-    check(`
+    check(
+      `
           a = 1
           b = 2
           c = 3
       Those are the first three letters of the alphabet.
-    `, `
+    `,
+      `
       const a = 1;
       const b = 2;
       const c = 3;
       // Those are the first three letters of the alphabet.
-    `, {
-      options: {
-        literate: true,
+    `,
+      {
+        options: {
+          literate: true
+        }
       }
-    });
+    );
   });
 
   it('requires a blank line before moving to a code section', () => {
-    check(`
+    check(
+      `
       I can
         indent
           all that I want
             and it still will be in a comment.
       
           exceptNow = true
-    `, `
+    `,
+      `
       // I can
       //   indent
       //     all that I want
       //       and it still will be in a comment.
       const exceptNow = true;
-    `, {
-      options: {
-        literate: true,
+    `,
+      {
+        options: {
+          literate: true
+        }
       }
-    });
+    );
   });
 
   it('handles increasing indentation across distinct code sections', () => {
-    check(`
+    check(
+      `
       This is a
       multiline comment.
       
@@ -92,7 +105,8 @@ describe('literate mode', () => {
       multiline comment.      
       
               c
-    `, `
+    `,
+      `
       // This is a
       // multiline comment.
       if (a) {
@@ -106,46 +120,60 @@ describe('literate mode', () => {
           c;
         }
       }
-    `, {
-      options: {
-        literate: true,
+    `,
+      {
+        options: {
+          literate: true
+        }
       }
-    });
+    );
   });
 
   it('treats normal coffee files as non-literate', () => {
-    check(`
+    check(
+      `
       a = 1
-    `, `
+    `,
+      `
       const a = 1;
-    `, {
-      options: {
-        filename: 'foo.coffee',
+    `,
+      {
+        options: {
+          filename: 'foo.coffee'
+        }
       }
-    });
+    );
   });
 
   it('treats .coffee.md files as literate', () => {
-    check(`
+    check(
+      `
       a = 1
-    `, `
+    `,
+      `
       // a = 1
-    `, {
-      options: {
-        filename: 'foo.coffee.md',
+    `,
+      {
+        options: {
+          filename: 'foo.coffee.md'
+        }
       }
-    });
+    );
   });
 
   it('treats .litcoffee files as literate', () => {
-    check(`
+    check(
+      `
       a = 1
-    `, `
+    `,
+      `
       // a = 1
-    `, {
-      options: {
-        filename: 'foo.litcoffee',
+    `,
+      {
+        options: {
+          filename: 'foo.litcoffee'
+        }
       }
-    });
+    );
   });
 });

--- a/test/logical_operator_test.ts
+++ b/test/logical_operator_test.ts
@@ -2,74 +2,98 @@ import check from './support/check';
 
 describe('`and` operator', () => {
   it('turns `and` into `&&`', () => {
-    check(`
+    check(
+      `
       a and b
-    `, `
+    `,
+      `
       a && b;
-    `);
+    `
+    );
   });
 
   it('leaves `&&` alone', () => {
-    check(`
+    check(
+      `
       a && b
-    `, `
+    `,
+      `
       a && b;
-    `);
+    `
+    );
   });
 
   it('works with equality-test operands', () => {
-    check(`
+    check(
+      `
       a is b and c is d
-    `, `
+    `,
+      `
       (a === b) && (c === d);
-    `);
+    `
+    );
   });
 
   it('turns into `||` when used in an `unless`', () => {
-    check(`
+    check(
+      `
       unless a && b
         c()
-    `, `
+    `,
+      `
       if (!a || !b) {
         c();
       }
-    `);
+    `
+    );
   });
 });
 
 describe('`or` operator', () => {
   it('turns `or` into `||`', () => {
-    check(`
+    check(
+      `
       a or b
-    `, `
+    `,
+      `
       a || b;
-    `);
+    `
+    );
   });
 
   it('leaves `||` alone', () => {
-    check(`
+    check(
+      `
       a || b
-    `, `
+    `,
+      `
       a || b;
-    `);
+    `
+    );
   });
 
   it('works with equality-test operands', () => {
-    check(`
+    check(
+      `
       a is b or c is d
-    `, `
+    `,
+      `
       (a === b) || (c === d);
-    `);
+    `
+    );
   });
 
   it('turns into `&&` when used in an `unless`', () => {
-    check(`
+    check(
+      `
       unless a || b
         c()
-    `, `
+    `,
+      `
       if (!a && !b) {
         c();
       }
-    `);
+    `
+    );
   });
 });

--- a/test/math_test.ts
+++ b/test/math_test.ts
@@ -2,82 +2,109 @@ import check from './support/check';
 
 describe('division', () => {
   it('is passed through', () => {
-    check(`
+    check(
+      `
       a / b
-    `, `
+    `,
+      `
       a / b;
-    `);
+    `
+    );
   });
 
   it('transforms left and right', () => {
-    check(`
+    check(
+      `
       (a b) / (c d)
-    `, `
+    `,
+      `
       (a(b)) / (c(d));
-    `);
+    `
+    );
   });
 });
 
 describe('multiplication', () => {
   it('is passed through', () => {
-    check(`
+    check(
+      `
       a * b
-    `, `
+    `,
+      `
       a * b;
-    `);
+    `
+    );
   });
 
   it('transforms left and right', () => {
-    check(`
+    check(
+      `
       (a b) * (c d)
-    `, `
+    `,
+      `
       (a(b)) * (c(d));
-    `);
+    `
+    );
   });
 });
 
 describe('remainder', () => {
   it('is passed through', () => {
-    check(`
+    check(
+      `
       a % b
-    `, `
+    `,
+      `
       a % b;
-    `);
+    `
+    );
   });
 
   it('transforms left and right', () => {
-    check(`
+    check(
+      `
       (a b) % (c d)
-    `, `
+    `,
+      `
       (a(b)) % (c(d));
-    `);
+    `
+    );
   });
 });
 
 describe('floor division', () => {
   it('wraps division in a `Math.floor` call', () => {
-    check(`
+    check(
+      `
       a // b
-    `, `
+    `,
+      `
       Math.floor(a / b);
-    `);
+    `
+    );
   });
 
   it('transforms left and right', () => {
-    check(`
+    check(
+      `
       (a b) // (c d)
-    `, `
+    `,
+      `
       Math.floor((a(b)) / (c(d)));
-    `);
+    `
+    );
   });
 });
 
 describe('exponentiation', () => {
   it('wraps exponentiation in a `Math.pow` call', () => {
-    check(`
+    check(
+      `
       (a b) ** (c d)
-    `, `
+    `,
+      `
       Math.pow((a(b)), (c(d)));
-    `);
+    `
+    );
   });
 });

--- a/test/member_access_test.ts
+++ b/test/member_access_test.ts
@@ -2,160 +2,208 @@ import check from './support/check';
 
 describe('member access', () => {
   it('allows dot-on-the-next-line style member access', () => {
-    check(`
+    check(
+      `
       a
         .b
-    `, `
+    `,
+      `
       a
         .b;
-    `);
+    `
+    );
   });
 
   it('allows dot-on-this-line-member-on-next-line style member access', () => {
-    check(`
+    check(
+      `
       a. # hello!
         b
-    `, `
+    `,
+      `
       a. // hello!
         b;
-    `);
+    `
+    );
   });
 
   it('allows dot-on-the-next-line style member access as a callee', () => {
-    check(`
+    check(
+      `
       a
         .b()
-    `, `
+    `,
+      `
       a
         .b();
-    `);
+    `
+    );
   });
 
   it('allows dot-on-the-next-line style member access as a callee with arguments', () => {
-    check(`
+    check(
+      `
       a
         .b(1, 2)
-    `, `
+    `,
+      `
       a
         .b(1, 2);
-    `);
+    `
+    );
   });
 
   it('allows chained dot-on-the-next-line style member access as a callee', () => {
-    check(`
+    check(
+      `
       a
         .b()
         .c()
-    `, `
+    `,
+      `
       a
         .b()
         .c();
-    `);
+    `
+    );
   });
 
   it('allows assignment to member expressions of functions', () => {
-    check(`
+    check(
+      `
       a.b = ->
-    `, `
+    `,
+      `
       a.b = function() {};
-    `);
+    `
+    );
   });
 
   it('wraps parens around number literals on the left side of a member access', () => {
-    check(`
+    check(
+      `
       1.toString()
-    `, `
+    `,
+      `
       (1).toString();
-    `);
+    `
+    );
   });
 
   it('does not wrap parens around number literals containing a dot', () => {
-    check(`
+    check(
+      `
       1.5.toString()
-    `, `
+    `,
+      `
       1.5.toString();
-    `);
+    `
+    );
   });
 
   it('transforms calling the result of a dynamic member access properly', () => {
-    check(`
+    check(
+      `
       a[b]()
-    `, `
+    `,
+      `
       a[b]();
-    `);
+    `
+    );
   });
 
   it('forces expressions in dynamic member access', () => {
-    check(`
+    check(
+      `
       a[if b then c else d]
-    `, `
+    `,
+      `
       a[b ? c : d];
-    `);
+    `
+    );
   });
 
   it('handles access to object constructed with multiline args 1', () => {
-    check(`
+    check(
+      `
       P -> 
         foo
       .then
-    `, `
+    `,
+      `
       P(() => foo).then;
-    `);
+    `
+    );
   });
 
   it('handles access to object constructed with multiline args 2', () => {
-    check(`
+    check(
+      `
       Q -> P -> 
         foo
       .then
-    `, `
+    `,
+      `
       Q(() => P(() => foo) ).then;
-    `);
+    `
+    );
   });
 
   it('handles access to object constructed with multiline args 3', () => {
-    check(`
+    check(
+      `
       Q -> P -> 
         foo
         
       .then
-    `, `
+    `,
+      `
       Q(() => P(() => foo) ).then;
-    `);
+    `
+    );
   });
 
   it('handles access to object constructed with multiline args 4', () => {
-    check(`
+    check(
+      `
       Q -> P ->
           foo
           
          .then
-    `, `
+    `,
+      `
       Q(() => P(() => foo) ).then;
-    `);
+    `
+    );
   });
 
   it('handles an implicit call wrapping a multiline function call and followed by a dot', () => {
-    check(`
+    check(
+      `
       a b(
         c)
         .d
-    `, `
+    `,
+      `
       a(b(
         c)).d;
-    `);
+    `
+    );
   });
 
   it('handles a complex implicit call wrapping a multiline function call and followed by a dot', () => {
-    check(`
+    check(
+      `
       a
         .b c(d,
           e)
         .f
-    `, `
+    `,
+      `
       a
         .b(c(d,
           e)).f;
-    `);
+    `
+    );
   });
 });

--- a/test/new_op_test.ts
+++ b/test/new_op_test.ts
@@ -2,104 +2,134 @@ import check from './support/check';
 
 describe('`new` operator', () => {
   it('inserts missing commas after arguments', () => {
-    check(`
+    check(
+      `
       new Serializer(
         a
         b
       )
-    `, `
+    `,
+      `
       new Serializer(
         a,
         b
       );
-    `);
+    `
+    );
   });
 
   it('inserts missing parentheses in a call with arguments', () => {
-    check(`
+    check(
+      `
       new Array 1
-    `, `
+    `,
+      `
       new Array(1);
-    `);
+    `
+    );
   });
 
   it('leaves missing parentheses off in a call with no arguments', () => {
-    check(`
+    check(
+      `
       new Object
-    `, `
+    `,
+      `
       new Object;
-    `);
+    `
+    );
   });
 
   it('does not add parentheses in complicated `new` expressions where it would be incorrect', () => {
-    check(`
+    check(
+      `
       new A().B
-    `, `
+    `,
+      `
       new A().B;
-    `);
+    `
+    );
   });
 
   it('inserts missing parentheses before an implicit object brace', () => {
-    check(`
+    check(
+      `
       new A
         a: a
         b: b
-    `, `
+    `,
+      `
       new A({
         a,
         b
       });
-    `);
+    `
+    );
   });
 
   it('defines proper bounds for new operators', () => {
-    check(`
+    check(
+      `
       new Construct a, 
         a: [
           'abc'
           'def'
         ]
-    `, `
+    `,
+      `
       new Construct(a, { 
         a: [
           'abc',
           'def'
         ]
       });
-    `);
+    `
+    );
   });
 
   it('allows `new` on regular functions', () => {
-    check(`
+    check(
+      `
       new -> a
-    `, `
+    `,
+      `
       (new (function() { return a; }));
-    `);
+    `
+    );
   });
 
   it('allows `new` on bound functions', () => {
     // Note that the resulting code crashes when run, which is a documented
     // correctness issue in decaffeinate.
-    check(`
+    check(
+      `
       new => a
-    `, `
+    `,
+      `
       new (() => a);
-    `);
+    `
+    );
   });
 
   it('wraps parens around an IIFE `try` used with `new`', () => {
-    check(`
+    check(
+      `
       new try Array
-    `, `
+    `,
+      `
       new ((() => { try { return Array; } catch (error) {} })());
-    `);
+    `
+    );
   });
 
   it('wraps parens around a `do` used with `new`', () => {
-    check(`
+    check(
+      `
       new do -> ->
-    `, `
+    `,
+      `
       new ((() => function() {})());
-    `);
+    `
+    );
   });
 });

--- a/test/newline_test.ts
+++ b/test/newline_test.ts
@@ -2,23 +2,14 @@ import check from './support/check';
 
 describe('newlines', () => {
   it('handles code with Windows newlines', () => {
-    check(
-      '->\r\n  if a\r\n    b\r\n  return\r\n',
-      '(function() {\r\n  if (a) {\r\n    b;\r\n  }\r\n});\r\n'
-    );
+    check('->\r\n  if a\r\n    b\r\n  return\r\n', '(function() {\r\n  if (a) {\r\n    b;\r\n  }\r\n});\r\n');
   });
 
   it('handles code with mixed newlines, preferring UNIX when there is a tie', () => {
-    check(
-      '->\r\n  if a\n    b\n  return\r\n',
-      '(function() {\n  if (a) {\n    b;\n  }\n});\n'
-    );
+    check('->\r\n  if a\n    b\n  return\r\n', '(function() {\n  if (a) {\n    b;\n  }\n});\n');
   });
 
   it('handles code with UNIX newlines', () => {
-    check(
-      '->\n  if a\n    b\n  return\n',
-      '(function() {\n  if (a) {\n    b;\n  }\n});\n'
-    );
+    check('->\n  if a\n    b\n  return\n', '(function() {\n  if (a) {\n    b;\n  }\n});\n');
   });
 });

--- a/test/object_test.ts
+++ b/test/object_test.ts
@@ -1,4 +1,4 @@
-import check, {checkCS2} from './support/check';
+import check, { checkCS2 } from './support/check';
 
 describe('objects', () => {
   it('adds parentheses around implicit bare object literals', () => {
@@ -10,239 +10,304 @@ describe('objects', () => {
   });
 
   it('adds curly braces immediately around a single-line object', () => {
-    check(`
+    check(
+      `
       a b: c, d: e
-    `, `
+    `,
+      `
       a({b: c, d: e});
-    `);
+    `
+    );
   });
 
   it('allows objects as conditional consequents', () => {
-    check(`
+    check(
+      `
       if a then { b: c }
-    `, `
+    `,
+      `
       if (a) { ({ b: c }); }
-    `);
+    `
+    );
   });
 
   it('allows objects as conditional alternates', () => {
-    check(`
+    check(
+      `
       if a then b else { c: d }
-    `, `
+    `,
+      `
       if (a) { b; } else { ({ c: d }); }
-    `);
+    `
+    );
   });
 
   it('inserts commas between object members if absent', () => {
-    check(`
+    check(
+      `
       ({
         a: b
         c: d
       })
-    `, `
+    `,
+      `
       ({
         a: b,
         c: d
       });
-    `);
+    `
+    );
   });
 
   it('indents and loosely wraps multi-line objects if needed', () => {
-    check(`
+    check(
+      `
       a: b,
       c: d
-    `, `
+    `,
+      `
       ({
         a: b,
         c: d
       });
-    `);
+    `
+    );
   });
 
   it('adds curly braces loosely around a nested object', () => {
-    check(`
+    check(
+      `
       a:
         b: c
-    `, `
+    `,
+      `
       ({
         a: {
           b: c
         }
       });
-    `);
+    `
+    );
   });
 
   it('adds curly braces inside a function call', () => {
-    check(`
+    check(
+      `
       a b,
         c: d
         e: f
-    `, `
+    `,
+      `
       a(b, {
         c: d,
         e: f
       }
       );
-    `);
+    `
+    );
   });
 
   it('uses concise methods for functions in objects', () => {
-    check(`
+    check(
+      `
       ({
         a: -> true
         b  :  -> false
       });
-    `, `
+    `,
+      `
       ({
         a() { return true; },
         b() { return false; }
       });
-    `);
+    `
+    );
   });
 
   it('converts methods for fat arrow functions in objects properly', () => {
-    check(`
+    check(
+      `
       ({
         a: => @true
         b  :  => @false
       });
-    `, `
+    `,
+      `
       ({
         a: () => this.true,
         b  :  () => this.false
       });
-    `);
+    `
+    );
   });
 
   it('does not use computed properties for method keys', () => {
-    check(`
+    check(
+      `
       ({
         'a': -> b
       })
-    `, `
+    `,
+      `
       ({
         'a'() { return b; }
       });
-    `);
+    `
+    );
   });
 
   it('does not use computed properties for string keys with non-function values', () => {
-    check(`
+    check(
+      `
       {
         'a': b
       }
-    `, `
+    `,
+      `
       ({
         'a': b
       });
-    `);
+    `
+    );
   });
 
   it('does not use computed properties for number keys', () => {
-    check(`
+    check(
+      `
       { 0: 1, 3.14: 0 }
-    `, `
+    `,
+      `
       ({ 0: 1, 3.14: 0 });
-    `);
+    `
+    );
   });
 
   it('handles quoted strings as keys', () => {
-    check(`
+    check(
+      `
       write 301, '', 'Location': pathname+'/'
-    `, `
+    `,
+      `
       write(301, '', {'Location': pathname+'/'});
-    `);
+    `
+    );
   });
 
   it('adds braces to implicit objects that are not the first argument', () => {
-    check(`
+    check(
+      `
       a b, c: d
-    `, `
+    `,
+      `
       a(b, {c: d});
-    `);
+    `
+    );
   });
 
   it('adds braces to implicit objects that are not the last argument', () => {
-    check(`
+    check(
+      `
       a b: c, d
-    `, `
+    `,
+      `
       a({b: c}, d);
-    `);
+    `
+    );
   });
 
   it('adds braces to implicit objects that are in the middle of the arguments', () => {
-    check(`
+    check(
+      `
       a b, c: d, e
-    `, `
+    `,
+      `
       a(b, {c: d}, e);
-    `);
+    `
+    );
   });
 
   it('does not add braces to explicit object arguments', () => {
-    check(`
+    check(
+      `
       a {b}, {c}, {d}
-    `, `
+    `,
+      `
       a({b}, {c}, {d});
-    `);
+    `
+    );
   });
 
   it('does not stick braces to opening parentheses for leading argument objects', () => {
-    check(`
+    check(
+      `
       a(
         b: c
         d
       )
-    `, `
+    `,
+      `
       a(
         {b: c},
         d
       );
-    `);
+    `
+    );
   });
 
   it('does not stick braces to closing parentheses for trailing argument objects', () => {
-    check(`
+    check(
+      `
       a(
         b
         c: d
       )
-    `, `
+    `,
+      `
       a(
         b,
         {c: d}
       );
-    `);
+    `
+    );
   });
 
   it('adds opening and closing braces in the right places for multi-line objects in function calls', () => {
-    check(`
+    check(
+      `
       a
         a: b
         c: d
-    `, `
+    `,
+      `
       a({
         a: b,
         c: d
       });
-    `);
+    `
+    );
   });
 
   it('transforms shorthand-this key-values to the appropriate key-value pair', () => {
-    check(`
+    check(
+      `
       {@a}
-    `, `
+    `,
+      `
       ({a: this.a});
-    `);
+    `
+    );
   });
 
   it('adds the curly braces at the right place for implicitly-returned objects', () => {
-    check(`
+    check(
+      `
       ->
         b = 1
         d = 2
         a: b
         c: d
-    `, `
+    `,
+      `
       (function() {
         const b = 1;
         const d = 2;
@@ -251,198 +316,252 @@ describe('objects', () => {
           c: d
         };
       });
-    `);
+    `
+    );
   });
 
   it('adds parentheses around an assignment whose LHS starts with an object', () => {
-    check(`
+    check(
+      `
       {a}.b = c
-    `, `
+    `,
+      `
       ({a}.b = c);
-    `);
+    `
+    );
   });
 
   it('expands shorthand string-key object members', () => {
-    check(`
+    check(
+      `
       x = {"FOO", "BAR", "BAZ"}
-    `, `
+    `,
+      `
       const x = {"FOO": "FOO", "BAR": "BAR", "BAZ": "BAZ"};
-    `);
+    `
+    );
   });
 
   it('expands shorthand string-key computed object members', () => {
-    check(`
+    check(
+      `
       x = {"a#{b}c"}
-    `, `
+    `,
+      `
       const x = {[\`a\${b}c\`]: \`a\${b}c\`};
-    `);
+    `
+    );
   });
 
   it('expands shorthand string-key computed object members with a non-repeatable interpolation', () => {
-    check(`
+    check(
+      `
       x = {"a#{b()}c"}
-    `, `
+    `,
+      `
       let ref;
       const x = {[ref = \`a\${b()}c\`]: ref};
-    `);
+    `
+    );
   });
 
   it('adds braces when implicit multi-line object is wrapped in parens', () => {
-    check(`
+    check(
+      `
       x = (
         a: b
         c: d
       )
-    `, `
+    `,
+      `
       const x = ({
         a: b,
         c: d
       });
-    `);
+    `
+    );
   });
 
   it('adds braces when explicitly returning an implicit multi-line object wrapped in parens', () => {
-    check(`
+    check(
+      `
       ->
         return (
           a: b
           c: d
         )
-    `, `
+    `,
+      `
       () =>
         ({
           a: b,
           c: d
         })
       ;
-    `);
+    `
+    );
   });
 
   it('adds braces when implicitly returning an implicit multi-line object wrapped in parens', () => {
-    check(`
+    check(
+      `
       ->
         (
           a: b
           c: d
         )
-    `, `
+    `,
+      `
       () =>
         ({
           a: b,
           c: d
         })
       ;
-    `);
+    `
+    );
   });
 
   it('adds brackets around template literals', () => {
-    check(`
+    check(
+      `
       {"a#{b}c": d}
-    `, `
+    `,
+      `
       ({[\`a\${b}c\`]: d});
-    `);
+    `
+    );
   });
 
   it('adds brackets around multiline herestrings', () => {
-    check(`
+    check(
+      `
       {"""a
       b""": c}
-    `, `
+    `,
+      `
       ({[\`a
       b\`]: c});
-    `);
+    `
+    );
   });
 
   it('special-cases template literals with only a single expression', () => {
-    check(`
+    check(
+      `
       {"#{a.b}": c}
-    `, `
+    `,
+      `
       ({[a.b]: c});
-    `);
+    `
+    );
   });
 
   it('handles methods where the function is surrounded by parens', () => {
-    check(`
+    check(
+      `
       x: (-> x)
-    `, `
+    `,
+      `
       ({x() { return x; }});
-    `);
+    `
+    );
   });
 
   it('handles an implicit object inside an array', () => {
-    check(`
+    check(
+      `
       [
         a: b
         c: d
       ]
-    `, `
+    `,
+      `
       [{
         a: b,
         c: d
       }
       ];
-    `);
+    `
+    );
   });
 
   it('allows semicolon delimiters between object values', () => {
-    check(`
+    check(
+      `
       {a: b, c: d; e: f, g: h;}
-    `, `
+    `,
+      `
       ({a: b, c: d, e: f, g: h,});
-    `);
+    `
+    );
   });
 
   it('handles implicit objects after an existence operator in an expression context', () => {
-    check(`
+    check(
+      `
       a = b ?
         c: d
         e: f
-    `, `
+    `,
+      `
       const a = typeof b !== 'undefined' && b !== null ? b : {
         c: d,
         e: f
       };
-    `);
+    `
+    );
   });
 
   it('handles implicit objects after an existence operator in a statement context', () => {
-    check(`
+    check(
+      `
       a ?
         b: c
         d: e
-    `, `
+    `,
+      `
       if (typeof a === 'undefined' || a === null) { ({
           b: c,
           d: e
         }); }
-    `);
+    `
+    );
   });
 
   it('handles nested implicit objects in a conditional expression', () => {
-    check(`
+    check(
+      `
       x = if count then {a: b: c} else {d: e: f}
-    `, `
+    `,
+      `
       const x = count ? {a: {b: c}} : {d: {e: f}};
-    `);
+    `
+    );
   });
 
   it('handles nested implicit objects in a conditional statement', () => {
-    check(`
+    check(
+      `
       if count then {a: b: c} else {d: e: f}
-    `, `
+    `,
+      `
       if (count) { ({a: {b: c}}); } else { ({d: {e: f}}); }
-    `);
+    `
+    );
   });
 
   it('handles an object with function values ending in semicolons', () => {
-    check(`
+    check(
+      `
       {
         a: ->
           b;
         c: ->
           d;
       }
-    `, `
+    `,
+      `
       ({
         a() {
           return b;
@@ -451,18 +570,21 @@ describe('objects', () => {
           return d;
         }
       });
-    `);
+    `
+    );
   });
 
   it('handles an object with parenthesized function values ending in semicolons', () => {
-    check(`
+    check(
+      `
       {
         a: ->
           (b);
         c: ->
           (d);
       }
-    `, `
+    `,
+      `
       ({
         a() {
           return (b);
@@ -471,11 +593,13 @@ describe('objects', () => {
           return (d);
         }
       });
-    `);
+    `
+    );
   });
 
   it('handles an object with semicolons on the next line', () => {
-    check(`
+    check(
+      `
       {
         a: ->
           b
@@ -484,7 +608,8 @@ describe('objects', () => {
           d
           ;
       }
-    `, `
+    `,
+      `
       ({
         a() {
           return b;
@@ -495,15 +620,18 @@ describe('objects', () => {
         }
           
       });
-    `);
+    `
+    );
   });
 
   it('handles nested objects with an inner statement ending in a semicolon', () => {
-    check(`
+    check(
+      `
       a:
         b: ->
           c;
-    `, `
+    `,
+      `
       ({
         a: {
           b() {
@@ -511,41 +639,50 @@ describe('objects', () => {
           }
         }
       });
-    `);
+    `
+    );
   });
 
   it('handles an object literal ending in a semicolon', () => {
-    check(`
+    check(
+      `
       o = 
         a: 1
         b: 2;
-    `, `
+    `,
+      `
       const o = { 
         a: 1,
         b: 2
       };
-    `);
+    `
+    );
   });
 
   it('handles an implicit object arg ending in a comma', () => {
-    check(`
+    check(
+      `
       a
         b: c,
-    `, `
+    `,
+      `
       a({
         b: c});
-    `);
+    `
+    );
   });
 
   it('correctly handles comma-separated implicit object args', () => {
-    check(`
+    check(
+      `
       somefunc 
         hey: 1,
         yo: 2,
       ,
         sup: 2,
         friend: 3
-    `, `
+    `,
+      `
       somefunc({ 
         hey: 1,
         yo: 2
@@ -555,43 +692,53 @@ describe('objects', () => {
         friend: 3
       }
       );
-    `);
+    `
+    );
   });
 
   it('allows complex CS2 computed property keys', () => {
-    checkCS2(`
+    checkCS2(
+      `
       o = {
         [a b]: c
       }
-    `, `
+    `,
+      `
       const o = {
         [a(b)]: c
       };
-    `);
+    `
+    );
   });
 
   it('allows simple shorthand computed property keys', () => {
-    checkCS2(`
+    checkCS2(
+      `
       o = {
         [a]
       }
-    `, `
+    `,
+      `
       const o = {
         [a]: a
       };
-    `);
+    `
+    );
   });
 
   it('allows complex shorthand computed property keys', () => {
-    checkCS2(`
+    checkCS2(
+      `
       o = {
         [a b]
       }
-    `, `
+    `,
+      `
       let ref;
       const o = {
         [ref = a(b)]: ref
       };
-    `);
+    `
+    );
   });
 });

--- a/test/of_test.ts
+++ b/test/of_test.ts
@@ -2,41 +2,53 @@ import check from './support/check';
 
 describe('of operator', () => {
   it('turns into an `in` operator', () => {
-    check(`
+    check(
+      `
       a of b
-    `, `
+    `,
+      `
       a in b;
-    `);
+    `
+    );
   });
 
   it('works in an expression context', () => {
-    check(`
+    check(
+      `
       a(b, c.d of e)
-    `, `
+    `,
+      `
       a(b, c.d in e);
-    `);
+    `
+    );
   });
 
   it('works with negated `of`', () => {
-    check(`
+    check(
+      `
       a not of b
       a !of b
       a ! of b
-    `, `
+    `,
+      `
       !(a in b);
       !(a in b);
       !(a in b);
-    `);
+    `
+    );
   });
 
   it('can be double negated', () => {
-    check(`
+    check(
+      `
       unless a not of b
         c
-    `, `
+    `,
+      `
       if (a in b) {
         c;
       }
-    `);
+    `
+    );
   });
 });

--- a/test/parameter_assignment_test.ts
+++ b/test/parameter_assignment_test.ts
@@ -2,54 +2,68 @@ import check from './support/check';
 
 describe('parameter assignment', () => {
   it('allows assigning as a typical local binding', () => {
-    check(`
+    check(
+      `
       (a) ->
-    `, `
+    `,
+      `
       (function(a) {});
-    `);
+    `
+    );
   });
 
   it('allows assigning to a `this` property', () => {
-    check(`
+    check(
+      `
       (@a) ->
-    `, `
+    `,
+      `
       (function(a) {
         this.a = a;
       });
-    `);
+    `
+    );
   });
 
   it('allows assigning to multiple `this` properties', () => {
-    check(`
+    check(
+      `
       (@a, @b) ->
-    `, `
+    `,
+      `
       (function(a, b) {
         this.a = a;
         this.b = b;
       });
-    `);
+    `
+    );
   });
 
   it('adds assignments to `this` properties before any function body', () => {
-    check(`
+    check(
+      `
       (@a, @b) ->
         @a + @b
-    `, `
+    `,
+      `
       (function(a, b) {
         this.a = a;
         this.b = b;
         return this.a + this.b;
       });
-    `);
+    `
+    );
   });
 
   it('does not clobber any variables declared in the function scope', () => {
-    check(`
+    check(
+      `
       a = 1
       (@a, @b) ->
         b = 2
         a + b
-    `, `
+    `,
+      `
       const a = 1;
       (function(a1, b1) {
         this.a = a1;
@@ -57,31 +71,37 @@ describe('parameter assignment', () => {
         const b = 2;
         return a + b;
       });
-    `);
+    `
+    );
   });
 
   it('inserts the assignments at the right indentation', () => {
-    check(`
+    check(
+      `
       if true
         (@a) ->
           @a
-    `, `
+    `,
+      `
       if (true) {
         (function(a) {
           this.a = a;
           return this.a;
         });
       }
-    `);
+    `
+    );
   });
 
   it('inserts all assignments with the right indentation', () => {
-    check(`
+    check(
+      `
       z()
 
       a: (@b) ->
           @b
-    `, `
+    `,
+      `
       z();
 
       ({
@@ -90,43 +110,53 @@ describe('parameter assignment', () => {
               return this.b;
           }
       });
-    `);
+    `
+    );
   });
 
   it('works as expected for struct-like class constructors', () => {
-    check(`
+    check(
+      `
       class Point
         constructor: (@x, @y) ->
-    `, `
+    `,
+      `
       class Point {
         constructor(x, y) {
           this.x = x;
           this.y = y;
         }
       }
-    `);
+    `
+    );
   });
 
   it('works with default parameters', () => {
-    check(`
+    check(
+      `
       (@a=1) ->
-    `, `
+    `,
+      `
       (function(a) {
         if (a == null) { a = 1; }
         this.a = a;
       });
-    `);
+    `
+    );
   });
 
   it('ensures parameters with default values are not redeclared', () => {
-    check(`
+    check(
+      `
       (a=0) ->
         a ?= 1
-    `, `
+    `,
+      `
       (function(a) {
         if (a == null) { a = 0; }
         return a != null ? a : (a = 1);
       });
-    `);
+    `
+    );
   });
 });

--- a/test/prototype_member_access_test.ts
+++ b/test/prototype_member_access_test.ts
@@ -18,20 +18,26 @@ describe('changing prototype member access into normal member access', () => {
   });
 
   it('allows getting a repeatable version of the prototype object', () => {
-    check(`
+    check(
+      `
       a():: ?= b
-    `, `
+    `,
+      `
       let base;
       if ((base = a()).prototype == null) { base.prototype = b; }
-    `);
+    `
+    );
   });
 
   it('is able to be made repeatable', () => {
-    check(`
+    check(
+      `
       a()::b ?= c
-    `, `
+    `,
+      `
       let base;
       if ((base = a()).prototype.b == null) { base.prototype.b = c; }
-    `);
+    `
+    );
   });
 });

--- a/test/range_test.ts
+++ b/test/range_test.ts
@@ -2,37 +2,51 @@ import check from './support/check';
 
 describe('range', () => {
   it('converts short literal array ranges to literal arrays', () => {
-    check(`
+    check(
+      `
       [0..20]
-    `, `
+    `,
+      `
       [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
-    `);
+    `
+    );
 
-    check(`
+    check(
+      `
       [2..0]
-    `, `
+    `,
+      `
       [2, 1, 0];
-    `);
+    `
+    );
   });
 
   it('converts short literal non-inclusive ranges to literal arrays', () => {
-    check(`
+    check(
+      `
       [0...20]
-    `, `
+    `,
+      `
       [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
-    `);
+    `
+    );
 
-    check(`
+    check(
+      `
       [2...0]
-    `, `
+    `,
+      `
       [2, 1];
-    `);
+    `
+    );
   });
 
   it('converts long literal array ranges to IIFEs for building at runtime', () => {
-    check(`
+    check(
+      `
       [0..100]
-    `, `
+    `,
+      `
       __range__(0, 100, true);
       function __range__(left, right, inclusive) {
         let range = [];
@@ -43,11 +57,14 @@ describe('range', () => {
         }
         return range;
       }
-    `);
+    `
+    );
 
-    check(`
+    check(
+      `
       [100..0]
-    `, `
+    `,
+      `
       __range__(100, 0, true);
       function __range__(left, right, inclusive) {
         let range = [];
@@ -58,13 +75,16 @@ describe('range', () => {
         }
         return range;
       }
-    `);
+    `
+    );
   });
 
   it('converts long literal non-inclusive array ranges to IIFEs for building at runtime', () => {
-    check(`
+    check(
+      `
       [0...100]
-    `, `
+    `,
+      `
       __range__(0, 100, false);
       function __range__(left, right, inclusive) {
         let range = [];
@@ -75,11 +95,14 @@ describe('range', () => {
         }
         return range;
       }
-    `);
+    `
+    );
 
-    check(`
+    check(
+      `
       [100...0]
-    `, `
+    `,
+      `
       __range__(100, 0, false);
       function __range__(left, right, inclusive) {
         let range = [];
@@ -90,13 +113,16 @@ describe('range', () => {
         }
         return range;
       }
-    `);
+    `
+    );
   });
 
   it('converts variable ranges to IIFEs for building at runtime', () => {
-    check(`
+    check(
+      `
       [a..b]
-    `, `
+    `,
+      `
       __range__(a, b, true);
       function __range__(left, right, inclusive) {
         let range = [];
@@ -107,13 +133,16 @@ describe('range', () => {
         }
         return range;
       }
-    `);
+    `
+    );
   });
 
   it('converts non-inclusive variable ranges to IIFEs for building at runtime', () => {
-    check(`
+    check(
+      `
       [a...b]
-    `, `
+    `,
+      `
       __range__(a, b, false);
       function __range__(left, right, inclusive) {
         let range = [];
@@ -124,13 +153,16 @@ describe('range', () => {
         }
         return range;
       }
-    `);
+    `
+    );
   });
 
   it('converts variable ranges with side-effects into IIFEs for building at runtime', () => {
-    check(`
+    check(
+      `
       [a()..b]
-    `, `
+    `,
+      `
       __range__(a(), b, true);
       function __range__(left, right, inclusive) {
         let range = [];
@@ -141,11 +173,14 @@ describe('range', () => {
         }
         return range;
       }
-    `);
+    `
+    );
 
-    check(`
+    check(
+      `
       [a..b()]
-    `, `
+    `,
+      `
       __range__(a, b(), true);
       function __range__(left, right, inclusive) {
         let range = [];
@@ -156,11 +191,14 @@ describe('range', () => {
         }
         return range;
       }
-    `);
+    `
+    );
 
-    check(`
+    check(
+      `
       [a()..b()]
-    `, `
+    `,
+      `
       __range__(a(), b(), true);
       function __range__(left, right, inclusive) {
         let range = [];
@@ -171,6 +209,7 @@ describe('range', () => {
         }
         return range;
       }
-    `);
+    `
+    );
   });
 });

--- a/test/regular_expression_test.ts
+++ b/test/regular_expression_test.ts
@@ -1,4 +1,4 @@
-import check, {checkCS1, checkCS2} from './support/check';
+import check, { checkCS1, checkCS2 } from './support/check';
 import validate from './support/validate';
 
 describe('regular expressions', () => {
@@ -15,17 +15,20 @@ describe('regular expressions', () => {
   });
 
   it('rewrites block regular expressions as a RegExp call with a multiline string', () => {
-    check(`
+    check(
+      `
       a = ///
         foo .*
         bar
       ///
-    `, `
+    `,
+      `
       const a = new RegExp(\`\\
       foo.*\\
       bar\\
       \`);
-    `);
+    `
+    );
   });
 
   it('preserves slash escapes in regular expressions', () => {
@@ -49,31 +52,37 @@ describe('regular expressions', () => {
   });
 
   it('handles interpolations within comments in heregexes in CS1', () => {
-    checkCS1(`
+    checkCS1(
+      `
       ///
         foo  # hello #{abc}d
         #{bar}
       ///g
-    `, `
+    `,
+      `
       new RegExp(\`\\
       foo\${abc}d\\
       \${bar}\\
       \`, 'g');
-    `);
+    `
+    );
   });
 
   it('handles interpolations within comments in heregexes in CS2', () => {
-    checkCS2(`
+    checkCS2(
+      `
       ///
         foo  # hello #{abc}d
         #{bar}
       ///g
-    `, `
+    `,
+      `
       new RegExp(\`\\
       foo\\
       \${bar}\\
       \`, 'g');
-    `);
+    `
+    );
   });
 
   it('allows escaping spaces in heregexes', () => {
@@ -81,144 +90,198 @@ describe('regular expressions', () => {
   });
 
   it('escapes \\u2028 within regexes', () => {
-    check(`
+    check(
+      `
       /\u2028/
-      `, `
+      `,
+      `
       /\\u2028/;
-    `);
+    `
+    );
   });
 
   it('escapes \\u2029 within regexes', () => {
-    check(`
+    check(
+      `
       /\u2029/
-      `, `
+      `,
+      `
       /\\u2029/;
-    `);
+    `
+    );
   });
 
   it('uses the existing escape character for escaped \\u2028 within regexes', () => {
-    check(`
+    check(
+      `
       /\\\u2028/
-      `, `
+      `,
+      `
       /\\u2028/;
-    `);
+    `
+    );
   });
 
   it('leaves an escaped backslash when an escaped backslash is followed by \\u2028 within regexes', () => {
-    check(`
+    check(
+      `
       /\\\\\u2028/
-      `, `
+      `,
+      `
       /\\\\\\u2028/;
-    `);
+    `
+    );
   });
 
   it('removes \\u2028 within heregexes', () => {
-    check(`
+    check(
+      `
       ///\u2028///
-      `, `
+      `,
+      `
       new RegExp(\`\`);
-    `);
+    `
+    );
   });
 
   it('removes \\u2029 within heregexes', () => {
-    check(`
+    check(
+      `
       ///\u2029///
-      `, `
+      `,
+      `
       new RegExp(\`\`);
-    `);
+    `
+    );
   });
 
   it('handles escaped \\u2028 within heregexes', () => {
-    check(`
+    check(
+      `
       ///\\\u2028///
-      `, `
+      `,
+      `
       new RegExp(\`\\u2028\`);
-    `);
+    `
+    );
   });
 
   it('handles escaped \\u2029 within heregexes', () => {
-    check(`
+    check(
+      `
       ///\\\u2029///
-      `, `
+      `,
+      `
       new RegExp(\`\\u2029\`);
-    `);
+    `
+    );
   });
 
   it('handles \\0 within heregexes', () => {
-    check(`
+    check(
+      `
       ///\\0///
-      `, `
+      `,
+      `
       new RegExp(\`\\\\x00\`);
-    `);
+    `
+    );
   });
 
   it('behaves correctly with \\0 within heregexes', () => {
-    validate(`
+    validate(
+      `
       setResult(///\\0 1///.test('\\0' + '1'))
-      `, true);
+      `,
+      true
+    );
   });
 
   it('handles a double backslash followed by a space', () => {
-    check(`
+    check(
+      `
       ///\\\\[\\\\ ]///
-      `, `
+      `,
+      `
       new RegExp(\`\\\\\\\\[\\\\\\\\]\`);
-    `);
+    `
+    );
   });
 
   it('replaces unicode code point escapes with regular unicode escapes in regexes', () => {
-    check(`
+    check(
+      `
       /\\u{a}/
-      `, `
+      `,
+      `
       /\\u000a/;
-    `);
+    `
+    );
   });
 
   it('replaces non-BMP unicode code point escapes with regular unicode escapes in regexes', () => {
-    check(`
+    check(
+      `
       /\\u{10000}/
-      `, `
+      `,
+      `
       /\\ud800\\udc00/;
-    `);
+    `
+    );
   });
 
   it('replaces heregex unicode code point escapes with regular unicode escapes', () => {
-    check(`
+    check(
+      `
       ///\\u{a}///
-      `, `
+      `,
+      `
       new RegExp(\`\\\\u000a\`);
-    `);
+    `
+    );
   });
 
   it('replaces heregex non-BMP unicode code point escapes with regular unicode escapes', () => {
-    check(`
+    check(
+      `
       ///\\u{10000}///
-      `, `
+      `,
+      `
       new RegExp(\`\\\\ud800\\\\udc00\`);
-    `);
+    `
+    );
   });
 
   it('does not downgrade unicode code point escapes when the "u" flag is specified', () => {
-    check(`
+    check(
+      `
       /\\u{a}/u
-      `, `
+      `,
+      `
       /\\u{a}/u;
-    `);
+    `
+    );
   });
 
   it('does not downgrade heregex unicode code point escapes when the "u" flag is specified', () => {
-    check(`
+    check(
+      `
       ///\\u{a}///u
-      `, `
+      `,
+      `
       new RegExp(\`\\\\u{a}\`, 'u');
-    `);
+    `
+    );
   });
 
   it('does not replace unicode when u is preceded by two backslashes', () => {
-    check(`
+    check(
+      `
       /\\\\u{a}/
-      `, `
+      `,
+      `
       /\\\\u{a}/;
-    `);
+    `
+    );
   });
 });

--- a/test/remainder_test.ts
+++ b/test/remainder_test.ts
@@ -6,18 +6,24 @@ describe('remainder', () => {
   });
 
   it('processes the left-hand expression', () => {
-    check(`
+    check(
+      `
       (a 0) % b
-    `, `
+    `,
+      `
       (a(0)) % b;
-    `);
+    `
+    );
   });
 
   it('processes its right-hand expression', () => {
-    check(`
+    check(
+      `
       a % (b 0)
-    `, `
+    `,
+      `
       a % (b(0));
-    `);
+    `
+    );
   });
 });

--- a/test/return_test.ts
+++ b/test/return_test.ts
@@ -2,107 +2,128 @@ import check from './support/check';
 
 describe('return', () => {
   it('works with a return value', () =>
-    check(`
+    check(
+      `
       -> a; return 1
-    `, `
+    `,
+      `
       (function() { a; return 1; });
-    `)
-  );
+    `
+    ));
 
   it('works without a return value', () =>
-    check(`
+    check(
+      `
       ->
         return if a
-    `, `
+    `,
+      `
       (function() {
         if (a) { return; }
       });
-    `)
-  );
+    `
+    ));
 
   it('forces the return value to be an expression', () =>
-    check(`
+    check(
+      `
       -> return (if true then null)
-    `, `
+    `,
+      `
       () => true ? null : undefined;
-    `)
-  );
+    `
+    ));
 
   it('preserves comments when removing trailing empty returns', () =>
-    check(`
+    check(
+      `
       ->
         a  # b
         return
-    `, `
+    `,
+      `
       (function() {
         a;  // b
       });
-    `)
-  );
+    `
+    ));
 
   it('correctly removes trailing empty returns on the same line as another statement', () =>
-    check(`
+    check(
+      `
       -> a; return
-    `, `
+    `,
+      `
       (function() { a; });
-    `)
-  );
+    `
+    ));
 
   it('correctly removes trailing empty returns as the only function statement', () =>
-    check(`
+    check(
+      `
       -> return
-    `, `
+    `,
+      `
       (function() {  });
-    `)
-  );
+    `
+    ));
 
   it('does not pull code into comments when followed by a trailing empty return', () => {
-    check(`
+    check(
+      `
       a () ->
         b  # comment
         return
       .c =>
         d
-    `, `
+    `,
+      `
       a(function() {
         b;  // comment
         }).c(() => {
         return d;
       });
-    `);
+    `
+    );
   });
 
   it('allows a top-level return', () =>
-    check(`
+    check(
+      `
       return a
-    `, `
+    `,
+      `
       return a;
-    `)
-  );
+    `
+    ));
 
   it('allows return surrounded by parens', () =>
-    check(`
+    check(
+      `
       ->
         (return)
         a
-    `, `
+    `,
+      `
       (function() {
         return;
         return a;
       });
-    `)
-  );
+    `
+    ));
 
   it('allows return surrounded by two sets of parens', () =>
-    check(`
+    check(
+      `
       ->
         ((return))
         a
-    `, `
+    `,
+      `
       (function() {
         return;
         return a;
       });
-    `)
-  );
+    `
+    ));
 });

--- a/test/semicolon_test.ts
+++ b/test/semicolon_test.ts
@@ -2,27 +2,33 @@ import check from './support/check';
 
 describe('semicolons', () => {
   it('are inserted after all the parentheses surrounding statements', () => {
-    check(`
+    check(
+      `
       ((->
         result)())
       a
-    `, `
+    `,
+      `
       (() => result)();
       a;
-    `);
+    `
+    );
   });
 
   it('are inserted after the closing function braces for a function expression', () => {
-    check(`
+    check(
+      `
       a = ->
         arguments # c
       d
-    `, `
+    `,
+      `
       const a = function() {
         return arguments; // c
       };
       d;
-    `);
+    `
+    );
   });
 
   it('adds them after call expressions as statements', () => {
@@ -50,65 +56,83 @@ describe('semicolons', () => {
   });
 
   it('does not add them after `if` statements', () => {
-    check(`
+    check(
+      `
       if a
         b
-    `, `
+    `,
+      `
       if (a) {
         b;
       }
-    `);
+    `
+    );
   });
 
   it('does not add them after `for` loops', () => {
-    check(`
+    check(
+      `
       for a in b
         a
-    `, `
+    `,
+      `
       for (let a of Array.from(b)) {
         a;
       }
-    `);
-    check(`
+    `
+    );
+    check(
+      `
       for a of b
         a
-    `, `
+    `,
+      `
       for (let a in b) {
         a;
       }
-    `);
+    `
+    );
   });
 
   it('does not add them after `while` loops', () => {
-    check(`
+    check(
+      `
       while a
         a
-    `, `
+    `,
+      `
       while (a) {
         a;
       }
-    `);
+    `
+    );
   });
 
   it('does not add them after `loop` loops', () => {
-    check(`
+    check(
+      `
       loop
         a
-    `, `
+    `,
+      `
       while (true) {
         a;
       }
-    `);
+    `
+    );
   });
 
   it('breaks what would otherwise be an unintended multi-line call', () => {
     // https://github.com/decaffeinate/decaffeinate/issues/65#issuecomment-182250564
-    check(`
+    check(
+      `
       x = 1
       -> 2
-    `, `
+    `,
+      `
       const x = 1;
       () => 2;
-    `);
+    `
+    );
   });
 });

--- a/test/sequence_test.ts
+++ b/test/sequence_test.ts
@@ -2,59 +2,74 @@ import check from './support/check';
 
 describe('sequences', () => {
   it('become JavaScript sequence expressions', () => {
-    check(`
+    check(
+      `
       -> return (a; b)
-    `, `
+    `,
+      `
       () => (a, b);
-    `);
+    `
+    );
   });
 
   it('that are nested become JavaScript sequence expressions', () => {
-    check(`
+    check(
+      `
       -> return (a; b; c)
-    `, `
+    `,
+      `
       () => (a, b, c);
-    `);
+    `
+    );
   });
-  
+
   it('handles newlines as separators', () => {
-    check(`
+    check(
+      `
       if a then (
         b
         c
       )
-    `, `
+    `,
+      `
       if (a) { 
         b;
         c
       ; }
-    `);
+    `
+    );
   });
 
   it('handles mixed semicolon and newline-separated sequence expressions', () => {
-    check(`
+    check(
+      `
       a
       (
         b; c
         d
       )
-    `, `
+    `,
+      `
       a;
       
         b; c;
         d
       ;
-    `);
+    `
+    );
   });
 
   it('handles a negated sequence operation', () => {
-    check(`
+    check(
+      `
       unless (a; b)
         c
-    `, `
+    `,
+      `
       if (!(a, b)) {
         c;
       }
-    `);
+    `
+    );
   });
 });

--- a/test/slice_test.ts
+++ b/test/slice_test.ts
@@ -46,150 +46,204 @@ describe('slice', () => {
   });
 
   it('treats the left side as an expression', () => {
-    check(`
+    check(
+      `
       a = (b for c in d when e)[...2]
-    `, `
+    `,
+      `
       const a = (Array.from(d).filter((c) => e).map((c) => b)).slice(0, 2);
-    `);
+    `
+    );
   });
 
   it('properly handles string bounds in an inclusive range', () => {
-    validate(`
+    validate(
+      `
       a = [1, 2, 3, 4, 5]
       start = '1'
       end = '3'
       setResult(a[start..end])
-    `, [2, 3, 4]);
+    `,
+      [2, 3, 4]
+    );
   });
 
   it('does not generate a preincrement operator when adding `+` to an inclusive end', () => {
-    check(`
+    check(
+      `
       a[start..+end]
-    `, `
+    `,
+      `
       a.slice(start, + +end + 1 || undefined);
-    `);
+    `
+    );
   });
 
   it('handles an exclusive splice with both bounds specified', () => {
-    check(`
+    check(
+      `
       a[b...c] = d
-    `, `
+    `,
+      `
       a.splice(b, c - b, ...[].concat(d));
-    `);
+    `
+    );
   });
 
   it('handles an inclusive splice with both bounds specified', () => {
-    check(`
+    check(
+      `
       a[b..c] = d
-    `, `
+    `,
+      `
       a.splice(b, c - b + 1, ...[].concat(d));
-    `);
+    `
+    );
   });
 
   it('handles an exclusive splice with the first bound specified', () => {
-    check(`
+    check(
+      `
       a[b...] = c
-    `, `
+    `,
+      `
       a.splice(b, 9e9, ...[].concat(c));
-    `);
+    `
+    );
   });
 
   it('handles an inclusive splice with the first bound specified', () => {
-    check(`
+    check(
+      `
       a[b..] = c
-    `, `
+    `,
+      `
       a.splice(b, 9e9, ...[].concat(c));
-    `);
+    `
+    );
   });
 
   it('handles an exclusive splice with the last bound specified', () => {
-    check(`
+    check(
+      `
       a[...b] = c
-    `, `
+    `,
+      `
       a.splice(0, b, ...[].concat(c));
-    `);
+    `
+    );
   });
 
   it('handles an inclusive splice with the last bound specified', () => {
-    check(`
+    check(
+      `
       a[..b] = c
-    `, `
+    `,
+      `
       a.splice(0, b + 1, ...[].concat(c));
-    `);
+    `
+    );
   });
 
   it('handles an exclusive splice over an unbounded range', () => {
-    check(`
+    check(
+      `
       a[...] = b
-    `, `
+    `,
+      `
       a.splice(0, 9e9, ...[].concat(b));
-    `);
+    `
+    );
   });
 
   it('handles an inclusive splice over an unbounded range', () => {
-    check(`
+    check(
+      `
       a[..] = b
-    `, `
+    `,
+      `
       a.splice(0, 9e9, ...[].concat(b));
-    `);
+    `
+    );
   });
 
   it('does not extract the RHS if it is not necessary', () => {
-    check(`
+    check(
+      `
       a[b..c] = d()
-    `, `
+    `,
+      `
       a.splice(b, c - b + 1, ...[].concat(d()));
-    `);
+    `
+    );
   });
 
   it('extracts the array into a variable if necessary', () => {
-    check(`
+    check(
+      `
       =>
         return a[b...c] = d()
-    `, `
+    `,
+      `
       () => {
         let ref;
         return ref = d(), a.splice(b, c - b, ...[].concat(ref)), ref;
       };
-    `);
+    `
+    );
   });
 
   it('allows overwriting with an array', () => {
-    validate(`
+    validate(
+      `
       arr = ['a', 'b', 'c', 'd']
       arr[1...3] = ['Hello', 'World']
       setResult(arr)
-    `, ['a', 'Hello', 'World', 'd']);
+    `,
+      ['a', 'Hello', 'World', 'd']
+    );
   });
 
   it('allows overwriting with an individual element', () => {
-    validate(`
+    validate(
+      `
       arr = ['a', 'b', 'c', 'd']
       arr[1...3] = 'Hello';
       setResult(arr)
-    `, ['a', 'Hello', 'd']);
+    `,
+      ['a', 'Hello', 'd']
+    );
   });
 
   it('respects precedence on slice ranges', () => {
-    check(`
+    check(
+      `
       a[b..c or d]
-    `, `
+    `,
+      `
       a.slice(b, +(c || d) + 1 || undefined);
-    `);
+    `
+    );
   });
 
   it('respects precedence on splice ranges', () => {
-    check(`
+    check(
+      `
       a[b..c or d] = e
-    `, `
+    `,
+      `
       a.splice(b, (c || d) - b + 1, ...[].concat(e));
-    `);
+    `
+    );
   });
 
   it('behaves properly when there is a logical operator in a slice range', () => {
-    validate(`
+    validate(
+      `
       a = [1..4]
       setResult(a[..2 or 3])
-    `, [1, 2, 3]);
+    `,
+      [1, 2, 3]
+    );
   });
 });

--- a/test/soaked_test.ts
+++ b/test/soaked_test.ts
@@ -4,13 +4,10 @@ import validate from './support/validate';
 function checkSoak(input: string, expectedOutput: string, expectedOptionalChainingOutput: string): void {
   check(input, expectedOutput);
   try {
-    check(input, expectedOptionalChainingOutput, {options: {useOptionalChaining: true}});
+    check(input, expectedOptionalChainingOutput, { options: { useOptionalChaining: true } });
   } catch (e) {
     // Ignore some failures for now: https://github.com/decaffeinate/decaffeinate/issues/1281
-    if (
-      !e.message.includes('EsnextStage failed to parse') &&
-      !e.message.includes('Invalid left-hand side')
-    ) {
+    if (!e.message.includes('EsnextStage failed to parse') && !e.message.includes('Invalid left-hand side')) {
       throw e;
     }
   }
@@ -20,7 +17,7 @@ function checkSoak(input: string, expectedOutput: string, expectedOptionalChaini
 function validateSoak(source: string, expectedOutput: any): void {
   validate(source, expectedOutput);
   try {
-    validate(source, expectedOutput, {options: {useOptionalChaining: true}, skipNodeCheck: true});
+    validate(source, expectedOutput, { options: { useOptionalChaining: true }, skipNodeCheck: true });
   } catch (e) {
     // Ignore some failures for now: https://github.com/decaffeinate/decaffeinate/issues/1281
     if (!e.message.includes('EsnextStage failed to parse')) {
@@ -32,91 +29,117 @@ function validateSoak(source: string, expectedOutput: any): void {
 describe('soaked expressions', () => {
   describe('function application', () => {
     it('works with a basic function', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a = null
         a?()
-      `, `
+      `,
+        `
         const a = null;
         if (typeof a === 'function') {
           a();
         }
-      `, `
+      `,
+        `
         const a = null;
         a?.();
-      `);
+      `
+      );
     });
 
     it('works with a function that is not safe to repeat', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a()?()
-      `, `
+      `,
+        `
         __guardFunc__(a(), f => f());
         function __guardFunc__(func, transform) {
           return typeof func === 'function' ? transform(func) : undefined;
         }
-      `, `
+      `,
+        `
         a()?.();
-      `);
+      `
+      );
     });
 
     it('works in an expression context', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a(b()?())
-      `, `
+      `,
+        `
         a(__guardFunc__(b(), f => f()));
         function __guardFunc__(func, transform) {
           return typeof func === 'function' ? transform(func) : undefined;
         }
-      `, `
+      `,
+        `
         a(b()?.());
-      `);
+      `
+      );
     });
 
     it('preserves arguments', () => {
-        checkSoak(`
+      checkSoak(
+        `
         a()?(1, 2, 3)
-      `, `
+      `,
+        `
         __guardFunc__(a(), f => f(1, 2, 3));
         function __guardFunc__(func, transform) {
           return typeof func === 'function' ? transform(func) : undefined;
         }
-      `, `
+      `,
+        `
         a()?.(1, 2, 3);
-      `);
+      `
+      );
     });
 
     it('handles nested soaked function calls', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a = null
         a?(1)?(2)
-      `, `
+      `,
+        `
         const a = null;
         __guardFunc__(typeof a === 'function' ? a(1) : undefined, f => f(2));
         function __guardFunc__(func, transform) {
           return typeof func === 'function' ? transform(func) : undefined;
         }
-      `, `
+      `,
+        `
         const a = null;
         a?.(1)?.(2);
-      `);
+      `
+      );
     });
 
     it('works with repeatable member access as the function', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a.b?()
-      `, `
+      `,
+        `
         if (typeof a.b === 'function') {
           a.b();
         }
-      `, `
+      `,
+        `
         a.b?.();
-      `);
+      `
+      );
     });
 
     it('works with non-repeatable member access as the function', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a().b?()
-      `, `
+      `,
+        `
         __guardMethod__(a(), 'b', o => o.b());
         function __guardMethod__(obj, methodName, transform) {
           if (typeof obj !== 'undefined' && obj !== null && typeof obj[methodName] === 'function') {
@@ -125,27 +148,35 @@ describe('soaked expressions', () => {
             return undefined;
           }
         }
-      `, `
+      `,
+        `
         a().b?.();
-      `);
+      `
+      );
     });
 
     it('works with repeatable dynamic member access as the function', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a[b]?()
-      `, `
+      `,
+        `
         if (typeof a[b] === 'function') {
           a[b]();
         }
-      `, `
+      `,
+        `
         a[b]?.();
-      `);
+      `
+      );
     });
 
     it('works with non-repeatable dynamic member access as the function', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a()[b]?()
-      `, `
+      `,
+        `
         __guardMethod__(a(), b, (o, m) => o[m]());
         function __guardMethod__(obj, methodName, transform) {
           if (typeof obj !== 'undefined' && obj !== null && typeof obj[methodName] === 'function') {
@@ -154,15 +185,19 @@ describe('soaked expressions', () => {
             return undefined;
           }
         }
-      `, `
+      `,
+        `
         a()[b]?.();
-      `);
+      `
+      );
     });
 
     it('works with dynamic member access whose key is unsafe to repeat as the function', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a[b()]?()
-      `, `
+      `,
+        `
         __guardMethod__(a, b(), (o, m) => o[m]());
         function __guardMethod__(obj, methodName, transform) {
           if (typeof obj !== 'undefined' && obj !== null && typeof obj[methodName] === 'function') {
@@ -171,60 +206,82 @@ describe('soaked expressions', () => {
             return undefined;
           }
         }
-      `, `
+      `,
+        `
         a[b()]?.();
-      `);
+      `
+      );
     });
 
     it('allows undeclared variables for soaked function calls in an expression context', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a = b?()
-      `, `
+      `,
+        `
         const a = typeof b === 'function' ? b() : undefined;
-      `, `
+      `,
+        `
         const a = typeof b === 'function' ? b() : undefined;
-      `);
+      `
+      );
     });
 
     it('does not crash when using a soaked member access on an undeclared variable', () => {
-      validateSoak(`
+      validateSoak(
+        `
         a?.b
         setResult(true)
-      `, true);
+      `,
+        true
+      );
     });
 
     it('does not crash when using a soaked dynamic member access on an undeclared variable', () => {
-      validateSoak(`
+      validateSoak(
+        `
         a?['b']
         setResult(true)
-      `, true);
+      `,
+        true
+      );
     });
 
     it('does not crash when using a soaked function invocation on an undeclared variable', () => {
-      validateSoak(`
+      validateSoak(
+        `
         a?()
         setResult(true)
-      `, true);
+      `,
+        true
+      );
     });
 
     it('evaluates soaked function calls', () => {
-      validateSoak(`
+      validateSoak(
+        `
         f = -> 3
         setResult(f?())
-      `, 3);
+      `,
+        3
+      );
     });
 
     // Skip for now because the optional chaining implementation doesn't handle
     // this case.
     it.skip('skips soaked function invocations on non-functions', () => {
-      validateSoak(`
+      validateSoak(
+        `
         f = 3
         setResult('' + f?())
-      `, 'undefined');
+      `,
+        'undefined'
+      );
     });
 
     it('properly sets this in soaked method calls', () => {
-      validateSoak(`
+      validateSoak(
+        `
         o = false
         a = {
           b: ->
@@ -233,11 +290,14 @@ describe('soaked expressions', () => {
         }
         a.b?()
         setResult(o)
-      `, true);
+      `,
+        true
+      );
     });
 
     it('properly sets `this` in shorthand-`this` soaked method calls', () => {
-      validateSoak(`
+      validateSoak(
+        `
         o = false
         a = {
           b: ->
@@ -248,11 +308,14 @@ describe('soaked expressions', () => {
         }
         a.b()
         setResult(o)
-      `, true);
+      `,
+        true
+      );
     });
 
     it('properly sets `this` in soaked dynamic method calls', () => {
-      validateSoak(`
+      validateSoak(
+        `
         o = false
         a = {
           b: ->
@@ -261,286 +324,370 @@ describe('soaked expressions', () => {
         }
         a['b']?()
         setResult(o)
-      `, true);
+      `,
+        true
+      );
     });
   });
 
   describe('soaked member access', () => {
     it('handles soaked member access assignment', () => {
-      checkSoak(`
+      checkSoak(
+        `
         canvasContext = null
         canvasContext?.font = $('body').css('font')
-      `, `
+      `,
+        `
         const canvasContext = null;
         if (canvasContext != null) {
           canvasContext.font = $('body').css('font');
         }
-      `, `
+      `,
+        `
         const canvasContext = null;
         canvasContext?.font = $('body').css('font');
-      `);
+      `
+      );
     });
 
     it('handles soaked member access with conflicting variable names', () => {
-      checkSoak(`
+      checkSoak(
+        `
         x = 5
         a()?.b(x)
-      `, `
+      `,
+        `
         const x = 5;
         __guard__(a(), x1 => x1.b(x));
         function __guard__(value, transform) {
           return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
         }
-      `, `
+      `,
+        `
         const x = 5;
         a()?.b(x);
-      `);
+      `
+      );
     });
 
     it('handles soaked member access with assignment within an expression', () => {
-      checkSoak(`
+      checkSoak(
+        `
         b = null
         a(b?.c = d)
-      `, `
+      `,
+        `
         const b = null;
         a(b != null ? b.c = d : undefined);
-      `, `
+      `,
+        `
         const b = null;
         a(b?.c = d);
-      `);
+      `
+      );
     });
 
     it('handles soaked member access with a function call', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a = null
         a?.b()
-      `, `
+      `,
+        `
         const a = null;
         if (a != null) {
           a.b();
         }
-      `, `
+      `,
+        `
         const a = null;
         a?.b();
-      `);
+      `
+      );
     });
 
     it('handles soaked member access on the result of a function call', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a.b()?.c
-      `, `
+      `,
+        `
         __guard__(a.b(), x => x.c);
         function __guard__(value, transform) {
           return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
         }
-      `, `
+      `,
+        `
         a.b()?.c;
-      `);
+      `
+      );
     });
 
     it('allows soaked member access to be used in an expression', () => {
-      checkSoak(`
+      checkSoak(
+        `
         b = null
         a(b?.c)
-      `, `
+      `,
+        `
         const b = null;
         a(b != null ? b.c : undefined);
-      `, `
+      `,
+        `
         const b = null;
         a(b?.c);
-      `);
+      `
+      );
     });
 
     it('handles dynamic member access', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a = null
         a?[b]()
-      `, `
+      `,
+        `
         const a = null;
         if (a != null) {
           a[b]();
         }
-      `, `
+      `,
+        `
         const a = null;
         a?.[b]();
-      `);
+      `
+      );
     });
 
     it('handles soaked dynamic member access followed by normal dynamic member access', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a = null
         a?[b].c[d]
-      `, `
+      `,
+        `
         const a = null;
         if (a != null) {
           a[b].c[d];
         }
-      `, `
+      `,
+        `
         const a = null;
         a?.[b].c[d];
-      `);
+      `
+      );
     });
 
     it('handles nested soaked dynamic member access', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a = null
         a?[b].c?[d]
-      `, `
+      `,
+        `
         const a = null;
         __guard__(a != null ? a[b].c : undefined, x => x[d]);
         function __guard__(value, transform) {
           return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
         }
-      `, `
+      `,
+        `
         const a = null;
         a?.[b].c?.[d];
-      `);
+      `
+      );
     });
 
     it('allows undeclared variables for soaked dynamic member accesses in an expression context', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a = b?[c]
-      `, `
+      `,
+        `
         const a = typeof b !== 'undefined' && b !== null ? b[c] : undefined;
-      `, `
+      `,
+        `
         const a = typeof b !== 'undefined' && b !== null ? b[c] : undefined;
-      `);
+      `
+      );
     });
 
     it('uses a shorter check for declared variables for soaked dynamic member accesses in an expression context', () => {
-      checkSoak(`
+      checkSoak(
+        `
         b = {}
         a = b?[c]
-      `, `
+      `,
+        `
         const b = {};
         const a = b != null ? b[c] : undefined;
-      `, `
+      `,
+        `
         const b = {};
         const a = b?.[c];
-      `);
+      `
+      );
     });
 
     it('handles soaked member access within a condition', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a = null
         if a?.b then c
-      `, `
+      `,
+        `
         const a = null;
         if (a != null ? a.b : undefined) { c; }
-      `, `
+      `,
+        `
         const a = null;
         if (a?.b) { c; }
-      `);
+      `
+      );
     });
 
     it('handles nested soaked member access', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a()?.b()?.c = 0;
-      `, `
+      `,
+        `
         __guard__(__guard__(a(), x1 => x1.b()), x => x.c = 0);
         function __guard__(value, transform) {
           return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
         }
-      `, `
+      `,
+        `
         a()?.b()?.c = 0;
-      `);
+      `
+      );
     });
 
     it('handles explicit parens around soaks', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a = null
         (a?.b).c
-      `, `
+      `,
+        `
         const a = null;
         (a != null ? a.b : undefined).c;
-      `, `
+      `,
+        `
         const a = null;
         (a?.b).c;
-      `);
+      `
+      );
     });
 
     it('keeps postfix ++ within soak expressions', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a()?.b++
-      `, `
+      `,
+        `
         __guard__(a(), x => x.b++);
         function __guard__(value, transform) {
           return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
         }
-      `, `
+      `,
+        `
         a()?.b++;
-      `);
+      `
+      );
     });
 
     it('keeps postfix -- within soak expressions', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a()?.b--
-      `, `
+      `,
+        `
         __guard__(a(), x => x.b--);
         function __guard__(value, transform) {
           return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
         }
-      `, `
+      `,
+        `
         a()?.b--;
-      `);
+      `
+      );
     });
 
     it('keeps prefix ++ within soak expressions', () => {
-      checkSoak(`
+      checkSoak(
+        `
         ++a()?.b
-      `, `
+      `,
+        `
         __guard__(a(), x => ++x.b);
         function __guard__(value, transform) {
           return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
         }
-      `, `
+      `,
+        `
         ++a()?.b;
-      `);
+      `
+      );
     });
 
     it('keeps prefix ++ within soaked dynamic accesses', () => {
-      checkSoak(`
+      checkSoak(
+        `
         ++a()?[b]
-      `, `
+      `,
+        `
         __guard__(a(), x => ++x[b]);
         function __guard__(value, transform) {
           return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
         }
-      `, `
+      `,
+        `
         ++a()?.[b];
-      `);
+      `
+      );
     });
 
     it('keeps prefix ++ within soaked dynamic accesses where the LHS is surrounded by parens', () => {
-      checkSoak(`
+      checkSoak(
+        `
         ++(a())?[b]
-      `, `
+      `,
+        `
         __guard__((a()), x => ++x[b]);
         function __guard__(value, transform) {
           return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
         }
-      `, `
+      `,
+        `
         ++(a())?.[b];
-      `);
+      `
+      );
     });
 
     it('keeps prefix ++ within soaked function calls', () => {
-      checkSoak(`
+      checkSoak(
+        `
         ++a()?(b).c
-      `, `
+      `,
+        `
         __guardFunc__(a(), f => ++f(b).c);
         function __guardFunc__(func, transform) {
           return typeof func === 'function' ? transform(func) : undefined;
         }
-      `, `
+      `,
+        `
         ++a()?.(b).c;
-      `);
+      `
+      );
     });
 
     it('keeps prefix ++ within soaked method calls', () => {
-      checkSoak(`
+      checkSoak(
+        `
         ++a().b?(c).d
-      `, `
+      `,
+        `
         __guardMethod__(a(), 'b', o => ++o.b(c).d);
         function __guardMethod__(obj, methodName, transform) {
           if (typeof obj !== 'undefined' && obj !== null && typeof obj[methodName] === 'function') {
@@ -549,15 +696,19 @@ describe('soaked expressions', () => {
             return undefined;
           }
         }
-      `, `
+      `,
+        `
         ++a().b?.(c).d;
-      `);
+      `
+      );
     });
 
     it('keeps prefix ++ within soaked dynamic method calls', () => {
-      checkSoak(`
+      checkSoak(
+        `
         ++a()[b]?(c).d
-      `, `
+      `,
+        `
         __guardMethod__(a(), b, (o, m) => ++o[m](c).d);
         function __guardMethod__(obj, methodName, transform) {
           if (typeof obj !== 'undefined' && obj !== null && typeof obj[methodName] === 'function') {
@@ -566,102 +717,136 @@ describe('soaked expressions', () => {
             return undefined;
           }
         }
-      `, `
+      `,
+        `
         ++a()[b]?.(c).d;
-      `);
+      `
+      );
     });
 
     it('keeps prefix -- within soak expressions', () => {
-      checkSoak(`
+      checkSoak(
+        `
         --a()?.b
-      `, `
+      `,
+        `
         __guard__(a(), x => --x.b);
         function __guard__(value, transform) {
           return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
         }
-      `, `
+      `,
+        `
         --a()?.b;
-      `);
+      `
+      );
     });
 
     it('keeps delete within soak expressions', () => {
-      checkSoak(`
+      checkSoak(
+        `
         delete a()?.b
-      `, `
+      `,
+        `
         __guard__(a(), x => delete x.b);
         function __guard__(value, transform) {
           return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
         }
-      `, `
+      `,
+        `
         delete a()?.b;
-      `);
+      `
+      );
     });
 
     it('handles soaked prototype access', () => {
-      checkSoak(`
+      checkSoak(
+        `
         a()?::b
-      `, `
+      `,
+        `
         __guard__(a(), x => x.prototype.b);
         function __guard__(value, transform) {
           return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
         }
-      `, `
+      `,
+        `
         a()?.prototype.b;
-      `);
+      `
+      );
     });
 
     it('correctly handles normal soaked access', () => {
-      validateSoak(`
+      validateSoak(
+        `
         a = {b: 5}
         setResult(a?.b)
-      `, 5);
+      `,
+        5
+      );
     });
 
     it('correctly handles missing soaked access', () => {
-      validateSoak(`
+      validateSoak(
+        `
         a = {b: null}
         setResult('' + a.b?.c)
-      `, 'undefined');
+      `,
+        'undefined'
+      );
     });
 
     it('correctly handles dynamic soaked access', () => {
-      validateSoak(`
+      validateSoak(
+        `
         a = {b: 5}
         setResult(a?['b'])
-      `, 5);
+      `,
+        5
+      );
     });
 
     it('correctly handles missing dynamic soaked access', () => {
-      validateSoak(`
+      validateSoak(
+        `
         a = {b: null}
         setResult('' + a.b?['c'])
-      `, 'undefined');
+      `,
+        'undefined'
+      );
     });
 
     it('stops evaluating the expression when hitting a soak failure', () => {
-        validateSoak(`
+      validateSoak(
+        `
         a = {b: 5}
         setResult('' + a.d?.e.f())
-      `, 'undefined');
+      `,
+        'undefined'
+      );
     });
 
     it('skips assignment when a soak fails', () => {
-      validateSoak(`
+      validateSoak(
+        `
         x = 1
         y = null
         z = {}
         y?.a = x++
         z?.a = x++
         setResult(x)
-      `, 2);
+      `,
+        2
+      );
     });
   });
 
   it('handles a soaked method call on a soaked member access', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = {}
       a?.b?()
-    `, `
+    `,
+      `
       const a = {};
       __guardMethod__(a, 'b', o => o.b());
       function __guardMethod__(obj, methodName, transform) {
@@ -671,17 +856,21 @@ describe('soaked expressions', () => {
           return undefined;
         }
       }
-    `, `
+    `,
+      `
       const a = {};
       a?.b?.();
-    `);
+    `
+    );
   });
 
   it('handles a soaked method call on a soaked dynamic member access', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = null
       a?[b]?()
-    `, `
+    `,
+      `
       const a = null;
       __guardMethod__(a, b, (o, m) => o[m]());
       function __guardMethod__(obj, methodName, transform) {
@@ -691,17 +880,21 @@ describe('soaked expressions', () => {
           return undefined;
         }
       }
-    `, `
+    `,
+      `
       const a = null;
       a?.[b]?.();
-    `);
+    `
+    );
   });
-  
+
   it('handles a combination of soaked function calls and soaked member accesses', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = null
       a?(1)?.b?()?[c].d?()?.e = 1
-    `, `
+    `,
+      `
       const a = null;
       __guard__(__guardMethod__(__guard__(__guardMethod__(typeof a === 'function' ? a(1) : undefined, 'b', o1 => o1.b()), x1 => x1[c]), 'd', o => o.d()), x => x.e = 1);
       function __guard__(value, transform) {
@@ -714,18 +907,22 @@ describe('soaked expressions', () => {
           return undefined;
         }
       }
-    `, `
+    `,
+      `
       const a = null;
       a?.(1)?.b?.()?.[c].d?.()?.e = 1;
-    `);
+    `
+    );
   });
 
   it('properly sets patching bounds for soaked function applications', () => {
-    checkSoak(`
+    checkSoak(
+      `
       f()?(a, 
         b: c
         d: e)
-    `, `
+    `,
+      `
       __guardFunc__(f(), f => f(a, { 
         b: c,
         d: e
@@ -733,235 +930,299 @@ describe('soaked expressions', () => {
       function __guardFunc__(func, transform) {
         return typeof func === 'function' ? transform(func) : undefined;
       }
-    `, `
+    `,
+      `
       f()?.(a, { 
         b: c,
         d: e
       });
-    `);
+    `
+    );
   });
 
   it('properly transforms an `in` operator with a soak expression on the left', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = null
       a?.b in c
-    `, `
+    `,
+      `
       const a = null;
       Array.from(c).includes(a != null ? a.b : undefined);
-    `, `
+    `,
+      `
       const a = null;
       Array.from(c).includes(a?.b);
-    `);
+    `
+    );
   });
 
   it('properly transforms an `in` operator with a soak expression on the right', () => {
-    checkSoak(`
+    checkSoak(
+      `
       b = null
       a in b?.c
-    `, `
+    `,
+      `
       const b = null;
       Array.from(b != null ? b.c : undefined).includes(a);
-    `, `
+    `,
+      `
       const b = null;
       Array.from(b?.c).includes(a);
-    `);
+    `
+    );
   });
 
   it('handles a soaked access used with an existence operator', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = b()?.c ? d
-    `, `
+    `,
+      `
       let left;
       const a = (left = __guard__(b(), x => x.c)) != null ? left : d;
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
-    `, `
+    `,
+      `
       let left;
       const a = (left = b()?.c) != null ? left : d;
-    `);
+    `
+    );
   });
 
   it('handles a soaked dynamic access used with an existence operator', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = b()?[c()] ? d
-    `, `
+    `,
+      `
       let left;
       const a = (left = __guard__(b(), x => x[c()])) != null ? left : d;
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
-    `, `
+    `,
+      `
       let left;
       const a = (left = b()?.[c()]) != null ? left : d;
-    `);
+    `
+    );
   });
 
   it('handles a soaked access used with an existence assignment operator', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a()?.b ?= c
-    `, `
+    `,
+      `
       let base;
       __guard__((base = a()), x => x.b != null ? base.b : (base.b = c));
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
-    `, `
+    `,
+      `
       let base;
       (base = a())?.b != null ? base.b : (base.b = c);
-    `);
+    `
+    );
   });
 
   it('handles a soaked dynamic access used with an existence assignment operator', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a()?[b()] ?= d
-    `, `
+    `,
+      `
       let name;
       let base;
       __guard__((base = a()), x => x[name = b()] != null ? base[name] : (base[name] = d));
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
-    `, `
+    `,
+      `
       let base, name;
       (base = a())?.[name = b()] != null ? base[name] : (base[name] = d);
-    `);
+    `
+    );
   });
 
   it('handles a soaked access used with a logical assignment operator', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a()?.b and= c
-    `, `
+    `,
+      `
       let base;
       __guard__((base = a()), x => x.b && (base.b = c));
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
-    `, `
+    `,
+      `
       let base;
       (base = a())?.b && (base.b = c);
-    `);
+    `
+    );
   });
 
   it('handles a soaked dynamic access used with a logical assignment operator', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a()?[b()] and= d
-    `, `
+    `,
+      `
       let name;
       let base;
       __guard__((base = a()), x => x[name = b()] && (base[name] = d));
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
-    `, `
+    `,
+      `
       let base, name;
       (base = a())?.[name = b()] && (base[name] = d);
-    `);
+    `
+    );
   });
 
   it('allows a repeated soak operation as a loop target', () => {
-    checkSoak(`
+    checkSoak(
+      `
       i + j for j, i in foo()?.bar ? [] 
-    `, `
+    `,
+      `
       let left;
       const iterable = (left = __guard__(foo(), x => x.bar)) != null ? left : [];
       for (let i = 0; i < iterable.length; i++) { const j = iterable[i]; i + j; } 
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
-    `, `
+    `,
+      `
       let left;
       const iterable = (left = foo()?.bar) != null ? left : [];
       for (let i = 0; i < iterable.length; i++) { const j = iterable[i]; i + j; } 
-    `);
+    `
+    );
   });
 
   it('handles a soaked dynamic access used with a logical assignment operator with a function RHS', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a.b()?.c or= (it) -> it
-    `, `
+    `,
+      `
       let base;
       __guard__((base = a.b()), x => x.c || (base.c = it => it));
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
-    `, `
+    `,
+      `
       let base;
       (base = a.b())?.c || (base.c = it => it);
-    `);
+    `
+    );
   });
 
   it('handles a possibly undeclared variable in a statement context', () => {
-    checkSoak(`
+    checkSoak(
+      `
       ++a?.b[c()]
-    `, `
+    `,
+      `
       if (typeof a !== 'undefined' && a !== null) {
         ++a.b[c()];
       }
-    `, `
+    `,
+      `
       if (typeof a !== 'undefined' && a !== null) {
         ++a.b[c()];
       }
-    `);
+    `
+    );
   });
 
   it('handles a simple identifier that has been declared in a statement context', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = f()
       ++a?.b[c()]
-    `, `
+    `,
+      `
       const a = f();
       if (a != null) {
         ++a.b[c()];
       }
-    `, `
+    `,
+      `
       const a = f();
       ++a?.b[c()];
-    `);
+    `
+    );
   });
 
   it('handles a possibly undeclared variable in an expression context', () => {
-    checkSoak(`
+    checkSoak(
+      `
       x = ++a?.b[c()]
-    `, `
+    `,
+      `
       const x = typeof a !== 'undefined' && a !== null ? ++a.b[c()] : undefined;
-    `, `
+    `,
+      `
       const x = typeof a !== 'undefined' && a !== null ? ++a.b[c()] : undefined;
-    `);
+    `
+    );
   });
 
   it('handles a simple identifier that has been declared in an expression context', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = f()
       x = ++a?.b[c()]
-    `, `
+    `,
+      `
       const a = f();
       const x = a != null ? ++a.b[c()] : undefined;
-    `, `
+    `,
+      `
       const a = f();
       const x = ++a?.b[c()];
-    `);
+    `
+    );
   });
 
   it('properly follows precedence with soak expressions', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = f()
       x = a?.b or []
-    `, `
+    `,
+      `
       const a = f();
       const x = (a != null ? a.b : undefined) || [];
-    `, `
+    `,
+      `
       const a = f();
       const x = a?.b || [];
-    `);
+    `
+    );
   });
 
   it('properly handles chained simple soak operations', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = f()
       if a?.b?.c?
         d
-    `, `
+    `,
+      `
       const a = f();
       if (__guard__(a != null ? a.b : undefined, x => x.c) != null) {
         d;
@@ -969,356 +1230,445 @@ describe('soaked expressions', () => {
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
-    `, `
+    `,
+      `
       const a = f();
       if (a?.b?.c != null) {
         d;
       }
-    `);
+    `
+    );
   });
 
   it('properly handles a soaked method call followed by a binary exists op', () => {
-    checkSoak(`
+    checkSoak(
+      `
       b = null
       a = b?.filter(-> c) ? null
-    `, `
+    `,
+      `
       let left;
       const b = null;
       const a = (left = (b != null ? b.filter(() => c) : undefined)) != null ? left : null;
-    `, `
+    `,
+      `
       let left;
       const b = null;
       const a = (left = b?.filter(() => c)) != null ? left : null;
-    `);
+    `
+    );
   });
 
   it('properly handles a soak operation inside a ternary', () => {
-    checkSoak(`
+    checkSoak(
+      `
       b = 0
       a = if b?.c then d else e
-    `, `
+    `,
+      `
       const b = 0;
       const a = (b != null ? b.c : undefined) ? d : e;
-    `, `
+    `,
+      `
       const b = 0;
       const a = b?.c ? d : e;
-    `);
+    `
+    );
   });
 
   it('has the correct runtime behavior with a soak operation inside a ternary', () => {
-    validateSoak(`
+    validateSoak(
+      `
       a = {b: 'should not return'}
       setResult(if a?.b then 'should return')
-    `, 'should return');
+    `,
+      'should return'
+    );
   });
 
   it('does not add parens around a soaked while condition', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = {}
       while a?.b
         break
-    `, `
+    `,
+      `
       const a = {};
       while (a != null ? a.b : undefined) {
         break;
       }
-    `, `
+    `,
+      `
       const a = {};
       while (a?.b) {
         break;
       }
-    `);
+    `
+    );
   });
 
   it('does not add parens around a soaked indexing expression', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = {}
       b = {}
       d = a[b?.c]
-    `, `
+    `,
+      `
       const a = {};
       const b = {};
       const d = a[b != null ? b.c : undefined];
-    `, `
+    `,
+      `
       const a = {};
       const b = {};
       const d = a[b?.c];
-    `);
+    `
+    );
   });
 
   it('properly handles a soaked condition in an `unless` statement', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = null
       unless a?.b
         c
-    `, `
+    `,
+      `
       const a = null;
       if (!(a != null ? a.b : undefined)) {
         c;
       }
-    `, `
+    `,
+      `
       const a = null;
       if (!a?.b) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('properly handles a soaked condition in an `until` statement', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = null
       until a?.b
         c
-    `, `
+    `,
+      `
       const a = null;
       while (!(a != null ? a.b : undefined)) {
         c;
       }
-    `, `
+    `,
+      `
       const a = null;
       while (!a?.b) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('properly handles a soaked condition in an `unless` statement with an assignment', () => {
-    checkSoak(`
+    checkSoak(
+      `
       b = null
       unless a = b?.c
         d
-    `, `
+    `,
+      `
       let a;
       const b = null;
       if (!(a = b != null ? b.c : undefined)) {
         d;
       }
-    `, `
+    `,
+      `
       let a;
       const b = null;
       if (!(a = b?.c)) {
         d;
       }
-    `);
+    `
+    );
   });
 
   it('properly patches the object key in a soaked dynamic member access', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = null
       a?[@b]
-    `, `
+    `,
+      `
       const a = null;
       if (a != null) {
         a[this.b];
       }
-    `, `
+    `,
+      `
       const a = null;
       a?.[this.b];
-    `);
+    `
+    );
   });
 
   it('properly places parens for expression-style soaked assignment', () => {
-    checkSoak(`
+    checkSoak(
+      `
       b = null
       a = b?.c = 1
-    `, `
+    `,
+      `
       const b = null;
       const a = (b != null ? b.c = 1 : undefined);
-    `, `
+    `,
+      `
       const b = null;
       const a = (b?.c = 1);
-    `);
+    `
+    );
   });
 
   it('handles simple soaked new operations', () => {
-    checkSoak(`
+    checkSoak(
+      `
       A = null
       new A?(b)
-    `, `
+    `,
+      `
       const A = null;
       if (typeof A === 'function') {
         new A(b);
       }
-    `, `
+    `,
+      `
       const A = null;
       new A?.(b);
-    `);
+    `
+    );
   });
 
   it('handles implicit soaked new operations', () => {
-    checkSoak(`
+    checkSoak(
+      `
       A = null
       new A? b
-    `, `
+    `,
+      `
       const A = null;
       if (typeof A === 'function') {
         new A(b);
       }
-    `, `
+    `,
+      `
       const A = null;
       new A?.(b);
-    `);
+    `
+    );
   });
 
   it('handles complex soaked new operations', () => {
-    checkSoak(`
+    checkSoak(
+      `
       new A[b()]?(c)
-    `, `
+    `,
+      `
       __guardFunc__(A[b()], f => new f(c));
       function __guardFunc__(func, transform) {
         return typeof func === 'function' ? transform(func) : undefined;
       }
-    `, `
+    `,
+      `
       new A[b()]?.(c);
-    `);
+    `
+    );
   });
 
   it('handles soaked slice operations', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = b?[c..d]
-    `, `
+    `,
+      `
       const a = __guard__(b, x => x.slice(c, +d + 1 || undefined));
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
-    `, `
+    `,
+      `
       const a = b?.slice(c, +d + 1 || undefined);
-    `);
+    `
+    );
   });
 
   it('properly computes the soak container for soaked slice operations', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = b?[c..d].e
-    `, `
+    `,
+      `
       const a = __guard__(b, x => x.slice(c, +d + 1 || undefined).e);
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
-    `, `
+    `,
+      `
       const a = b?.slice(c, +d + 1 || undefined).e;
-    `);
+    `
+    );
   });
 
   it('handles soaked splice operations', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a?[b..c] = d
-    `, `
+    `,
+      `
       __guard__(a, x => x.splice(b, c - b + 1, ...[].concat(d)));
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
-    `, `
+    `,
+      `
       a?.splice(b, c - b + 1, ...[].concat(d));
-    `);
+    `
+    );
   });
 
   it('handles complex splice operations', () => {
-    checkSoak(`
+    checkSoak(
+      `
       [a, b()?[c..]] = d
-    `, `
+    `,
+      `
       let a;
       a = d[0], __guard__(b(), x => x.splice(c, 9e9, ...[].concat(d[1])));
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
-    `, `
+    `,
+      `
       let a;
       a = d[0], b()?.splice(c, 9e9, ...[].concat(d[1]));
-    `);
+    `
+    );
   });
 
   it('handles a parenthesized soak operation within `unless`', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = {b: 1}
       unless (a?.b)
         c
-    `, `
+    `,
+      `
       const a = {b: 1};
       if (!(a != null ? a.b : undefined)) {
         c;
       }
-    `, `
+    `,
+      `
       const a = {b: 1};
       if (!a?.b) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('handles a nested parenthesized soak operation within `unless`', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = {b: 1}
       unless (a?.b.c)
         d
-    `, `
+    `,
+      `
       const a = {b: 1};
       if (!(a != null ? a.b.c : undefined)) {
         d;
       }
-    `, `
+    `,
+      `
       const a = {b: 1};
       if (!a?.b.c) {
         d;
       }
-    `);
+    `
+    );
   });
 
   it('handles a parenthesized soak operation within `until`', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = {b: 1}
       until (a?.b)
         c
-    `, `
+    `,
+      `
       const a = {b: 1};
       while (!(a != null ? a.b : undefined)) {
         c;
       }
-    `, `
+    `,
+      `
       const a = {b: 1};
       while (!a?.b) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('handles a parenthesized soak operation within a negated logical operator', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = {b: 1}
       unless c and (a?.b)
         d
-    `, `
+    `,
+      `
       const a = {b: 1};
       if (!c || (!(a != null ? a.b : undefined))) {
         d;
       }
-    `, `
+    `,
+      `
       const a = {b: 1};
       if (!c || (!a?.b)) {
         d;
       }
-    `);
+    `
+    );
   });
 
   it('handles a parenthesized soak operation within a negated switch case', () => {
-    checkSoak(`
+    checkSoak(
+      `
       a = {b: 1}
       switch
         when (a?.b)
           c
-    `, `
+    `,
+      `
       const a = {b: 1};
       switch (false) {
         case (!(a != null ? a.b : undefined)):
           c;
           break;
       }
-    `, `
+    `,
+      `
       const a = {b: 1};
       switch (false) {
         case (!a?.b):
           c;
           break;
       }
-    `);
+    `
+    );
   });
 });

--- a/test/spread_test.ts
+++ b/test/spread_test.ts
@@ -1,112 +1,151 @@
-import {checkCS1, checkCS2} from './support/check';
-import validate, {validateCS1} from './support/validate';
+import { checkCS1, checkCS2 } from './support/check';
+import validate, { validateCS1 } from './support/validate';
 
 describe('spread', () => {
   it('handles simple function calls', () => {
-    checkCS1(`
+    checkCS1(
+      `
       a(b...)
-    `, `
+    `,
+      `
       a(...Array.from(b || []));
-    `);
+    `
+    );
   });
 
   it('handles simple function calls in CS2', () => {
-    checkCS2(`
+    checkCS2(
+      `
       a(b...)
-    `, `
+    `,
+      `
       a(...b);
-    `);
+    `
+    );
   });
 
   it('handles advanced function calls', () => {
-    checkCS1(`
+    checkCS1(
+      `
       a(1, 2, makeArray(arguments...)...)
-    `, `
+    `,
+      `
       a(1, 2, ...Array.from(makeArray(...arguments)));
-    `);
+    `
+    );
   });
 
   it('handles advanced function calls in CS2', () => {
-    checkCS2(`
+    checkCS2(
+      `
       a(1, 2, makeArray(arguments...)...)
-    `, `
+    `,
+      `
       a(1, 2, ...makeArray(...arguments));
-    `);
+    `
+    );
   });
 
   it('has the correct runtime behavior when spreading null in a function call', () => {
-    validate(`
+    validate(
+      `
       f = -> arguments.length
       try
         # Works in CS1
         setResult(f(null...))
       catch
         setResult('Fails in CS2')
-    `, {cs1: 0, cs2: 'Fails in CS2'});
+    `,
+      { cs1: 0, cs2: 'Fails in CS2' }
+    );
   });
 
   it('has the correct runtime behavior when spreading a fake array in a function call', () => {
     // Ignore CS2 checking since Babel handles this case wrong and doesn't crash.
-    validateCS1(`
+    validateCS1(
+      `
       f = -> arguments.length
       obj = {length: 2, 0: 'a', 1: 'b'}
       setResult(f(1, 2, obj...))
-    `, 4);
+    `,
+      4
+    );
   });
 
   it('handles simple array literals', () => {
-    checkCS1(`
+    checkCS1(
+      `
       [b...]
-    `, `
+    `,
+      `
       [...Array.from(b)];
-    `);
+    `
+    );
   });
 
   it('handles simple array literals in CS2', () => {
-    checkCS2(`
+    checkCS2(
+      `
       [b...]
-    `, `
+    `,
+      `
       [...b];
-    `);
+    `
+    );
   });
 
   it('handles advanced array literals', () => {
-    checkCS1(`
+    checkCS1(
+      `
       [1, 2, makeArray(arguments...)...]
-    `, `
+    `,
+      `
       [1, 2, ...Array.from(makeArray(...arguments))];
-    `);
+    `
+    );
   });
 
   it('handles advanced array literals in CS2', () => {
-    checkCS2(`
+    checkCS2(
+      `
       [1, 2, makeArray(arguments...)...]
-    `, `
+    `,
+      `
       [1, 2, ...makeArray(...arguments)];
-    `);
+    `
+    );
   });
 
   it('has the correct runtime behavior when spreading a fake array in an array literal', () => {
     // Ignore CS2 checking since Babel handles this case wrong and doesn't crash.
-    validateCS1(`
+    validateCS1(
+      `
       obj = {length: 2, 0: 'a', 1: 'b'}
       setResult([1, 2, obj...])
-    `, [1, 2, 'a', 'b']);
+    `,
+      [1, 2, 'a', 'b']
+    );
   });
 
   it('handles array spread with the operator on the LHS', () => {
-    checkCS2(`
+    checkCS2(
+      `
       a = [...b, c]
-    `, `
+    `,
+      `
       const a = [...b, c];
-    `);
+    `
+    );
   });
 
   it('handles postfix conditionals in spread operators', () => {
-    checkCS2(`
+    checkCS2(
+      `
       [a if b...]
-    `, `
+    `,
+      `
       [...(b ? a : undefined)];
-    `);
+    `
+    );
   });
 });

--- a/test/string_integration_test.ts
+++ b/test/string_integration_test.ts
@@ -24,25 +24,24 @@ function generateThreeLineTests(strings: Array<string>): Array<string> {
 
 function runAssignmentTest(quote: string, string: string): void {
   validate(
-`testVariable = "test variable"
-setResult(${quote}${string}${quote})`);
+    `testVariable = "test variable"
+setResult(${quote}${string}${quote})`
+  );
 }
 
 function runFunctionTest(quote: string, string: string): void {
   validate(
-`runTest = () ->
+    `runTest = () ->
   testVariable = "test variable"
   return ${quote}${string}${quote}
-setResult(runTest())`);
+setResult(runTest())`
+  );
 }
 
 describe('string integration', function(): void {
   this.timeout(180000);
-  let strings = ['', '   ', 'word', '   leading indent', 'trailing indent   ',
-                 '    leading and trailing indent    '];
-  let quotes = [
-    ['\'', 'single quote (\')'],
-    ['"', 'double quote (")']];
+  let strings = ['', '   ', 'word', '   leading indent', 'trailing indent   ', '    leading and trailing indent    '];
+  let quotes = [["'", "single quote (')"], ['"', 'double quote (")']];
 
   let twoLineTests = generateTwoLineTests(strings);
   let threeLineTests = generateThreeLineTests(strings);

--- a/test/string_interpolation_test.ts
+++ b/test/string_interpolation_test.ts
@@ -26,80 +26,98 @@ describe('string interpolation', () => {
   });
 
   it('handles double quotes inside triple-double quotes', () => {
-    check(`
+    check(
+      `
       a="""
       bar="#{bar}"
       """
-    `, `
+    `,
+      `
       const a=\`\\
       bar="\${bar}"\\
       \`;
-    `);
-  });
-
-  it('handles comments inside interpolations', () => {
-    check(`
-      a="#{
-      b # foo!
-      }"
-    `, `
-      const a=\`\${
-      b // foo!
-      }\`;
-    `);
-  });
-
-  it('handles nested string interpolations', () => {
-    check(`
-      "a#{"b#{c}d"}e"
-    `, `
-      \`a\${\`b\${c}d\`}e\`;
-    `);
-  });
-
-  it('escapes ${ inside strings that become template strings', () => {
-    check(
-      '"#{interpolation}${not interpolation}"',
-      '`${interpolation}\\${not interpolation}`;'
+    `
     );
   });
 
+  it('handles comments inside interpolations', () => {
+    check(
+      `
+      a="#{
+      b # foo!
+      }"
+    `,
+      `
+      const a=\`\${
+      b // foo!
+      }\`;
+    `
+    );
+  });
+
+  it('handles nested string interpolations', () => {
+    check(
+      `
+      "a#{"b#{c}d"}e"
+    `,
+      `
+      \`a\${\`b\${c}d\`}e\`;
+    `
+    );
+  });
+
+  it('escapes ${ inside strings that become template strings', () => {
+    check('"#{interpolation}${not interpolation}"', '`${interpolation}\\${not interpolation}`;');
+  });
+
   it('escapes ${ inside block strings that become template strings', () => {
-    check(`
+    check(
+      `
       """
       \${a}
       \${b}
       """
-    `, `
+    `,
+      `
       \`\\
       \\\${a}
       \\\${b}\\
       \`;
-    `);
+    `
+    );
   });
 
   it('is allowed inside an object with explicit curly braces', () => {
-    check(`
+    check(
+      `
       { a: "#{b}" }
-    `, `
+    `,
+      `
       ({ a: \`\${b}\` });
-    `);
+    `
+    );
   });
 
   it('works with two string interpolations separated by something', () => {
-    check(`
+    check(
+      `
       "#{a} #{b}"
-    `, `
+    `,
+      `
       \`\${a} \${b}\`;
-    `);
+    `
+    );
   });
 
   it('handles parentheses before interpolations (#212)', () => {
-    check(`
+    check(
+      `
       "(#{a}"
-    `, `
+    `,
+      `
       \`(\${a}\`;
-    `);
+    `
+    );
   });
 
   it('handles if expressions inside interpolations', () => {
@@ -107,84 +125,108 @@ describe('string interpolation', () => {
   });
 
   it('handles interpolations in indented herestrings', () => {
-    check(`
+    check(
+      `
       """
         a
         #{b}
         """
-    `, `
+    `,
+      `
       \`\\
       a
       \${b}\\
       \`;
-    `);
+    `
+    );
   });
 
   it('does not strip leading whitespace in an edge case in interpolated strings (#556)', () => {
-    check(`
+    check(
+      `
       """    a
       b#{c}
       """
-    `, `
+    `,
+      `
       \`    a
       b\${c}\\
       \`;
-    `);
+    `
+    );
   });
 
   it('removes newlines from multiline double-quoted strings (#554)', () => {
-    check(`
+    check(
+      `
       "
       a
       #{b}
       c
       "
-    `, `
+    `,
+      `
       \`\\
       a \\
       \${b} \\
       c\\
       \`;
-    `);
+    `
+    );
   });
 
   it('handles empty string interpolations', () => {
-    check(`
+    check(
+      `
       "a#{}b"
-    `, `
+    `,
+      `
       \`ab\`;
-    `);
+    `
+    );
   });
 
   it('handles empty heregex interpolations', () => {
-    check(`
+    check(
+      `
       ///a#{}b///
-    `, `
+    `,
+      `
       new RegExp(\`ab\`);
-    `);
+    `
+    );
   });
 
   it('handles lone empty string interpolations', () => {
-    check(`
+    check(
+      `
       "#{}"
-    `, `
+    `,
+      `
       \`\`;
-    `);
+    `
+    );
   });
 
   it('handles tagged template literals', () => {
-    check(`
+    check(
+      `
       a"b#{c}d"
-    `, `
+    `,
+      `
       a\`b\${c}d\`;
-    `);
+    `
+    );
   });
 
   it('emits a tagged template literal even if there are no interpolations', () => {
-    check(`
+    check(
+      `
       a"b"
-    `, `
+    `,
+      `
       a\`b\`;
-    `);
+    `
+    );
   });
 });

--- a/test/string_test.ts
+++ b/test/string_test.ts
@@ -55,111 +55,144 @@ describe('strings', () => {
   });
 
   it('works when the triple-quoted string is indented', () => {
-    check(`
+    check(
+      `
       a = """
            foo
            bar
           """
-    `, `
+    `,
+      `
       const a = \`\\
       foo
       bar\\
       \`;
-    `);
+    `
+    );
   });
 
   it('appends semicolons after the parentheses of a function call with a triple-double-quoted multi-line string as argument', () => {
-    check(`
+    check(
+      `
       a("""line1
       line2""")
-    `, `
+    `,
+      `
       a(\`line1
       line2\`);
-    `);
+    `
+    );
   });
 
   it('appends semicolons after the parentheses of a function call with a triple-single-quoted multi-line string as argument', () => {
-    check(`
+    check(
+      `
       a('''line1
       line2''')
-    `, `
+    `,
+      `
       a(\`line1
       line2\`);
-    `);
+    `
+    );
   });
 
   it('converts multi line string assignment', () => {
-    check(`
+    check(
+      `
       a = "this is a 
            multi line
            string"
-      `, `
+      `,
+      `
       const a = \`this is a \\
       multi line \\
       string\`;
-    `);
+    `
+    );
   });
 
   it('converts multi line string in function call', () => {
-    check(`
+    check(
+      `
       fn("this is a 
           multi line
           string")
-      `, `
+      `,
+      `
       fn(\`this is a \\
       multi line \\
       string\`);
-    `);
+    `
+    );
   });
 
   it('allows escaping newlines in double-quoted strings', () => {
-    check(`
+    check(
+      `
       a = "a\\
       b"
-      `, `
+      `,
+      `
       const a = \`a\\
       b\`;
-    `);
+    `
+    );
   });
 
   it('escapes \\u2028 within strings', () => {
-    check(`
+    check(
+      `
       '\u2028'
-      `, `
+      `,
+      `
       '\\u2028';
-    `);
+    `
+    );
   });
 
   it('escapes \\u2029 within strings', () => {
-    check(`
+    check(
+      `
       '\u2029'
-      `, `
+      `,
+      `
       '\\u2029';
-    `);
+    `
+    );
   });
 
   it('uses the existing escape character for escaped \\u2028', () => {
-    check(`
+    check(
+      `
       '\\\u2028'
-      `, `
+      `,
+      `
       '\\u2028';
-    `);
+    `
+    );
   });
 
   it('leaves an escaped backslash when an escaped backslash is followed by \\u2028', () => {
-    check(`
+    check(
+      `
       '\\\\\u2028'
-      `, `
+      `,
+      `
       '\\\\\\u2028';
-    `);
+    `
+    );
   });
 
   it('handles \\0 followed by a number', () => {
-    validate(`
+    validate(
+      `
       setResult('
         \\0\\
         1
       ')
-      `, '\x001');
+      `,
+      '\x001'
+    );
   });
 });

--- a/test/suggestions_test.ts
+++ b/test/suggestions_test.ts
@@ -1,12 +1,14 @@
-import check, {checkCS1} from './support/check';
+import check, { checkCS1 } from './support/check';
 
 describe('suggestions', () => {
   it('provides a suggestion for the babel constructor workaround', () => {
-    check(`
+    check(
+      `
       class A extends B
         c: =>
           d
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS001: Remove Babel/TypeScript constructor workaround
@@ -30,34 +32,42 @@ describe('suggestions', () => {
           return d;
         }
       }
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('provides no suggestions for an ordinary file', () => {
-    check(`
+    check(
+      `
       x = 1
-    `, `
+    `,
+      `
       const x = 1;
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('only shows one of each suggestion', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class A extends B
         constructor: (@c) ->
           super
       class E extends F
         constructor: (@g) ->
           super
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS001: Remove Babel/TypeScript constructor workaround
@@ -89,18 +99,22 @@ describe('suggestions', () => {
           super(...arguments);
         }
       }
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests removing Array.from from for-of loops', () => {
-    check(`
+    check(
+      `
       for a in b
         c
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS101: Remove unnecessary use of Array.from
@@ -109,97 +123,121 @@ describe('suggestions', () => {
       for (let a of Array.from(b)) {
         c;
       }
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('does not suggest removing Array.from from for-of loops over an array literal', () => {
-    check(`
+    check(
+      `
       for a in [1, 2, 3]
         b
-    `, `
+    `,
+      `
       for (let a of [1, 2, 3]) {
         b;
       }
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests removing Array.from from includes usages', () => {
-    check(`
+    check(
+      `
       a in b
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS101: Remove unnecessary use of Array.from
        * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
        */
       Array.from(b).includes(a);
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests cleaning up implicit returns', () => {
-    check(`
+    check(
+      `
       ->
         f()
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS102: Remove unnecessary code created because of implicit returns
        * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
        */
       () => f();
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('does not suggest implicit returns when there is an explicit return', () => {
-    check(`
+    check(
+      `
       ->
         f()
         return
-    `, `
+    `,
+      `
       (function() {
         f();
       });
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('does not suggest implicit return cleanup for inline functions', () => {
-    check(`
+    check(
+      `
       values = [1, 2, 3]
       values = values.map((val) -> val + 1)
-    `, `
+    `,
+      `
       let values = [1, 2, 3];
       values = values.map(val => val + 1);
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests removing guard on complex soak operations', () => {
-    check(`
+    check(
+      `
       a()?.b
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS103: Rewrite code to no longer use __guard__
@@ -209,17 +247,21 @@ describe('suggestions', () => {
       function __guard__(value, transform) {
         return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
       }
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('does not suggest removing guard on simple soak operations', () => {
-    check(`
+    check(
+      `
       a?.b
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS207: Consider shorter variations of null checks
@@ -228,17 +270,21 @@ describe('suggestions', () => {
       if (typeof a !== 'undefined' && a !== null) {
         a.b;
       }
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests removing inline assignments', () => {
-    check(`
+    check(
+      `
       accounts[getAccountId()] //= splitFactor
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS104: Avoid inline assignments
@@ -246,59 +292,75 @@ describe('suggestions', () => {
        */
       let name;
       accounts[name = getAccountId()] = Math.floor(accounts[name] / splitFactor);
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests removing assignments when the expression is already repeatable', () => {
-    check(`
+    check(
+      `
       accounts[accountId] //= splitFactor
-    `, `
+    `,
+      `
       accounts[accountId] = Math.floor(accounts[accountId] / splitFactor);
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests simplifying complex assignments', () => {
-    check(`
+    check(
+      `
       {a: [b, ..., c]} = d
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS201: Simplify complex destructure assignments
        * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
        */
       const array = d.a, b = array[0], c = array[array.length - 1];
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('does not suggest simplifying simple assignments', () => {
-    check(`
+    check(
+      `
       {a: {b: c}} = d
-    `, `
+    `,
+      `
       const {a: {b: c}} = d;
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests simplifying dynamic range loops', () => {
-    check(`
+    check(
+      `
       for a in [b..c]
         d
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS202: Simplify dynamic range loops
@@ -307,33 +369,41 @@ describe('suggestions', () => {
       for (let a = b, end = c, asc = b <= end; asc ? a <= end : a >= end; asc ? a++ : a--) {
         d;
       }
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('does not suggest simplifying loops with a known direction', () => {
-    check(`
+    check(
+      `
       for a in [b..c] by 1
         d
-    `, `
+    `,
+      `
       for (let a = b, end = c; a <= end; a++) {
         d;
       }
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests cleaning up || {} in a for-own loop', () => {
-    check(`
+    check(
+      `
       for own a of b
         c
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS203: Remove \`|| {}\` from converted for-own loops
@@ -342,17 +412,21 @@ describe('suggestions', () => {
       for (let a of Object.keys(b || {})) {
         c;
       }
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests cleaning up order for complex `includes` usage', () => {
-    check(`
+    check(
+      `
       a() in b()
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS101: Remove unnecessary use of Array.from
@@ -362,37 +436,45 @@ describe('suggestions', () => {
        */
       let needle;
       (needle = a(), Array.from(b()).includes(needle));
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('does not suggest cleaning up order for simple `includes` usage', () => {
-    check(`
+    check(
+      `
       a in b
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS101: Remove unnecessary use of Array.from
        * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
        */
       Array.from(b).includes(a);
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests avoiding IIFEs', () => {
-    check(`
+    check(
+      `
       x = try
         a
       catch b
         c
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS205: Consider reworking code to avoid use of IIFEs
@@ -403,21 +485,25 @@ describe('suggestions', () => {
       } catch (b) {
         return c;
       } })();
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('does not suggest avoiding IIFEs when the return is pushed down', () => {
-    check(`
+    check(
+      `
       ->
         return if a
           b
         else
           c
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS102: Remove unnecessary code created because of implicit returns
@@ -430,18 +516,22 @@ describe('suggestions', () => {
           return c;
         }
       });
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests avoiding initClass when it is generated', () => {
-    check(`
+    check(
+      `
       class A
         b: c
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS206: Consider reworking classes to avoid initClass
@@ -453,33 +543,41 @@ describe('suggestions', () => {
         }
       }
       A.initClass();
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('does not suggest avoiding initClass for normal classes', () => {
-    check(`
+    check(
+      `
       class A
         b: -> c
-    `, `
+    `,
+      `
       class A {
         b() { return c; }
       }
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests shortening null checks for the binary existence operator', () => {
-    check(`
+    check(
+      `
       a = 1
       x = a ? b
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS207: Consider shorter variations of null checks
@@ -487,18 +585,22 @@ describe('suggestions', () => {
        */
       const a = 1;
       const x = a != null ? a : b;
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests shortening null checks for the unary existence operator', () => {
-    check(`
+    check(
+      `
       a = 1
       b = a?
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS207: Consider shorter variations of null checks
@@ -506,35 +608,43 @@ describe('suggestions', () => {
        */
       const a = 1;
       const b = (a != null);
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests removing top-level this', () => {
-    check(`
+    check(
+      `
       this
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS208: Avoid top-level this
        * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
        */
       this;
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests removing top-level this within a fat arrow function', () => {
-    check(`
+    check(
+      `
       =>
         return this
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS208: Avoid top-level this
@@ -543,48 +653,60 @@ describe('suggestions', () => {
       () => {
         return this;
       };
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('does not suggest removing top-level this within a normal function', () => {
-    check(`
+    check(
+      `
       ->
         return this
-    `, `
+    `,
+      `
       (function() {
         return this;
       });
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('does not consider a static method to use top-level this', () => {
-    check(`
+    check(
+      `
       class A
         @b: -> c
-    `, `
+    `,
+      `
       class A {
         static b() { return c; }
       }
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('suggests removing top-level return', () => {
-    check(`
+    check(
+      `
       if foo
         return
-    `, `
+    `,
+      `
       /*
        * decaffeinate suggestions:
        * DS209: Avoid top-level return
@@ -593,18 +715,22 @@ describe('suggestions', () => {
       if (foo) {
         return;
       }
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 
   it('preserves a shebang line at the top of the file', () => {
-    check(`
+    check(
+      `
       #!/usr/bin/env coffee
       a?.b
-    `, `
+    `,
+      `
       #!/usr/bin/env node
       /*
        * decaffeinate suggestions:
@@ -614,10 +740,12 @@ describe('suggestions', () => {
       if (typeof a !== 'undefined' && a !== null) {
         a.b;
       }
-    `, {
-      options: {
-        disableSuggestionComment: false,
-      },
-    });
+    `,
+      {
+        options: {
+          disableSuggestionComment: false
+        }
+      }
+    );
   });
 });

--- a/test/super_test.ts
+++ b/test/super_test.ts
@@ -1,15 +1,17 @@
-import check, {checkCS1} from './support/check';
+import check, { checkCS1 } from './support/check';
 
 describe('super', () => {
   it('spreads `arguments` when no arguments are given', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class C extends B
         constructor: (x) ->
           super
 
         fn: (x) ->
           super
-    `, `
+    `,
+      `
       class C extends B {
         constructor(x) {
           super(...arguments);
@@ -19,97 +21,122 @@ describe('super', () => {
           return super.fn(...arguments);
         }
       }
-    `);
+    `
+    );
   });
 
   // https://github.com/decaffeinate/decaffeinate/issues/375
   it('can be used as an argument to another call', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class A
         b: ->
           c(super)
-    `, `
+    `,
+      `
       class A {
         b() {
           return c(super.b(...arguments));
         }
       }
-    `);
+    `
+    );
   });
 
   it('allows super within a class assigned to a variable', () => {
-    checkCS1(`
+    checkCS1(
+      `
       A = class extends B
         f: ->
           super
-    `, `
+    `,
+      `
       const A = class extends B {
         f() {
           return super.f(...arguments);
         }
       };
-    `);
+    `
+    );
   });
 
   it('allows super within a method assignment with a property access class', () => {
-    checkCS1(`
+    checkCS1(
+      `
       a.b.prototype.c = -> super
-    `, `
+    `,
+      `
       let cls;
       (cls = a.b).prototype.c = function() { return cls.prototype.__proto__.c.call(this, ...arguments); };
-    `);
+    `
+    );
   });
 
   it('allows super within a method assignment with a computed class', () => {
-    checkCS1(`
+    checkCS1(
+      `
       a().prototype.b = -> super
-    `, `
+    `,
+      `
       let cls;
       (cls = a()).prototype.b = function() { return cls.prototype.__proto__.b.call(this, ...arguments); };
-    `);
+    `
+    );
   });
 
   it('allows super within a dynamic prototype member access', () => {
-    checkCS1(`
+    checkCS1(
+      `
       A().prototype[b()] = ->
         super
-    `, `
+    `,
+      `
       let cls, method;
       (cls = A()).prototype[method = b()] = function() {
         return cls.prototype.__proto__[method].call(this, ...arguments);
       };
-    `);
+    `
+    );
   });
 
   it('does not mark a proto assign as repeatable if the method does not call super', () => {
-    check(`
+    check(
+      `
       A().prototype[b()] = ->
         3
-    `, `
+    `,
+      `
       A().prototype[b()] = () => 3;
-    `);
+    `
+    );
   });
 
   it('allows super on a method with a non-identifier name', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class A
         0: -> super
-    `, `
+    `,
+      `
       class A {
         0() { return super[0](...arguments); }
       }
-    `);
+    `
+    );
   });
 
   it('allows super on a method with a non-repeatable computed name', () => {
-    checkCS1(`
+    checkCS1(
+      `
       class A
         "#{b()}": -> super
-    `, `
+    `,
+      `
       let method;
       class A {
         [method = b()]() { return super[method](...arguments); }
       }
-    `);
+    `
+    );
   });
 });

--- a/test/support/assertDeepEqual.ts
+++ b/test/support/assertDeepEqual.ts
@@ -20,13 +20,17 @@ function isDeepEqual(actual: any, expected: any): boolean {
     return false;
   }
   if (actual.constructor.name === 'Array' && expected.constructor.name === 'Array') {
-    return actual.length === expected.length &&
+    return (
+      actual.length === expected.length &&
       // tslint:disable-next-line:no-any
-      actual.every((val: any, i: number) => isDeepEqual(val, expected[i]));
+      actual.every((val: any, i: number) => isDeepEqual(val, expected[i]))
+    );
   }
   if (actual.constructor.name === 'Object' && expected.constructor.name === 'Object') {
-    return isDeepEqual(Object.keys(actual).sort(), Object.keys(expected).sort()) &&
-      Object.keys(actual).every(key => isDeepEqual(actual[key], expected[key]));
+    return (
+      isDeepEqual(Object.keys(actual).sort(), Object.keys(expected).sort()) &&
+      Object.keys(actual).every(key => isDeepEqual(actual[key], expected[key]))
+    );
   }
   return false;
 }

--- a/test/support/assertError.ts
+++ b/test/support/assertError.ts
@@ -5,8 +5,13 @@ import PatchError from '../../src/utils/PatchError';
 import stripSharedIndent from '../../src/utils/stripSharedIndent';
 
 export default function assertError(
-    source: string, expectedErrorText: string, options: Options=DEFAULT_OPTIONS): void {
-  if (source[0] === '\n') { source = stripSharedIndent(source); }
+  source: string,
+  expectedErrorText: string,
+  options: Options = DEFAULT_OPTIONS
+): void {
+  if (source[0] === '\n') {
+    source = stripSharedIndent(source);
+  }
 
   try {
     convert(source, options);

--- a/test/support/check.ts
+++ b/test/support/check.ts
@@ -10,25 +10,38 @@ export type Extra = {
 };
 
 export default function check(
-    source: string, expected: string, {options={}, shouldStripIndent=true}: Extra = {}): void {
-  ({source, expected} = maybeStripIndent(shouldStripIndent, source, expected));
-  checkOutput(source, expected, {...options, useCS2: false});
-  checkOutput(source, expected, {...options, useCS2: true});
+  source: string,
+  expected: string,
+  { options = {}, shouldStripIndent = true }: Extra = {}
+): void {
+  ({ source, expected } = maybeStripIndent(shouldStripIndent, source, expected));
+  checkOutput(source, expected, { ...options, useCS2: false });
+  checkOutput(source, expected, { ...options, useCS2: true });
 }
 
 export function checkCS1(
-    source: string, expected: string, {options={}, shouldStripIndent=true}: Extra = {}): void {
-  ({source, expected} = maybeStripIndent(shouldStripIndent, source, expected));
-  checkOutput(source, expected, {...options, useCS2: false});
+  source: string,
+  expected: string,
+  { options = {}, shouldStripIndent = true }: Extra = {}
+): void {
+  ({ source, expected } = maybeStripIndent(shouldStripIndent, source, expected));
+  checkOutput(source, expected, { ...options, useCS2: false });
 }
 
 export function checkCS2(
-    source: string, expected: string, {options={}, shouldStripIndent=true}: Extra = {}): void {
-  ({source, expected} = maybeStripIndent(shouldStripIndent, source, expected));
-  checkOutput(source, expected, {...options, useCS2: true});
+  source: string,
+  expected: string,
+  { options = {}, shouldStripIndent = true }: Extra = {}
+): void {
+  ({ source, expected } = maybeStripIndent(shouldStripIndent, source, expected));
+  checkOutput(source, expected, { ...options, useCS2: true });
 }
 
-function maybeStripIndent(shouldStripIndent: boolean, source: string, expected: string): {source: string, expected: string} {
+function maybeStripIndent(
+  shouldStripIndent: boolean,
+  source: string,
+  expected: string
+): { source: string; expected: string } {
   if (shouldStripIndent) {
     if (source[0] === '\n') {
       source = stripSharedIndent(source);
@@ -37,14 +50,14 @@ function maybeStripIndent(shouldStripIndent: boolean, source: string, expected: 
       expected = stripSharedIndent(expected);
     }
   }
-  return {source, expected};
+  return { source, expected };
 }
 
 function checkOutput(source: string, expected: string, options: Options): void {
   try {
     let converted = convert(source, {
       disableSuggestionComment: true,
-      ...options,
+      ...options
     });
     let actual = converted.code;
     if (actual.endsWith('\n') && !expected.endsWith('\n')) {

--- a/test/support/validate.ts
+++ b/test/support/validate.ts
@@ -8,10 +8,10 @@ import PatchError from '../../src/utils/PatchError';
 import assertDeepEqual from './assertDeepEqual';
 
 export type ValidateOptions = {
-  options?: Options,
+  options?: Options;
   // If we generate syntax not supported by node, don't try running the
   // resulting JS there directly.
-  skipNodeCheck?: boolean,
+  skipNodeCheck?: boolean;
 };
 
 /**
@@ -32,36 +32,40 @@ export type ValidateOptions = {
  * 'o' variable must be equal to that value.
  */
 export default function validate(
-    // tslint:disable-next-line:no-any
-    source: string, expectedOutput?: any | {cs1: any, cs2: any},
-    {options = {}, skipNodeCheck = false}: ValidateOptions = {}
-  ): void {
+  source: string,
+  // tslint:disable-next-line:no-any
+  expectedOutput?: any | { cs1: any; cs2: any },
+  { options = {}, skipNodeCheck = false }: ValidateOptions = {}
+): void {
   let expectedCS1 = expectedOutput && expectedOutput.hasOwnProperty('cs1') ? expectedOutput.cs1 : expectedOutput;
   let expectedCS2 = expectedOutput && expectedOutput.hasOwnProperty('cs2') ? expectedOutput.cs2 : expectedOutput;
-  runValidateCase(source, expectedCS1, {options: {...options, useCS2: false}, skipNodeCheck});
-  runValidateCase(source, expectedCS2, {options: {...options, useCS2: true}, skipNodeCheck});
+  runValidateCase(source, expectedCS1, { options: { ...options, useCS2: false }, skipNodeCheck });
+  runValidateCase(source, expectedCS2, { options: { ...options, useCS2: true }, skipNodeCheck });
 }
 
 export function validateCS1(
+  source: string,
   // tslint:disable-next-line:no-any
-  source: string, expectedOutput?: any,
-  {options = {}, skipNodeCheck = false}: ValidateOptions = {}
+  expectedOutput?: any,
+  { options = {}, skipNodeCheck = false }: ValidateOptions = {}
 ): void {
-  runValidateCase(source, expectedOutput, {options: {...options, useCS2: false}, skipNodeCheck});
+  runValidateCase(source, expectedOutput, { options: { ...options, useCS2: false }, skipNodeCheck });
 }
 
 export function validateCS2(
+  source: string,
   // tslint:disable-next-line:no-any
-  source: string, expectedOutput?: any,
-  {options = {}, skipNodeCheck = false}: ValidateOptions = {}
+  expectedOutput?: any,
+  { options = {}, skipNodeCheck = false }: ValidateOptions = {}
 ): void {
-  runValidateCase(source, expectedOutput, {options: {...options, useCS2: true}, skipNodeCheck});
+  runValidateCase(source, expectedOutput, { options: { ...options, useCS2: true }, skipNodeCheck });
 }
 
 function runValidateCase(
+  source: string,
   // tslint:disable-next-line:no-any
-  source: string, expectedOutput?: any,
-  {options = {}, skipNodeCheck = false}: ValidateOptions = {}
+  expectedOutput?: any,
+  { options = {}, skipNodeCheck = false }: ValidateOptions = {}
 ): void {
   try {
     runValidation(source, expectedOutput, options, skipNodeCheck);
@@ -96,10 +100,11 @@ function runValidation(source: string, expectedOutput: {}, options: Options, ski
   let compile = options.useCS2 ? cs2Compile : cs1Compile;
   let coffeeES5 = compile(source, { bare: true }) as string;
   let decaffeinateES6 = convert(source, options).code;
-  let decaffeinateES5 = babel.transform(decaffeinateES6, {
-    presets: ['es2015'],
-    plugins: ['transform-optional-chaining'],
-  }).code || '';
+  let decaffeinateES5 =
+    babel.transform(decaffeinateES6, {
+      presets: ['es2015'],
+      plugins: ['transform-optional-chaining']
+    }).code || '';
 
   let coffeeOutput = runCodeAndExtract(coffeeES5);
   let decaffeinateOutput = runCodeAndExtract(decaffeinateES5);

--- a/test/switch_test.ts
+++ b/test/switch_test.ts
@@ -3,50 +3,59 @@ import validate from './support/validate';
 
 describe('switch', () => {
   it('works with a single case', () => {
-    check(`
+    check(
+      `
       switch a
         when b
           c
-    `, `
+    `,
+      `
       switch (a) {
         case b:
           c;
           break;
       }
-    `);
+    `
+    );
   });
 
   it('works when there is a comment after the expression', () => {
-    check(`
+    check(
+      `
       switch a # yolo
         when b
           c
-    `, `
+    `,
+      `
       switch (a) { // yolo
         case b:
           c;
           break;
       }
-    `);
+    `
+    );
   });
 
-
   it('works when the expression is already surrounded by parens', () => {
-    check(`
+    check(
+      `
       switch (a?)
         when b
           c
-    `, `
+    `,
+      `
       switch (typeof a !== 'undefined' && a !== null) {
         case b:
           c;
           break;
       }
-    `);
+    `
+    );
   });
 
   it('only inserts break statements when needed', () => {
-    check(`
+    check(
+      `
       switch a
         when b
           c
@@ -54,7 +63,8 @@ describe('switch', () => {
         when d
           e
           break
-    `, `
+    `,
+      `
       switch (a) {
         case b:
           c;
@@ -63,17 +73,20 @@ describe('switch', () => {
           e;
           break;
       }
-    `);
+    `
+    );
   });
 
   it('works with multiple cases', () => {
-    check(`
+    check(
+      `
       switch a
         when b
           c
         when d
           e
-    `, `
+    `,
+      `
       switch (a) {
         case b:
           c;
@@ -82,42 +95,51 @@ describe('switch', () => {
           e;
           break;
       }
-    `);
+    `
+    );
   });
 
   it('works with multiple conditions per case', () => {
-    check(`
+    check(
+      `
       switch a
         when b, c
           d
-    `, `
+    `,
+      `
       switch (a) {
         case b: case c:
           d;
           break;
       }
-    `);
+    `
+    );
   });
 
   it('works with cases and consequents on the same line', () => {
-    check(`
+    check(
+      `
       switch a
         when b then c
-    `, `
+    `,
+      `
       switch (a) {
         case b: c; break;
       }
-    `);
+    `
+    );
   });
 
   it('works with a default case', () => {
-    check(`
+    check(
+      `
       switch a
         when b
           c
         else
           d
-    `, `
+    `,
+      `
       switch (a) {
         case b:
           c;
@@ -125,29 +147,35 @@ describe('switch', () => {
         default:
           d;
       }
-    `);
+    `
+    );
   });
 
   it('works with a single-line default case', () => {
-    check(`
+    check(
+      `
       switch a
         when b then c
         else d
-    `, `
+    `,
+      `
       switch (a) {
         case b: c; break;
         default: d;
       }
-    `);
+    `
+    );
   });
 
   it('works with an indented switch', () => {
-    check(`
+    check(
+      `
       if true
         switch a
           when b
             c
-    `, `
+    `,
+      `
       if (true) {
         switch (a) {
           case b:
@@ -155,11 +183,13 @@ describe('switch', () => {
             break;
         }
       }
-    `);
+    `
+    );
   });
 
   it('works with implicit returns', () => {
-    check(`
+    check(
+      `
       ->
         switch a
           when b then c
@@ -167,7 +197,8 @@ describe('switch', () => {
             e
             f
           else g
-    `, `
+    `,
+      `
       (function() {
         switch (a) {
           case b: return c;
@@ -177,17 +208,20 @@ describe('switch', () => {
           default: return g;
         }
       });
-    `);
+    `
+    );
   });
 
   it('works with implicit returns with the default case on another line', () => {
-    check(`
+    check(
+      `
       ->
         switch a
           when b then c
           else
             d
-    `, `
+    `,
+      `
       (function() {
         switch (a) {
           case b: return c;
@@ -195,17 +229,20 @@ describe('switch', () => {
             return d;
         }
       });
-    `);
+    `
+    );
   });
 
   it('writes the closing curly brace inside a function closing brace', () => {
-    check(`
+    check(
+      `
       a = ->
         switch b
           when c
             d
       e
-    `, `
+    `,
+      `
       const a = function() {
         switch (b) {
           case c:
@@ -213,18 +250,21 @@ describe('switch', () => {
         }
       };
       e;
-    `);
+    `
+    );
   });
 
   it('converts a switch without an expression properly', () => {
-    check(`
+    check(
+      `
       switch
         when score < 60 then 'F'
         when score < 70 then 'D'
         when score < 80 then 'C'
         when score < 90 then 'B'
         else 'A'
-    `, `
+    `,
+      `
       switch (false) {
         case score >= 60: 'F'; break;
         case score >= 70: 'D'; break;
@@ -232,21 +272,25 @@ describe('switch', () => {
         case score >= 90: 'B'; break;
         default: 'A';
       }
-    `, {
-      options: {
-        looseComparisonNegation: true,
+    `,
+      {
+        options: {
+          looseComparisonNegation: true
+        }
       }
-    });
+    );
   });
 
   it('converts a switch without an expression with function call cases', () => {
-    check(`
+    check(
+      `
       switch
         when a()
           'B'
         when c()
           'D'
-    `, `
+    `,
+      `
       switch (false) {
         case !a():
           'B';
@@ -255,39 +299,47 @@ describe('switch', () => {
           'D';
           break;
       }
-    `);
+    `
+    );
   });
 
   it('works with `switch` used as an expression', () => {
-    check(`
+    check(
+      `
       a = switch b
         when c then d
         when f
           return g
         else e
-    `, `
+    `,
+      `
       const a = (() => { switch (b) {
         case c: return d;
         case f:
           return g;
         default: return e;
       } })();
-    `);
+    `
+    );
   });
 
   it('works with `switch` used as an expression surrounded by parens', () => {
-    check(`
+    check(
+      `
       a(switch b
         when c then d)
-    `, `
+    `,
+      `
       a((() => { switch (b) {
         case c: return d;
       } })());
-    `);
+    `
+    );
   });
 
   it('works with the switch from the CoffeeScript demo page', () => {
-    check(`
+    check(
+      `
     switch day
       when "Mon" then go work
       when "Tue" then go relax
@@ -298,7 +350,8 @@ describe('switch', () => {
           go dancing
       when "Sun" then go church
       else go work
-    `, `
+    `,
+      `
       switch (day) {
         case "Mon": go(work); break;
         case "Tue": go(relax); break;
@@ -312,30 +365,36 @@ describe('switch', () => {
         case "Sun": go(church); break;
         default: go(work);
       }
-    `);
+    `
+    );
   });
 
   it('works with switch expressions returning an object literal', () => {
-    check(`
+    check(
+      `
       a b, switch c
         when d
           {}
-    `, `
+    `,
+      `
       a(b, (() => { switch (c) {
         case d:
           return {};
       } })());
-    `);
+    `
+    );
   });
 
   it('works with empty switch cases', () => {
-    check(`
+    check(
+      `
     switch a
       when b then
         # Do nothing
       when c then
         # Do nothing
-    `, `
+    `,
+      `
       switch (a) {
         case b:
           break;
@@ -344,17 +403,20 @@ describe('switch', () => {
           break;
       }
           // Do nothing
-    `);
+    `
+    );
   });
 
   it('handles a switch as an argument to a function call', () => {
-    check(`
+    check(
+      `
       a switch b
         when c
           d
         when e
           f
-    `, `
+    `,
+      `
       a((() => { switch (b) {
         case c:
           return d;
@@ -362,11 +424,13 @@ describe('switch', () => {
           return f;
       
       } })());
-    `);
+    `
+    );
   });
 
   it('inserts break statements properly in cases containing returns', () => {
-    check(`
+    check(
+      `
       ->
         switch a
           when b
@@ -375,7 +439,8 @@ describe('switch', () => {
           when e
             if f
               return g
-    `, `
+    `,
+      `
       (function() {
         switch (a) {
           case b:
@@ -390,18 +455,21 @@ describe('switch', () => {
             break;
         }
       });
-    `);
+    `
+    );
   });
 
   it('handles switch expressions within simple for expressions', () => {
-    check(`
+    check(
+      `
       x = for a in b
         switch a
           when 'c'
             d
           else
             e
-    `, `
+    `,
+      `
       const x = (() => {
         const result = [];
         for (let a of Array.from(b)) {
@@ -415,11 +483,13 @@ describe('switch', () => {
         }
         return result;
       })();
-    `);
+    `
+    );
   });
 
   it('handles switch expressions within complex for expressions', () => {
-    check(`
+    check(
+      `
       x = for a in b by 1
         y = switch a
           when 'c'
@@ -427,7 +497,8 @@ describe('switch', () => {
           else
             e
         y
-    `, `
+    `,
+      `
       const x = (() => {
         const result = [];
         for (let i = 0; i < b.length; i++) {
@@ -442,18 +513,21 @@ describe('switch', () => {
         }
         return result;
       })();
-    `);
+    `
+    );
   });
 
   it('handles a switch case with a while loop with a break', () => {
-    check(`
+    check(
+      `
       switch a
         when 'b'
           while false
             break
         when 'c'
           console.log 'Got here'
-    `, `
+    `,
+      `
       switch (a) {
         case 'b':
           while (false) {
@@ -464,32 +538,38 @@ describe('switch', () => {
           console.log('Got here');
           break;
       }
-    `);
+    `
+    );
   });
 
   it('sets the switch condition to be an expression', () => {
-    check(`
+    check(
+      `
       a = 1
       switch (a ?= b)
         when c
           d
-    `, `
+    `,
+      `
       let a = 1;
       switch (a != null ? a : (a = b)) {
         case c:
           d;
           break;
       }
-    `);
+    `
+    );
   });
 
   it('allows an IIFE-style switch inside a generator', () => {
-    check(`
+    check(
+      `
       ->
         x = switch yield 1
           when 2
             3
-    `, `
+    `,
+      `
       (function*() {
         let x;
         return x = yield* (function*() { switch ((yield 1)) {
@@ -497,16 +577,19 @@ describe('switch', () => {
             return 3;
         } }).call(this);
       });
-    `);
+    `
+    );
   });
 
   it('properly handles an expression-style switch in an implicit return context', () => {
-    check(`
+    check(
+      `
       ->
         x = (switch a
            when b
              c)
-    `, `
+    `,
+      `
       (function() {
         let x;
         return x = ((() => { switch (a) {
@@ -514,60 +597,72 @@ describe('switch', () => {
              return c;
         } })());
       });
-    `);
+    `
+    );
   });
 
   it('handles parenthesized break in a switch statement', () => {
-    check(`
+    check(
+      `
       x = switch a
         when b
           (break)
-    `, `
+    `,
+      `
       const x = (() => { switch (a) {
         case b:
           break;
       } })();
-    `);
+    `
+    );
   });
 
   it('handles break within switch in an implicit return context', () => {
-    check(`
+    check(
+      `
       ->
         switch a
           when b
             break
-    `, `
+    `,
+      `
       (function() {
         switch (a) {
           case b:
             break;
         }
       });
-    `);
+    `
+    );
   });
 
   it('handles a parenthesized switch case', () => {
-    check(`
+    check(
+      `
       switch a
         when (b)
           c
-    `, `
+    `,
+      `
       switch (a) {
         case (b):
           c;
           break;
       }
-    `);
+    `
+    );
   });
 
   it('allows falling through in a returned switch', () => {
-    check(`
+    check(
+      `
       ->
         return switch a
           when b
             c
         d
-    `, `
+    `,
+      `
       (function() {
         switch (a) {
           case b:
@@ -575,39 +670,48 @@ describe('switch', () => {
         }
         return d;
       });
-    `);
+    `
+    );
   });
 
   it('gives the correct result when returning an incomplete switch', () => {
-    validate(`
+    validate(
+      `
       f = ->
         return switch 1
           when 2
             3
         4
       setResult(f())
-    `, 4);
+    `,
+      4
+    );
   });
 
   it('gives the correct result when returning a parenthesized incomplete switch', () => {
-    validate(`
+    validate(
+      `
       f = ->
         return (switch 1
           when 2
             3)
         4
       setResult('' + f())
-    `, 'undefined');
+    `,
+      'undefined'
+    );
   });
 
   it('handles an IIFE switch with an assignment followed by access', () => {
-    check(`
+    check(
+      `
       a =
         switch b
           when c
             d = e
       d
-    `, `
+    `,
+      `
       let d;
       const a =
         (() => { switch (b) {
@@ -615,6 +719,7 @@ describe('switch', () => {
             return d = e;
         } })();
       d;
-    `);
+    `
+    );
   });
 });

--- a/test/throw_test.ts
+++ b/test/throw_test.ts
@@ -1,4 +1,4 @@
-import check, {checkCS1} from './support/check';
+import check, { checkCS1 } from './support/check';
 
 describe('throw', () => {
   it('is preserved when used in a statement context', () => {
@@ -14,66 +14,87 @@ describe('throw', () => {
   });
 
   it('is not considered an implicitly-returnable value', () => {
-    check(`
+    check(
+      `
       ->
         if err
           throw 42
-    `, `
+    `,
+      `
       (function() {
         if (err) {
           throw 42;
         }
       });
-    `);
+    `
+    );
   });
 
   it('blocks parent conditionals from becoming ternary expressions in single-line functions', () => {
-    check(`
+    check(
+      `
       -> if a then throw b
-    `, `
+    `,
+      `
       (function() { if (a) { throw b; } });
-    `);
+    `
+    );
   });
 
   it('blocks parent conditionals with a `return` from becoming ternary expressions in single-line functions', () => {
-    check(`
+    check(
+      `
       -> if a then throw b else c
-    `, `
+    `,
+      `
       (function() { if (a) { throw b; } else { return c; } });
-    `);
+    `
+    );
   });
 
   it('blocks parent conditionals from becoming ternary expressions in single-line bound functions', () => {
-    check(`
+    check(
+      `
       => if a then throw b
-    `, `
+    `,
+      `
       () => { if (a) { throw b; } };
-    `);
+    `
+    );
   });
 
   it('allows multiline throw statements', () => {
-    checkCS1(`
+    checkCS1(
+      `
       throw
         a
-    `, `
+    `,
+      `
       throw a;
-    `);
+    `
+    );
   });
 
   it('allows multiline throw expressions', () => {
-    checkCS1(`
+    checkCS1(
+      `
       (throw
         a)
-    `, `
+    `,
+      `
       throw a;
-    `);
+    `
+    );
   });
 
   it('treats the throw target as an expression', () => {
-    check(`
+    check(
+      `
       throw(res.data?.error)
-    `, `
+    `,
+      `
       throw(res.data != null ? res.data.error : undefined);
-    `);
+    `
+    );
   });
 });

--- a/test/try_test.ts
+++ b/test/try_test.ts
@@ -3,28 +3,33 @@ import validate from './support/validate';
 
 describe('try', () => {
   it('handles multi-line try/catch with catch assignee', () => {
-    check(`
+    check(
+      `
       try
         a()
       catch ex
         b()
-    `, `
+    `,
+      `
       try {
         a();
       } catch (ex) {
         b();
       }
-    `);
+    `
+    );
   });
 
   it('handles indented multi-line try/catch with catch assignee', () => {
-    check(`
+    check(
+      `
       ->
         try
           a()
         catch ex
           b()
-    `, `
+    `,
+      `
       (function() {
         try {
           return a();
@@ -32,246 +37,309 @@ describe('try', () => {
           return b();
         }
       });
-    `);
+    `
+    );
   });
 
   it('handles multi-line try/catch without catch assignee', () => {
-    check(`
+    check(
+      `
       try
         a()
       catch
         b()
-    `, `
+    `,
+      `
       try {
         a();
       } catch (error) {
         b();
       }
-    `);
+    `
+    );
   });
 
   it('handles multi-line try without catch clause without finally clause', () => {
-    check(`
+    check(
+      `
       try
         a()
-    `, `
+    `,
+      `
       try {
         a();
       } catch (error) {}
-    `);
+    `
+    );
   });
 
   it('handles multi-line indented try without catch clause without finally clause', () => {
-    check(`
+    check(
+      `
       ->
         try
           a()
-    `, `
+    `,
+      `
       (function() {
         try {
           return a();
         } catch (error) {}
       });
-    `);
+    `
+    );
   });
 
   it('handles multi-line try without catch clause with finally clause', () => {
-    check(`
+    check(
+      `
       try
         a()
       finally
         b()
-    `, `
+    `,
+      `
       try {
         a();
       } finally {
         b();
       }
-    `);
+    `
+    );
   });
 
   it('works with statements immediately following a catch-less try block', () => {
-    check(`
+    check(
+      `
       try
         a
       b
-    `, `
+    `,
+      `
       try {
         a;
       } catch (error) {}
       b;
-    `);
+    `
+    );
   });
 
   it('works with single-line try', () => {
-    check(`
+    check(
+      `
       try a
-    `, `
+    `,
+      `
       try { a; } catch (error) {}
-    `);
+    `
+    );
   });
 
   it('works with single-line try and single-line catch with `then`', () => {
-    check(`
+    check(
+      `
       try a catch err then b
-    `, `
+    `,
+      `
       try { a; } catch (err) { b; }
-    `);
+    `
+    );
   });
 
   it('works with single-line try used as an expression', () => {
-    check(`
+    check(
+      `
       a = try b()
-    `, `
+    `,
+      `
       const a = (() => { try { return b(); } catch (error) {} })();
-    `);
+    `
+    );
   });
 
   it('ensures the name of the catch assignee is unique', () => {
-    check(`
+    check(
+      `
       error = null
       try
         foo()
-    `, `
+    `,
+      `
       const error = null;
       try {
         foo();
       } catch (error1) {}
-    `);
+    `
+    );
   });
 
   it('handles try with an empty catch block', () => {
-    check(`
+    check(
+      `
       try
         something()
       catch
-    `, `
+    `,
+      `
       try {
         something();
       } catch (error) {}
-    `);
+    `
+    );
   });
 
   it('handles try with an empty finally block', () => {
-    check(`
+    check(
+      `
       try
         something()
       finally
-    `, `
+    `,
+      `
       try {
         something();
       } finally {}
-    `);
+    `
+    );
   });
 
   it('handles try with an empty catch and finally block', () => {
-    check(`
+    check(
+      `
       try
         something()
       catch
       finally
-    `, `
+    `,
+      `
       try {
         something();
       } catch (error) {}
       finally {}
-    `);
+    `
+    );
   });
 
   it('handles try with an empty catch block with a catch variable', () => {
-    check(`
+    check(
+      `
       try
         something()
       catch err
-    `, `
+    `,
+      `
       try {
         something();
       } catch (err) {}
-    `);
+    `
+    );
   });
 
   it('handles try with an empty catch block with a catch variable and an empty finally block', () => {
-    check(`
+    check(
+      `
       try
         something()
       catch err
       finally
-    `, `
+    `,
+      `
       try {
         something();
       } catch (err) {}
       finally {}
-    `);
+    `
+    );
   });
 
   it('handles try within a function with all blocks empty', () => {
-    check(`
+    check(
+      `
       ->
         try
         catch err
         finally
-    `, `
+    `,
+      `
       (function() {
         try {}
         catch (err) {}
         finally {}
       });
-    `);
+    `
+    );
   });
 
   it('handles try by itself', () => {
-    check(`
+    check(
+      `
       try
-    `, `
+    `,
+      `
       try {} catch (error) {}
-    `);
+    `
+    );
   });
 
   it('handles try with a non-empty catch', () => {
-    check(`
+    check(
+      `
       try
       catch
         a
-    `, `
+    `,
+      `
       try {}
       catch (error) {
         a;
       }
-    `);
+    `
+    );
   });
 
   it('handles empty try, catch, and finally all on one line', () => {
-    check(`
+    check(
+      `
       try catch err then finally
-    `, `
+    `,
+      `
       try {} catch (err) {} finally {}
-    `);
+    `
+    );
   });
 
   it('handles a try expression wrapped in parens', () => {
-    check(`
+    check(
+      `
       x = (try a catch b then c)
-    `, `
+    `,
+      `
       const x = ((() => { try { return a; } catch (b) { return c; } })());
-    `);
+    `
+    );
   });
 
   it('handles a try expression as an unless condition', () => {
-    check(`
+    check(
+      `
       unless (try a catch b then c) then d
-    `, `
+    `,
+      `
       if (!(() => { try { return a; } catch (b) { return c; } })()) { d; }
-    `);
+    `
+    );
   });
 
   it('handles an IIFE-style try statement with a yield', () => {
-    check(`
+    check(
+      `
       () ->
         x = try
           yield 1
         catch
           yield 2
-    `, `
+    `,
+      `
       (function*() {
         let x;
         return x = yield* (function*() { try {
@@ -280,17 +348,20 @@ describe('try', () => {
           return yield 2;
         } }).call(this);
       });
-    `);
+    `
+    );
   });
 
   it('treats the exception assignee as a normal variable in its outer scope if necessary', () => {
-    check(`
+    check(
+      `
       try
         a
       catch e
         b
       console.log e
-    `, `
+    `,
+      `
       let e;
       try {
         a;
@@ -299,76 +370,91 @@ describe('try', () => {
         b;
       }
       console.log(e);
-    `);
+    `
+    );
   });
 
   it('handles complex destructuring within a catch', () => {
-    check(`
+    check(
+      `
       try
         a
       catch {b: [c, ..., d]}
         e
-    `, `
+    `,
+      `
       try {
         a;
       } catch (error) {
         const array = error.b, c = array[0], d = array[array.length - 1];
         e;
       }
-    `);
+    `
+    );
   });
 
   it('properly picks a distinct variable name when choosing a catch assignee', () => {
-    check(`
+    check(
+      `
       try
         a
       catch {error}
         b
-    `, `
+    `,
+      `
       try {
         a;
       } catch (error1) {
         const {error} = error1;
         b;
       }
-    `);
+    `
+    );
   });
 
   it('handles a complex catch assignee with no catch body', () => {
-    check(`
+    check(
+      `
       try
         a
       catch error
       console.log error
-    `, `
+    `,
+      `
       let error;
       try {
         a;
       } catch (error1) { error = error1; }
       console.log(error);
-    `);
+    `
+    );
   });
 
   it('properly handles an expression-style try/catch in an implicit return context', () => {
-    check(`
+    check(
+      `
       ->
         x = (try a)
-    `, `
+    `,
+      `
       (function() {
         let x;
         return x = ((() => { try { return a; } catch (error) {} })());
       });
-    `);
+    `
+    );
   });
 
   it('properly handles continue within try within a loop expression', () => {
-    check(`
+    check(
+      `
       x = for a in b
         try
           continue
         catch error
           continue
-    `, `
+    `,
+      `
       const x = (() => {
         const result = [];
         for (let a of Array.from(b)) {
@@ -380,19 +466,24 @@ describe('try', () => {
         }
         return result;
       })();
-    `);
+    `
+    );
   });
 
   it('properly handles try used as an expression', () => {
-    check(`
+    check(
+      `
       x = try throw a catch then b
-    `, `
+    `,
+      `
       const x = (() => { try { throw a; } catch (error) { return b; } })();
-    `);
+    `
+    );
   });
 
   it('properly acts as an implicit return parent in expression form', () => {
-    validate(`
+    validate(
+      `
       arr = for i in [1, 2, 3]
         val = try
           1
@@ -400,35 +491,43 @@ describe('try', () => {
           2
         val
       setResult(arr)
-    `, [1, 1, 1]);
+    `,
+      [1, 1, 1]
+    );
   });
 
   it('properly handles a try/catch with `then` and an empty catch block', () => {
-    check(`
+    check(
+      `
       try
         a
       catch b then
-    `, `
+    `,
+      `
       try {
         a;
       } catch (b) {} 
-    `);
+    `
+    );
   });
 
   it('handles an IIFE try/catch with an assignment followed by access', () => {
-    check(`
+    check(
+      `
       a =
         try
           b = c
         catch
       b
-    `, `
+    `,
+      `
       let b;
       const a =
         (() => { try {
           return b = c;
         } catch (error) {} })();
       b;
-    `);
+    `
+    );
   });
 });

--- a/test/unary_operator_test.ts
+++ b/test/unary_operator_test.ts
@@ -35,14 +35,17 @@ describe('unary operators', () => {
   });
 
   it('transforms `not` to `!` when used in a condition', () => {
-    check(`
+    check(
+      `
       if not 0
         1
-    `, `
+    `,
+      `
       if (!0) {
         1;
       }
-    `);
+    `
+    );
   });
 
   it('preserves typeof operators', () => {
@@ -54,11 +57,14 @@ describe('unary operators', () => {
   });
 
   it('converts unary existential identifier checks of known bindings to non-strict null check', () => {
-    check(`
+    check(
+      `
       (a) -> a?
-    `, `
+    `,
+      `
       a => a != null;
-    `);
+    `
+    );
   });
 
   it('converts unary existential non-identifier to non-strict null check', () => {
@@ -77,49 +83,64 @@ describe('unary operators', () => {
   });
 
   it('converts unary existential operator and handles negation', () => {
-    check(`
+    check(
+      `
       unless a? and c
         b
-    `, `
+    `,
+      `
       if ((typeof a === 'undefined' || a === null) || !c) {
         b;
       }
-    `);
+    `
+    );
 
-    check(`
+    check(
+      `
       unless a.b?
         b
-    `, `
+    `,
+      `
       if (a.b == null) {
         b;
       }
-    `);
+    `
+    );
   });
 
   it('converts unary existential operator handling negation from a `not` prefix', () => {
-    check(`
+    check(
+      `
       (a) -> not a?
-    `, `
+    `,
+      `
       a => a == null;
-    `);
+    `
+    );
   });
 
   it('properly respects precedence with a unary operator in a conditional', () => {
-    check(`
+    check(
+      `
       unless typeof a.b?
         c
-    `, `
+    `,
+      `
       if (!typeof (a.b != null)) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('treats the increment operator as non-repeatable', () => {
-    validate(`
+    validate(
+      `
       n = 1
       (n++)?.toString()
       setResult(n)
-    `, 2);
+    `,
+      2
+    );
   });
 });

--- a/test/utils/PatchError_test.ts
+++ b/test/utils/PatchError_test.ts
@@ -5,7 +5,8 @@ import stripSharedIndent from '../../src/utils/stripSharedIndent';
 describe('PatchError', () => {
   it('handles files not ending in newlines', () => {
     let error = new PatchError('Sample error', 'abcdefg', 2, 4);
-    let expected = stripSharedIndent(`
+    let expected =
+      stripSharedIndent(`
       Sample error
       > 1 | abcdefg
           |   ^^
@@ -15,7 +16,8 @@ describe('PatchError', () => {
 
   it('does not crash on an out-of-order range', () => {
     let error = new PatchError('Sample error', 'abcdefg', 4, 2);
-    let expected = stripSharedIndent(`
+    let expected =
+      stripSharedIndent(`
       Sample error
       > 1 | abcdefg
           |     ^

--- a/test/utils/Scope_test.ts
+++ b/test/utils/Scope_test.ts
@@ -94,17 +94,13 @@ describe('Scope', () => {
   it('processes for-of loops by binding key and value assignees', () => {
     let scope = new Scope(containerNode);
     scope.processNode(statement('for key, {a, b, c: [d, e]} of object\n  key'));
-    ['key', 'a', 'b', 'd', 'e'].forEach(name =>
-        ok(scope.getBinding(name), `\`${name}\` should be bound in: ${scope}`)
-    );
+    ['key', 'a', 'b', 'd', 'e'].forEach(name => ok(scope.getBinding(name), `\`${name}\` should be bound in: ${scope}`));
   });
 
   it('processes for-in loops by binding value assignees', () => {
     let scope = new Scope(containerNode);
     scope.processNode(statement('for [a, {b, c}, d] in array\n  a'));
-    ['a', 'b', 'c', 'd'].forEach(name =>
-        ok(scope.getBinding(name), `\`${name}\` should be bound in: ${scope}`)
-    );
+    ['a', 'b', 'c', 'd'].forEach(name => ok(scope.getBinding(name), `\`${name}\` should be bound in: ${scope}`));
   });
 
   describe('claimFreeBinding', () => {

--- a/test/utils/formatCoffeeLexTokens_test.ts
+++ b/test/utils/formatCoffeeLexTokens_test.ts
@@ -12,7 +12,9 @@ describe('formatCoffeeLexTokens', () => {
     `);
     let tokenList = lex(source);
     let formattedTokens = formatCoffeeLexTokens(tokenList, new CodeContext(source));
-    strictEqual(formattedTokens, stripSharedIndent(`
+    strictEqual(
+      formattedTokens,
+      stripSharedIndent(`
       [1:1(0)-1:2(1)]: IDENTIFIER
       [1:3(2)-1:4(3)]: OPERATOR
       [1:5(4)-1:8(7)]: FOR
@@ -23,6 +25,7 @@ describe('formatCoffeeLexTokens', () => {
       [2:3(17)-2:4(18)]: IDENTIFIER
       [2:4(18)-2:5(19)]: CALL_START
       [2:5(19)-2:6(20)]: CALL_END
-    `) + '\n');
+    `) + '\n'
+    );
   });
 });

--- a/test/utils/formatCoffeeScriptAst_test.ts
+++ b/test/utils/formatCoffeeScriptAst_test.ts
@@ -1,6 +1,6 @@
 import { strictEqual } from 'assert';
-import {nodes as cs1Nodes} from 'decaffeinate-coffeescript';
-import {nodes as cs2Nodes} from 'decaffeinate-coffeescript2';
+import { nodes as cs1Nodes } from 'decaffeinate-coffeescript';
+import { nodes as cs2Nodes } from 'decaffeinate-coffeescript2';
 import CodeContext from '../../src/utils/CodeContext';
 import formatCoffeeScriptAst from '../../src/utils/formatCoffeeScriptAst';
 import stripSharedIndent from '../../src/utils/stripSharedIndent';
@@ -11,7 +11,9 @@ describe('formatCoffeeScriptAst', () => {
       x = a()
     `);
     let formattedTokens = formatCoffeeScriptAst(cs2Nodes(source), new CodeContext(source));
-    strictEqual(formattedTokens, stripSharedIndent(`
+    strictEqual(
+      formattedTokens,
+      stripSharedIndent(`
       Block [1:1(0)-1:8(7)] {
         expressions: [
           Assign [1:1(0)-1:8(7)] {
@@ -49,7 +51,8 @@ describe('formatCoffeeScriptAst', () => {
         ]
       }
 
-    `) + '\n');
+    `) + '\n'
+    );
   });
 
   it('properly formats switch statements', () => {
@@ -59,7 +62,9 @@ describe('formatCoffeeScriptAst', () => {
           2
     `);
     let formattedTokens = formatCoffeeScriptAst(cs2Nodes(source), new CodeContext(source));
-    strictEqual(formattedTokens, stripSharedIndent(`
+    strictEqual(
+      formattedTokens,
+      stripSharedIndent(`
       Block [1:1(0)-3:6(21)] {
         expressions: [
           Switch [1:1(0)-3:6(21)] {
@@ -90,7 +95,8 @@ describe('formatCoffeeScriptAst', () => {
           }
         ]
       }
-    `) + '\n');
+    `) + '\n'
+    );
   });
 
   it('properly formats CS1 code', () => {
@@ -98,7 +104,9 @@ describe('formatCoffeeScriptAst', () => {
       x = 1
     `);
     let formattedTokens = formatCoffeeScriptAst(cs1Nodes(source), new CodeContext(source));
-    strictEqual(formattedTokens, stripSharedIndent(`
+    strictEqual(
+      formattedTokens,
+      stripSharedIndent(`
       Block [1:1(0)-1:6(5)] {
         expressions: [
           Assign [1:1(0)-1:6(5)] {
@@ -122,6 +130,7 @@ describe('formatCoffeeScriptAst', () => {
           }
         ]
       }
-    `) + '\n');
+    `) + '\n'
+    );
   });
 });

--- a/test/utils/formatCoffeeScriptLexerTokens_test.ts
+++ b/test/utils/formatCoffeeScriptLexerTokens_test.ts
@@ -11,7 +11,9 @@ describe('formatCoffeeScriptLexerTokens', () => {
         a()
     `);
     let formattedTokens = formatCoffeeScriptLexerTokens(tokens(source), new CodeContext(source));
-    strictEqual(formattedTokens, stripSharedIndent(`
+    strictEqual(
+      formattedTokens,
+      stripSharedIndent(`
       [1:1(0)-1:2(1)]: IDENTIFIER: "x"
       [1:3(2)-1:4(3)]: =: "="
       [1:5(4)-1:8(7)]: FOR: "for"
@@ -24,6 +26,7 @@ describe('formatCoffeeScriptLexerTokens', () => {
       [2:5(19)-2:6(20)]: CALL_END: ")"
       [2:5(19)-2:6(20)]: OUTDENT: 2
       [2:6(20)-2:6(20)]: TERMINATOR: "\\n"
-    `) + '\n');
+    `) + '\n'
+    );
   });
 });

--- a/test/utils/formatDecaffeinateParserAst_test.ts
+++ b/test/utils/formatDecaffeinateParserAst_test.ts
@@ -1,5 +1,5 @@
 import { strictEqual } from 'assert';
-import {parse} from 'decaffeinate-parser';
+import { parse } from 'decaffeinate-parser';
 import CodeContext from '../../src/utils/CodeContext';
 import formatDecaffeinateParserAst from '../../src/utils/formatDecaffeinateParserAst';
 import stripSharedIndent from '../../src/utils/stripSharedIndent';
@@ -12,7 +12,9 @@ describe('formatDecaffeinateParserAst', () => {
         break
     `);
     let formattedTokens = formatDecaffeinateParserAst(parse(source), new CodeContext(source));
-    strictEqual(formattedTokens, stripSharedIndent(`
+    strictEqual(
+      formattedTokens,
+      stripSharedIndent(`
       Program [1:1(0)-3:8(22)] {
         body: Block [1:1(0)-3:8(22)] {
           inline: false
@@ -40,6 +42,7 @@ describe('formatDecaffeinateParserAst', () => {
           ]
         }
       }
-    `) + '\n');
+    `) + '\n'
+    );
   });
 });

--- a/test/utils/resolveToPatchError_test.ts
+++ b/test/utils/resolveToPatchError_test.ts
@@ -22,12 +22,15 @@ describe('resolveToPatchError', () => {
       if (!patchError) {
         throw new Error('Expected non-null error.');
       }
-      strictEqual(PatchError.prettyPrint(patchError), stripSharedIndent(`
+      strictEqual(
+        PatchError.prettyPrint(patchError),
+        stripSharedIndent(`
         testStage failed to parse: Unexpected token, expected ; (2:3)
           1 | let x = 3;
         > 2 | f())
             |    ^
-          3 | console.log('test');`) + '\n');
+          3 | console.log('test');`) + '\n'
+      );
     }
   });
 
@@ -44,12 +47,15 @@ describe('resolveToPatchError', () => {
       if (!patchError) {
         throw new Error('Expected non-null error.');
       }
-      strictEqual(PatchError.prettyPrint(patchError), stripSharedIndent(`
+      strictEqual(
+        PatchError.prettyPrint(patchError),
+        stripSharedIndent(`
         testStage failed to parse: unexpected indentation
           1 | x = 3
         > 2 |   f()
             | ^^
-          3 | console.log 'test'`) + '\n');
+          3 | console.log 'test'`) + '\n'
+      );
     }
   });
 
@@ -70,18 +76,20 @@ describe('resolveToPatchError', () => {
       if (!patchError) {
         throw new Error('Expected non-null error.');
       }
-      strictEqual(PatchError.prettyPrint(patchError), stripSharedIndent(`
+      strictEqual(
+        PatchError.prettyPrint(patchError),
+        stripSharedIndent(`
         esnext failed to parse: Unexpected token (3:0)
           1 | var x = 3;
           2 | if (
         > 3 | }
-            | ^`) + '\n');
+            | ^`) + '\n'
+      );
     }
   });
 
   it('returns null for other errors', () => {
-    let patchError = resolveToPatchError(
-      new Error('a normal error'), 'test content', 'test stage name');
+    let patchError = resolveToPatchError(new Error('a normal error'), 'test content', 'test stage name');
     strictEqual(patchError, null);
   });
 });

--- a/test/while_test.ts
+++ b/test/while_test.ts
@@ -1,95 +1,121 @@
-import check, {checkCS2} from './support/check';
+import check, { checkCS2 } from './support/check';
 
 describe('while', () => {
   it('surrounds its condition with parentheses', () => {
-    check(`
+    check(
+      `
       while a
         b
-    `, `
+    `,
+      `
       while (a) {
         b;
       }
-    `);
+    `
+    );
   });
 
   it('adds braces indented correctly', () => {
-    check(`
+    check(
+      `
       if a
         while b
           c
-    `, `
+    `,
+      `
       if (a) {
         while (b) {
           c;
         }
       }
-    `);
+    `
+    );
   });
 
   it('adds braces for single-line while loops correctly', () => {
-    check(`
+    check(
+      `
       b while a
-    `, `
+    `,
+      `
       while (a) { b; }
-    `);
+    `
+    );
   });
 
   it('does not add parentheses around the condition if they are already there', () => {
-    check(`
+    check(
+      `
       while (a)
         b
-    `, `
+    `,
+      `
       while (a) {
         b;
       }
-    `);
+    `
+    );
   });
 
   it('turns an `until` loop into a `while` loop with a negated condition', () => {
-    check(`
+    check(
+      `
       until a
         b
-    `, `
+    `,
+      `
       while (!a) {
         b;
       }
-    `);
+    `
+    );
   });
 
   it('wraps the `until` condition in parentheses if needed', () => {
-    check(`
+    check(
+      `
       until a < b
         a--
-    `, `
+    `,
+      `
       while (!(a < b)) {
         a--;
       }
-    `);
+    `
+    );
   });
 
   it('turns `loop` into a `while` loop with an always-true condition', () => {
-    check(`
+    check(
+      `
       loop
         a
-    `, `
+    `,
+      `
       while (true) {
         a;
       }
-    `);
+    `
+    );
   });
 
   it('turns `loop` with an inline body into an inline `while` loop with an always-true condition', () => {
-    check(`
+    check(
+      `
       loop a
-    `, `
+    `,
+      `
       while (true) { a; }
-    `);
+    `
+    );
   });
 
   it('handles `while` loops used as an expression', () => {
-    check(`
+    check(
+      `
       a(b while c)
-    `, `
+    `,
+      `
       a((() => {
         const result = [];
         while (c) {
@@ -97,13 +123,16 @@ describe('while', () => {
         }
         return result;
       })());
-    `);
+    `
+    );
   });
 
   it('handles `while` loops with a guard used as an expression', () => {
-    check(`
+    check(
+      `
       a(b while c when d)
-    `, `
+    `,
+      `
       a((() => {
         const result = [];
         while (c) {
@@ -113,11 +142,13 @@ describe('while', () => {
         }
         return result;
       })());
-    `);
+    `
+    );
   });
 
   it('collects `undefined` when a code path has no value', () => {
-    check(`
+    check(
+      `
       a(
         while b
           if c
@@ -125,7 +156,8 @@ describe('while', () => {
           else if e
             f
       )
-    `, `
+    `,
+      `
       a((() => {
         const result = [];
         
@@ -141,11 +173,13 @@ describe('while', () => {
 
         return result;
       })());
-    `);
+    `
+    );
   });
 
   it('does not use a temporary variable when all code paths are covered', () => {
-    check(`
+    check(
+      `
       a(
         while b
           switch c
@@ -154,7 +188,8 @@ describe('while', () => {
             else
               f
       )
-    `, `
+    `,
+      `
       a((() => {
         const result = [];
         
@@ -170,29 +205,35 @@ describe('while', () => {
 
         return result;
       })());
-    `);
+    `
+    );
   });
 
   it('does not consider a `while` loop as an implicit return if it returns itself', () => {
-    check(`
+    check(
+      `
       ->
         while true
           return a
-    `, `
+    `,
+      `
       (function() {
         while (true) {
           return a;
         }
       });
-    `);
+    `
+    );
   });
 
   it('considers a `while` loop as an implicit return if it only returns within a function', () => {
-    check(`
+    check(
+      `
       ->
         while true
           -> return a
-    `, `
+    `,
+      `
       () =>
         (() => {
           const result = [];
@@ -202,61 +243,76 @@ describe('while', () => {
           return result;
         })()
       ;
-    `);
+    `
+    );
   });
 
   it('handles a `while` loop with a `then` body', () => {
-    check(`
+    check(
+      `
       while a then ((a) -> a)(1)
-    `, `
+    `,
+      `
       while (a) { (a => a)(1); }
-    `);
+    `
+    );
   });
 
   it('handles a `loop` with a `then` body', () => {
-    check(`
+    check(
+      `
       loop then a
-    `, `
+    `,
+      `
       while (true) { a; }
-    `);
+    `
+    );
   });
 
   it('handles `while` with a `when` guard clause', () => {
-    check(`
+    check(
+      `
       while a b when c d
         e f
         g h
-    `, `
+    `,
+      `
       while (a(b)) {
         if (c(d)) {
           e(f);
           g(h);
         }
       }
-    `);
+    `
+    );
   });
 
   it('does not add parentheses around `when` guard clause if it already has them', () => {
-    check(`
+    check(
+      `
       while a when (b)
         c
-    `, `
+    `,
+      `
       while (a) {
         if (b) {
           c;
         }
       }
-    `);
+    `
+    );
   });
 
   it('handles a deeply-indented loop body in an expression context', () => {
-    check(`
+    check(
+      `
       longName(while a when b
                   if c
                     d
                   else if e
                     f)
-    `, `
+    `,
+      `
       longName((() => {
         const result = [];
         while (a) {
@@ -272,27 +328,33 @@ describe('while', () => {
         }
         return result;
       })());
-    `);
+    `
+    );
   });
 
   it('causes the condition not to add parentheses even if it normally would', () => {
-    check(`
+    check(
+      `
       a = b
       while a?
         c
-    `, `
+    `,
+      `
       const a = b;
       while (a != null) {
         c;
       }
-    `);
+    `
+    );
   });
 
   it('supports yields in bodies', () => {
-    check(`
+    check(
+      `
       -> while false
         yield a while true
-    `, `
+    `,
+      `
       (function*() { return yield* (function*() {
         const result = [];
         while (false) {
@@ -306,15 +368,18 @@ describe('while', () => {
         }
         return result;
       }).call(this); });
-    `);
+    `
+    );
   });
 
   it('supports yields in bodies referencing `arguments`', () => {
-    check(`
+    check(
+      `
       ->
         while false
           yield arguments.length while true
-    `, `
+    `,
+      `
       (function*() {
         return yield* (function*() {
           const result = [];
@@ -330,15 +395,18 @@ describe('while', () => {
           return result;
         }).apply(this, arguments);
       });
-    `);
+    `
+    );
   });
 
   it('supports yields in bodies referencing `arguments` in a nested function', () => {
-    check(`
+    check(
+      `
       ->
         while false
           yield (-> arguments.length) while true
-    `, `
+    `,
+      `
       (function*() {
         return yield* (function*() {
           const result = [];
@@ -354,46 +422,61 @@ describe('while', () => {
           return result;
         }).call(this);
       });
-    `);
+    `
+    );
   });
 
   it('handles a condition containing "then" within a post-while', () => {
-    check(`
+    check(
+      `
       2 while if 1 then 0
-    `, `
+    `,
+      `
       while (1 ? 0 : undefined) { 2; }
-    `);
+    `
+    );
   });
 
   it('does not add additional parens around a condition containing "then"', () => {
-    check(`
+    check(
+      `
       2 while (if 1 then 0)
-    `, `
+    `,
+      `
       while (1 ? 0 : undefined) { 2; }
-    `);
+    `
+    );
   });
 
   it('handles a guard containing "then" within a post-while', () => {
-    check(`
+    check(
+      `
       a while b when if c then d
-    `, `
+    `,
+      `
       while (b) { if (c ? d : undefined) { a; } }
-    `);
+    `
+    );
   });
 
   it('handles a multiline condition in a postfix while', () => {
-    check(`
+    check(
+      `
       a while do ->
         b
-    `, `
+    `,
+      `
       while ((() => b)()) { a; }
-    `);
+    `
+    );
   });
 
   it('handles a post-while as a function argument', () => {
-    check(`
+    check(
+      `
       a(b while c, d)
-    `, `
+    `,
+      `
       a(((() => {
         const result = [];
         while (c) {
@@ -401,13 +484,16 @@ describe('while', () => {
         }
         return result;
       })()), d);
-    `);
+    `
+    );
   });
 
   it('handles a post-while as an array element', () => {
-    check(`
+    check(
+      `
       [a while b, c]
-    `, `
+    `,
+      `
       [((() => {
         const result = [];
         while (b) {
@@ -415,13 +501,16 @@ describe('while', () => {
         }
         return result;
       })()), c];
-    `);
+    `
+    );
   });
 
   it('handles a post-while as an object element', () => {
-    check(`
+    check(
+      `
       {a: b while c, d}
-    `, `
+    `,
+      `
       ({a: ((() => {
         const result = [];
         while (c) {
@@ -429,40 +518,52 @@ describe('while', () => {
         }
         return result;
       })()), d});
-    `);
+    `
+    );
   });
 
   it('handles a postfix while followed by a semicolon', () => {
-    check(`
+    check(
+      `
       a while b; c
-    `, `
+    `,
+      `
       while (b) { a; } c;
-    `);
+    `
+    );
   });
 
   it('handles a while loop with an empty body', () => {
-    check(`
+    check(
+      `
       while a then
-    `, `
+    `,
+      `
       while (a) {} 
-    `);
+    `
+    );
   });
 
   it('handles a loop with an empty body', () => {
-    check(`
+    check(
+      `
       loop then
-    `, `
+    `,
+      `
       while (true) {} 
-    `);
+    `
+    );
   });
 
   it('handles an IIFE while with an assignment followed by access', () => {
-    check(`
+    check(
+      `
       a =
         while b
           c = d
       c
-    `, `
+    `,
+      `
       let c;
       const a =
         (() => {
@@ -473,16 +574,19 @@ describe('while', () => {
         return result;
       })();
       c;
-    `);
+    `
+    );
   });
 
   it('handles postfix while as a value in an implicit object literal', () => {
-    checkCS2(`
+    checkCS2(
+      `
       o =
         a:
           b: c while d
           e: f
-    `, `
+    `,
+      `
       const o = {
         a: {
           b: ((() => {
@@ -495,17 +599,20 @@ describe('while', () => {
           e: f
         }
       };
-    `);
+    `
+    );
   });
 
   it('handles postfix while as a value in an explicit object literal', () => {
-    checkCS2(`
+    checkCS2(
+      `
       o =
         a: {
           b: c while d
           e: f
         }
-    `, `
+    `,
+      `
       const o = {
         a: {
           b: (() => {
@@ -518,6 +625,7 @@ describe('while', () => {
           e: f
         }
       };
-    `);
+    `
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,6 +133,20 @@
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.0.3.tgz#1f89840c7aac2406cc43a2ecad98fc02a8e130e4"
 
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  dependencies:
+    acorn "^3.0.4"
+
+acorn@^3.0.4:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+
+acorn@^5.5.0:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
+
 add-variable-declarations@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/add-variable-declarations/-/add-variable-declarations-3.1.2.tgz#183902497fb7df0f8da23ebc0971dfce6f33ecfd"
@@ -142,6 +156,23 @@ add-variable-declarations@^3.1.0:
     babylon "7.0.0-beta.31"
     magic-string "^0.22.2"
 
+ajv-keywords@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
+
+ajv@^5.2.3, ajv@^5.3.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
+ansi-escapes@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
+
 ansi-regex@^0.2.0, ansi-regex@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-0.2.1.tgz#0d8e946967a3d8143f93e24e298525fc1b2235f9"
@@ -149,6 +180,10 @@ ansi-regex@^0.2.0, ansi-regex@^0.2.1:
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
 ansi-styles@^1.1.0:
   version "1.1.0"
@@ -163,6 +198,12 @@ ansi-styles@^3.1.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
   dependencies:
     color-convert "^1.0.0"
+
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
 
 ansicolors@~0.2.1:
   version "0.2.1"
@@ -187,6 +228,16 @@ arr-diff@^2.0.0:
 arr-flatten@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  dependencies:
+    array-uniq "^1.0.1"
+
+array-uniq@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
 
 array-unique@^0.2.1:
   version "0.2.1"
@@ -724,6 +775,20 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
+buffer-from@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.0.0.tgz#4cb8832d23612589b0406e9e2956c17f06fdf531"
+
+caller-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  dependencies:
+    callsites "^0.2.0"
+
+callsites@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
+
 cardinal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cardinal/-/cardinal-1.0.0.tgz#50e21c1b0aa37729f9377def196b5a9cec932ee9"
@@ -759,6 +824,14 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+chalk@^2.1.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chalk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
@@ -766,6 +839,20 @@ chalk@^2.3.0:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
+circular-json@^0.3.1:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  dependencies:
+    restore-cursor "^2.0.0"
 
 cli-table@^0.3.1:
   version "0.3.1"
@@ -780,6 +867,10 @@ cli-usage@^0.1.2:
     marked "^0.3.6"
     marked-terminal "^1.6.2"
 
+cli-width@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
+
 clone-stats@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
@@ -792,6 +883,10 @@ clone@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149"
 
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+
 coffee-lex@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/coffee-lex/-/coffee-lex-9.1.0.tgz#1fce57576ddcec6243ec43b7e276ac1da81aaca2"
@@ -799,6 +894,12 @@ coffee-lex@^9.1.0:
 color-convert@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  dependencies:
+    color-name "^1.1.1"
+
+color-convert@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
   dependencies:
     color-name "^1.1.1"
 
@@ -821,6 +922,15 @@ commander@2.11.0, commander@^2.9.0:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+
+concat-stream@^1.6.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
 
 configstore@^0.3.1:
   version "0.3.2"
@@ -853,6 +963,14 @@ core-js@^2.4.0:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cross-spawn@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 debug@3.1.0, debug@^3.0.1, debug@^3.1.0:
   version "3.1.0"
@@ -893,11 +1011,27 @@ deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
 
+deep-is@~0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
 defaults@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
   dependencies:
     clone "^1.0.2"
+
+del@^2.0.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
+  dependencies:
+    globby "^5.0.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    rimraf "^2.2.8"
 
 detect-indent@^4.0.0:
   version "4.0.0"
@@ -912,6 +1046,12 @@ diff@3.3.1:
 diff@^3.1.0, diff@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  dependencies:
+    esutils "^2.0.2"
 
 duplexify@^3.2.0:
   version "3.5.0"
@@ -932,6 +1072,67 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+eslint-plugin-prettier@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz#33e4e228bdb06142d03c560ce04ec23f6c767dd7"
+  dependencies:
+    fast-diff "^1.1.1"
+    jest-docblock "^21.0.0"
+
+eslint-scope@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint@^4.19.1:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
+  dependencies:
+    ajv "^5.3.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.4"
+    esquery "^1.0.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.0.1"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^3.0.6"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^1.0.1"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "~2.0.1"
+    table "4.0.2"
+    text-table "~0.2.0"
+
 esnext@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/esnext/-/esnext-3.3.1.tgz#115d3e32038a30e8dd3da7e80cdd8e92e307345d"
@@ -945,13 +1146,40 @@ esnext@^3.3.1:
     shebang-regex "^2.0.0"
     strip-indent "^2.0.0"
 
+espree@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+  dependencies:
+    acorn "^5.5.0"
+    acorn-jsx "^3.0.0"
+
 esprima@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
 esprima@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.0.0.tgz#53cf247acda77313e551c3aa2e73342d3fb4f7d9"
+
+esquery@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
+  dependencies:
+    estraverse "^4.0.0"
+
+esrecurse@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
+  dependencies:
+    estraverse "^4.1.0"
+
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -969,11 +1197,48 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
+external-editor@^2.0.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
   dependencies:
     is-extglob "^1.0.0"
+
+fast-deep-equal@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
+
+fast-diff@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+
+fast-levenshtein@~2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -997,6 +1262,15 @@ first-chunk-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz#59bfb50cd905f60d7c394cd3d9acaab4e6ad934e"
 
+flat-cache@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
+  dependencies:
+    circular-json "^0.3.1"
+    del "^2.0.2"
+    graceful-fs "^4.1.2"
+    write "^0.2.1"
+
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -1018,6 +1292,10 @@ fs-extra@^6.0.0:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
 gaze@^0.5.1:
   version "0.5.2"
@@ -1061,7 +1339,7 @@ glob2base@^0.0.12:
   dependencies:
     find-index "^0.1.1"
 
-glob@7.1.2, glob@^7.0.5, glob@^7.1.1:
+glob@7.1.2, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -1093,6 +1371,10 @@ globals@^10.0.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-10.1.0.tgz#4425a1881be0d336b4a823a82a7be725d5dd987c"
 
+globals@^11.0.1:
+  version "11.5.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.5.0.tgz#6bc840de6771173b191f13d3a9c94d441ee92642"
+
 globals@^11.1.0:
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
@@ -1100,6 +1382,17 @@ globals@^11.1.0:
 globals@^9.0.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+
+globby@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
+  dependencies:
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 globule@~0.1.0:
   version "0.1.0"
@@ -1158,9 +1451,27 @@ has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+
+iconv-lite@^0.4.17:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
+ignore@^3.3.3:
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
 infinity-agent@^2.0.0:
   version "2.0.3"
@@ -1177,13 +1488,32 @@ inherits@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-1.0.2.tgz#ca4309dadee6b54cc0b8d247e8d7c7a0975bdc9b"
 
-inherits@2, inherits@^2.0.1, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
+inquirer@^3.0.6:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
 
 invariant@^2.2.0:
   version "2.2.2"
@@ -1219,6 +1549,10 @@ is-finite@^1.0.0:
   dependencies:
     number-is-nan "^1.0.0"
 
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -1241,6 +1575,22 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-path-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
+
+is-path-in-cwd@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
+  dependencies:
+    is-path-inside "^1.0.0"
+
+is-path-inside@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
+  dependencies:
+    path-is-inside "^1.0.1"
+
 is-posix-bracket@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
@@ -1249,9 +1599,17 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
 is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
+
+is-resolvable@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
 is-stream@^1.0.0:
   version "1.1.0"
@@ -1269,11 +1627,19 @@ isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
+
+jest-docblock@^21.0.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
 
 js-tokens@^3.0.0:
   version "3.0.2"
@@ -1286,6 +1652,13 @@ js-yaml@^3.1.0:
     argparse "^1.0.7"
     esprima "^3.1.1"
 
+js-yaml@^3.9.1:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 jsesc@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
@@ -1293,6 +1666,14 @@ jsesc@^2.5.1:
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
+
+json-schema-traverse@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
 json-stable-stringify@^1.0.1:
   version "1.0.1"
@@ -1332,6 +1713,13 @@ latest-version@^1.0.0:
   dependencies:
     package-json "^1.0.0"
 
+levn@^0.3.0, levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+
 lines-and-columns@^1.1.5, lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -1339,6 +1727,14 @@ lines-and-columns@^1.1.5, lines-and-columns@^1.1.6:
 lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+
+lodash@^4.17.4, lodash@^4.3.0:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 lodash@^4.2.0:
   version "4.17.4"
@@ -1361,6 +1757,13 @@ lowercase-keys@^1.0.0:
 lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
+
+lru-cache@^4.0.1:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 magic-string@^0.22.1:
   version "0.22.1"
@@ -1410,6 +1813,10 @@ micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
+mimic-fn@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+
 minimatch@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-1.0.0.tgz#e0dd2120b49e1b724ce8d714c520822a9438576d"
@@ -1423,7 +1830,7 @@ minimatch@^2.0.1:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimatch@^3.0.4:
+minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -1477,6 +1884,10 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
 mversion@^1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/mversion/-/mversion-1.10.1.tgz#9322d1a4f11f6670de0024d1823a32a615a3d40e"
@@ -1503,6 +1914,10 @@ mz@^2.7.0:
 natives@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.0.tgz#e9ff841418a6b2ec7a495e939984f78f163e6e31"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
 nested-error-stacks@^1.0.0:
   version "1.0.2"
@@ -1557,6 +1972,23 @@ once@~1.3.0:
   dependencies:
     wrappy "1"
 
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  dependencies:
+    mimic-fn "^1.0.0"
+
+optionator@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.4"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    wordwrap "~1.0.0"
+
 ordered-read-streams@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz#fd565a9af8eb4473ba69b6ed8a34352cb552f126"
@@ -1565,7 +1997,7 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
-os-tmpdir@^1.0.0:
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -1596,9 +2028,17 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+pify@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -1610,6 +2050,14 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
+
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+
 prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
@@ -1618,6 +2066,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.12.1.tgz#c1ad20e803e7749faf905a409d2367e06bbe7325"
+
 private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
@@ -1625,6 +2077,18 @@ private@^0.1.6:
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 randomatic@^1.1.3:
   version "1.1.7"
@@ -1688,6 +2152,18 @@ readable-stream@^2.0.0:
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
+readable-stream@^2.2.2:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
 redeyed@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-1.0.1.tgz#e96c193b40c0816b00aec842698e61185e55498a"
@@ -1724,6 +2200,10 @@ regex-cache@^0.4.2:
   resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
   dependencies:
     is-equal-shallow "^0.1.3"
+
+regexpp@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
 
 regexpu-core@^4.1.3:
   version "4.1.3"
@@ -1770,11 +2250,35 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
+require-uncached@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  dependencies:
+    caller-path "^0.1.0"
+    resolve-from "^1.0.0"
+
+resolve-from@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
 resolve@^1.3.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
     path-parse "^1.0.5"
+
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
+rimraf@^2.2.8:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  dependencies:
+    glob "^7.0.5"
 
 rimraf@^2.5.4:
   version "2.6.1"
@@ -1782,15 +2286,39 @@ rimraf@^2.5.4:
   dependencies:
     glob "^7.0.5"
 
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  dependencies:
+    is-promise "^2.1.0"
+
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 semver-diff@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
   dependencies:
     semver "^5.0.3"
+
+semver@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 semver@^4.0.3:
   version "4.3.6"
@@ -1800,6 +2328,16 @@ semver@^5.0.3, semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
 shebang-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-2.0.0.tgz#f500bf6851b61356236167de2cc319b0fd7f0681"
@@ -1807,6 +2345,16 @@ shebang-regex@^2.0.0:
 sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
+
+signal-exit@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+slice-ansi@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
 
 source-map-support@^0.5.3:
   version "0.5.3"
@@ -1836,6 +2384,13 @@ string-length@^1.0.0:
   dependencies:
     strip-ansi "^3.0.0"
 
+string-width@^2.1.0, string-width@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
 string.prototype.codepointat@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz#6b26e9bd3afcaa7be3b4269b526de1b82000ac78"
@@ -1850,6 +2405,12 @@ string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  dependencies:
+    safe-buffer "~5.1.0"
+
 strip-ansi@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.3.0.tgz#25f48ea22ca79187f3174a4db8759347bb126220"
@@ -1861,6 +2422,12 @@ strip-ansi@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-bom@^1.0.0:
   version "1.0.0"
@@ -1901,6 +2468,27 @@ supports-color@^4.0.0:
   dependencies:
     has-flag "^2.0.0"
 
+supports-color@^5.3.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
+
+table@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
+  dependencies:
+    ajv "^5.2.3"
+    ajv-keywords "^2.1.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
+
+text-table@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
 thenify-all@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
@@ -1927,6 +2515,10 @@ through2@^1.0.0:
     readable-stream ">=1.1.13-1 <1.2.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
+through@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
 ticky@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ticky/-/ticky-1.0.1.tgz#b7cfa71e768f1c9000c497b9151b30947c50e46d"
@@ -1934,6 +2526,12 @@ ticky@1.0.1:
 timed-out@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-2.0.0.tgz#f38b0ae81d3747d628001f41dafc652ace671c0a"
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 to-fast-properties@^1.0.1:
   version "1.0.3"
@@ -1947,9 +2545,9 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-ts-node@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-6.0.0.tgz#46c25f8498593a9248eeea16906f1598fa098140"
+ts-node@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-6.0.3.tgz#28bf74bcad134fad17f7469dad04638ece03f0f4"
   dependencies:
     arrify "^1.0.0"
     chalk "^2.3.0"
@@ -1963,6 +2561,10 @@ ts-node@^6.0.0:
 tslib@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
+
+tslib@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
 tslint@^5.5.0:
   version "5.5.0"
@@ -1985,9 +2587,26 @@ tsutils@^2.5.1:
   dependencies:
     tslib "^1.7.1"
 
-typescript@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  dependencies:
+    prelude-ls "~1.1.2"
+
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript-eslint-parser@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-15.0.0.tgz#882fd3d7aabffbab0a7f98d2a59fb9a989c2b37f"
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
+
+typescript@^2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
 
 unicode-canonical-property-names-ecmascript@^1.0.2:
   version "1.0.2"
@@ -2063,9 +2682,25 @@ vlq@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.2.tgz#e316d5257b40b86bb43cb8d5fea5d7f54d6b0ca1"
 
+which@^1.2.9:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
+
+wordwrap@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+write@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  dependencies:
+    mkdirp "^0.5.1"
 
 xdg-basedir@^1.0.0:
   version "1.0.1"
@@ -2076,6 +2711,10 @@ xdg-basedir@^1.0.0:
 "xtend@>=4.0.0 <4.1.0-0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
 yn@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
To enforce that Prettier is run, I set up ESLint for the sole purpose of the
prettier/prettier rule. This also means that `yarn lint-fix` effectively runs
prettier.

Also upgrade TypeScript to latest so that it plays well with the TypeScript
ESLint parser.