### PR TITLE
types: remove unnecessary `as any` cast

### DIFF
--- a/src/stages/semicolons/index.ts
+++ b/src/stages/semicolons/index.ts
@@ -9,7 +9,7 @@ const BABYLON_PLUGINS: Array<ParserPlugin> = [
   'jsx',
   'asyncGenerators',
   'classProperties',
-  ['decorators', { decoratorsBeforeExport: true }] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  ['decorators', { decoratorsBeforeExport: true }],
   'doExpressions',
   'functionBind',
   'functionSent',


### PR DESCRIPTION

The typings for `@babel/parser` have been updated to account for options.