### PR TITLE
test(ci): update node versions to test with

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ before_script:
 after_script:
   - greenkeeper-lockfile-upload
 node_js:
-  - '9'
+  - '11'
+  - '10'
   - '8'
   - '6'
 branches:


### PR DESCRIPTION
Test in the latest (v11) and all currently supported LTS versions. Node v6 is supported until April 2019, so we can remove it after that.