### PR TITLE
fix: more correctly identify variable usages

### DIFF
--- a/src/stages/main/patchers/ForInPatcher.ts
+++ b/src/stages/main/patchers/ForInPatcher.ts
@@ -298,7 +298,7 @@ export default class ForInPatcher extends ForPatcher {
    * favor of cleaner code.
    */
   patchForOfLoop(): void {
-    // Save the filter code and remove if it it's there.
+    // Save the filter code and remove if it's there.
     this.getFilterCode();
     if (this.filter) {
       this.remove(this.target.outerEnd, this.filter.outerEnd);

--- a/src/utils/countVariableUsages.ts
+++ b/src/utils/countVariableUsages.ts
@@ -1,15 +1,37 @@
 import { traverse } from 'decaffeinate-parser';
-import { Identifier, Node } from 'decaffeinate-parser/dist/nodes';
+import { Identifier, Node, MemberAccessOp, ObjectInitialiserMember } from 'decaffeinate-parser/dist/nodes';
 
 /**
  * Gets the number of usages of the given name in the given node.
  */
 export default function countVariableUsages(node: Node, name: string): number {
   let numUsages = 0;
+
   traverse(node, child => {
-    if (child instanceof Identifier && child.data === name) {
-      numUsages += 1;
+    // Make sure it's the name we're looking for.
+    if (!(child instanceof Identifier) || child.data !== name) {
+      return;
     }
+
+    // Skip `b` in `a.b`.
+    if (child.parentNode instanceof MemberAccessOp && child.parentNode.member === child) {
+      return;
+    }
+
+    // Skip `a` in `{ a: b }`, but not in `{ a }` or `{ [a]: b }`.
+    if (
+      child.parentNode instanceof ObjectInitialiserMember &&
+      child.parentNode.key === child &&
+      // `{ a }`
+      child.parentNode.expression !== null &&
+      // `{ [a]: b }`
+      !child.parentNode.isComputed
+    ) {
+      return;
+    }
+
+    numUsages += 1;
   });
+
   return numUsages;
 }

--- a/test/for_test.ts
+++ b/test/for_test.ts
@@ -2379,4 +2379,23 @@ describe('for loops', () => {
       options: { loose: true }
     });
   });
+
+  it('does not count member access properties as variable uses (#1483)', () => {
+    checkCS2(
+      `
+      a.b
+      [
+        for b in c
+          d
+      ]
+      `,
+      `
+      a.b;
+      [
+        Array.from(c).map((b) =>
+          d)
+      ];
+      `
+    );
+  });
 });

--- a/test/utils/countVariableUsages_test.ts
+++ b/test/utils/countVariableUsages_test.ts
@@ -13,4 +13,40 @@ describe('countVariableUsages', () => {
     strictEqual(countVariableUsages(ast, 'y'), 1);
     strictEqual(countVariableUsages(ast, 'z'), 0);
   });
+
+  it('does not count member access properties as a variable usage', () => {
+    const ast = parse(`
+      x = 1
+      y.x
+    `);
+    strictEqual(countVariableUsages(ast, 'x'), 1);
+    strictEqual(countVariableUsages(ast, 'y'), 1);
+  });
+
+  it('does not count object keys as variable usages', () => {
+    const ast = parse(`
+      x = 1
+      { x: 2 }
+    `);
+    strictEqual(countVariableUsages(ast, 'x'), 1);
+  });
+
+  it('counts object shorthand values as variable usages', () => {
+    const ast = parse(`
+      x = 1
+      { x }
+    `);
+    strictEqual(countVariableUsages(ast, 'x'), 2);
+  });
+
+  it('counts a computed object key as a variable usage', () => {
+    const ast = parse(
+      `
+      x = 1
+      { [x]: 2 }
+    `,
+      { useCS2: true }
+    );
+    strictEqual(countVariableUsages(ast, 'x'), 2);
+  });
 });


### PR DESCRIPTION

The particular case that identified this issue is from #1483, in which `r.a` was being considered a usage of the `a` variable. This case and a few others are fixed in this commit.