### PR TITLE
fix: disable optional chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ decaffeinate could be improved, feel free to file an issue on the [issues] page.
   code.
 * `--use-optional-chaining`: Use the upcoming
   [optional chaining](https://github.com/tc39/proposal-optional-chaining) syntax
-  for operators like `?.`.
+  for operators like `?.` [**NOTE:** this is disabled and has no effect].
 * `--safe-import-function-identifiers`: Comma-separated list of function names
   that may safely be in the `import`/`require` section of the file. All other
   function calls will disqualify later `require`s from being converted to

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,7 +67,7 @@ function parseArguments(args: Array<string>): CLIOptions {
         break;
 
       case '--use-optional-chaining':
-        baseOptions.useOptionalChaining = true;
+        console.warn(`NOTE: ${arg} is disabled and has no effect`);
         break;
 
       case '--use-js-modules':
@@ -258,6 +258,7 @@ function usage(): void {
   console.log('                           top of the output file.');
   console.log('  --no-array-includes      Do not use Array.prototype.includes in generated code.');
   console.log('  --use-optional-chaining  Use the upcoming optional chaining syntax for operators like `?.`.');
+  console.log('                           NOTE: this is disabled and has no effect.');
   console.log('  --use-js-modules         Convert require and module.exports to import and export.');
   console.log('  --loose-js-modules       Allow named exports when converting to JS modules.');
   console.log('  --safe-import-function-identifiers');

--- a/src/options.ts
+++ b/src/options.ts
@@ -4,7 +4,6 @@ export type Options = {
   runToStage?: string | null;
   literate?: boolean;
   disableSuggestionComment?: boolean;
-  useOptionalChaining?: boolean;
   noArrayIncludes?: boolean;
   useJSModules?: boolean;
   looseJSModules?: boolean;
@@ -26,7 +25,6 @@ export const DEFAULT_OPTIONS: Options = {
   runToStage: null,
   literate: false,
   disableSuggestionComment: false,
-  useOptionalChaining: false,
   noArrayIncludes: false,
   useJSModules: false,
   looseJSModules: false,

--- a/src/stages/main/patchers/SlicePatcher.ts
+++ b/src/stages/main/patchers/SlicePatcher.ts
@@ -38,10 +38,6 @@ export default class SlicePatcher extends NodePatcher {
     }
   }
 
-  shouldPatchAsOptionalChaining(): boolean {
-    return false;
-  }
-
   /**
    * EXPRESSION '[' LEFT? ( .. | ... ) RIGHT? ']'
    */
@@ -50,8 +46,7 @@ export default class SlicePatcher extends NodePatcher {
     let indexStart = this.getIndexStartSourceToken();
     // `a[0..1]` → `a.slice(0..1]`
     //   ^           ^^^^^^^
-    let dot = this.shouldPatchAsOptionalChaining() ? '?.' : '.';
-    this.overwrite(this.expression.outerEnd, indexStart.end, `${dot}slice(`);
+    this.overwrite(this.expression.outerEnd, indexStart.end, '.slice(');
     if (this.left) {
       this.left.patch();
     } else if (this.right) {
@@ -123,8 +118,7 @@ export default class SlicePatcher extends NodePatcher {
     let indexStart = this.getIndexStartSourceToken();
     // `a[b..c]` → `a.splice(b..c]`
     //   ^           ^^^^^^^^
-    let dot = this.shouldPatchAsOptionalChaining() ? '?.' : '.';
-    this.overwrite(this.expression.outerEnd, indexStart.end, `${dot}splice(`);
+    this.overwrite(this.expression.outerEnd, indexStart.end, '.splice(');
     let leftCode;
     if (this.left) {
       leftCode = this.left.patchRepeatable();

--- a/src/stages/main/patchers/SoakedDynamicMemberAccessOpPatcher.ts
+++ b/src/stages/main/patchers/SoakedDynamicMemberAccessOpPatcher.ts
@@ -20,9 +20,7 @@ export default class SoakedDynamicMemberAccessOpPatcher extends DynamicMemberAcc
 
   patchAsExpression(): void {
     if (!this._shouldSkipSoakPatch) {
-      if (this.shouldPatchAsOptionalChaining()) {
-        this.patchAsOptionalChaining();
-      } else if (this.shouldPatchAsConditional()) {
+      if (this.shouldPatchAsConditional()) {
         this.patchAsConditional();
       } else {
         this.patchAsGuardCall();
@@ -33,20 +31,8 @@ export default class SoakedDynamicMemberAccessOpPatcher extends DynamicMemberAcc
     }
   }
 
-  shouldPatchAsOptionalChaining(): boolean {
-    return this.options.useOptionalChaining === true && !this.expression.mayBeUnboundReference();
-  }
-
   shouldPatchAsConditional(): boolean {
     return this.expression.isRepeatable() && !nodeContainsSoakOperation(this.expression.node);
-  }
-
-  patchAsOptionalChaining(): void {
-    this.expression.patch();
-    // `a?[b]` → `a?.[b]`
-    //              ^
-    this.overwrite(this.expression.outerEnd, this.indexingExpr.outerStart, '?.[');
-    this.indexingExpr.patch();
   }
 
   patchAsConditional(): void {

--- a/src/stages/main/patchers/SoakedFunctionApplicationPatcher.ts
+++ b/src/stages/main/patchers/SoakedFunctionApplicationPatcher.ts
@@ -44,9 +44,7 @@ const GUARD_METHOD_HELPER = `function __guardMethod__(obj, methodName, transform
 
 export default class SoakedFunctionApplicationPatcher extends FunctionApplicationPatcher {
   patchAsExpression(): void {
-    if (this.shouldPatchAsOptionalChaining()) {
-      this.patchAsOptionalChaining();
-    } else if (this.shouldPatchAsConditional()) {
+    if (this.shouldPatchAsConditional()) {
       this.patchAsConditional();
     } else {
       if (this.fn instanceof MemberAccessOpPatcher) {
@@ -60,20 +58,8 @@ export default class SoakedFunctionApplicationPatcher extends FunctionApplicatio
     }
   }
 
-  shouldPatchAsOptionalChaining(): boolean {
-    return this.options.useOptionalChaining === true && !this.fn.mayBeUnboundReference();
-  }
-
   shouldPatchAsConditional(): boolean {
     return this.fn.isRepeatable() && !nodeContainsSoakOperation(this.fn.node);
-  }
-
-  patchAsOptionalChaining(): void {
-    let callStartToken = this.getCallStartToken();
-    // `a?(b)` → `a?.(b)`
-    //              ^
-    this.insert(callStartToken.start, '.');
-    super.patchAsExpression();
   }
 
   patchAsConditional(): void {

--- a/src/stages/main/patchers/SoakedMemberAccessOpPatcher.ts
+++ b/src/stages/main/patchers/SoakedMemberAccessOpPatcher.ts
@@ -13,9 +13,7 @@ export default class SoakedMemberAccessOpPatcher extends MemberAccessOpPatcher {
 
   patchAsExpression(): void {
     if (!this._shouldSkipSoakPatch) {
-      if (this.shouldPatchAsOptionalChaining()) {
-        this.patchAsOptionalChaining();
-      } else if (this.shouldPatchAsConditional()) {
+      if (this.shouldPatchAsConditional()) {
         this.patchAsConditional();
       } else {
         this.patchAsGuardCall();
@@ -25,17 +23,8 @@ export default class SoakedMemberAccessOpPatcher extends MemberAccessOpPatcher {
     }
   }
 
-  shouldPatchAsOptionalChaining(): boolean {
-    return this.options.useOptionalChaining === true && !this.expression.mayBeUnboundReference();
-  }
-
   shouldPatchAsConditional(): boolean {
     return this.expression.isRepeatable() && !nodeContainsSoakOperation(this.expression.node);
-  }
-
-  patchAsOptionalChaining(): void {
-    // The operator is the same, so nothing special to do.
-    this.expression.patch();
   }
 
   patchAsConditional(): void {
@@ -44,7 +33,7 @@ export default class SoakedMemberAccessOpPatcher extends MemberAccessOpPatcher {
     let memberNameToken = this.getMemberNameSourceToken();
     let expressionCode = this.expression.patchRepeatable();
 
-    let conditionCode;
+    let conditionCode: string;
     if (this.expression.mayBeUnboundReference()) {
       conditionCode = `typeof ${expressionCode} !== 'undefined' && ${expressionCode} !== null`;
     } else {

--- a/src/stages/main/patchers/SoakedSlicePatcher.ts
+++ b/src/stages/main/patchers/SoakedSlicePatcher.ts
@@ -11,11 +11,6 @@ const GUARD_HELPER = `function __guard__(value, transform) {
 
 export default class SoakedSlicePatcher extends SlicePatcher {
   patchAsExpression(): void {
-    if (this.shouldPatchAsOptionalChaining()) {
-      super.patchAsExpression();
-      return;
-    }
-
     this.registerHelper('__guard__', GUARD_HELPER);
     this.addSuggestion(REMOVE_GUARD);
 
@@ -39,9 +34,6 @@ export default class SoakedSlicePatcher extends SlicePatcher {
    * For a soaked splice operation, we are the soak container.
    */
   getSpliceCode(expressionCode: string): string {
-    if (this.shouldPatchAsOptionalChaining()) {
-      return super.getSpliceCode(expressionCode);
-    }
     let spliceStart = this.captureCodeForPatchOperation(() => {
       this.registerHelper('__guard__', GUARD_HELPER);
       this.addSuggestion(REMOVE_GUARD);
@@ -50,9 +42,5 @@ export default class SoakedSlicePatcher extends SlicePatcher {
       this.patchAsSpliceExpressionStart();
     });
     return `__guard__(${spliceStart}, ...[].concat(${expressionCode})))`;
-  }
-
-  shouldPatchAsOptionalChaining(): boolean {
-    return this.options.useOptionalChaining || false;
   }
 }

--- a/test/support/validate.ts
+++ b/test/support/validate.ts
@@ -28,7 +28,7 @@ export type ValidateOptions = {
  * In addition, on node >= 6, we run the ES6 code directly to make sure it gives
  * the same result, to avoid behavior differences with babel.
  *
- * Optionally, expectedOutput can be specified. If it is, the the result of the
+ * Optionally, expectedOutput can be specified. If it is, then the result of the
  * 'o' variable must be equal to that value.
  */
 export default function validate(


### PR DESCRIPTION
BREAKING CHANGE: Since the spec has changed in ways that diverge from what CoffeeScript allowed, mapping soaked expressions to optional chaining makes less sense than in once did.

Closes #1281