### PR TITLE
fix: ensure `AsyncFunction` gets its own scope

### DIFF
--- a/src/utils/DecaffeinateContext.ts
+++ b/src/utils/DecaffeinateContext.ts
@@ -71,6 +71,7 @@ function computeScopeMap(program: Program): Map<Node, Scope> {
       case 'BoundFunction':
       case 'GeneratorFunction':
       case 'BoundGeneratorFunction':
+      case 'AsyncFunction':
       case 'Class': {
         const parentScope = parent && scopeMap.get(parent);
         if (!parentScope) {

--- a/test/function_test.ts
+++ b/test/function_test.ts
@@ -1,4 +1,4 @@
-import check from './support/check';
+import check, { checkCS2 } from './support/check';
 import validate from './support/validate';
 
 describe('functions', () => {
@@ -717,4 +717,33 @@ describe('functions', () => {
     `,
       2
     ));
+
+  it.only('correctly hoists variable declarations for async functions', () => {
+    checkCS2(
+      `
+        class A
+          b: ->
+            await c
+            [for e in f
+              d]
+            e = 1
+        `,
+      `
+        class A {
+          async b() {
+            let e;
+            await c;
+            [(() => {
+              const result = [];
+              for (e of Array.from(f)) {
+                result.push(d);
+              }
+              return result;
+            })()];
+            return e = 1;
+          }
+        }
+        `
+    );
+  });
 });


### PR DESCRIPTION

Without this, async functions could not be the target for variable hoisting.

Fixes #1506