### PR TITLE
fix: allow "EsnextStage" as an alias for "ResugarStage"

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -52,5 +52,8 @@ export function resolveOptions(options: Options): Options {
       looseJSModules: true
     };
   }
+  if (options.runToStage === 'EsnextStage') {
+    options = { ...options, runToStage: 'ResugarStage' };
+  }
   return { ...DEFAULT_OPTIONS, ...options };
 }


### PR DESCRIPTION

This fixes backward-incompatibility that would have required a major version bump.