### PR TITLE
chore: ensure exclusive tests can't sneak in again

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
     node: true,
     es6: true
   },
-  plugins: ['prettier', '@typescript-eslint/eslint-plugin'],
+  plugins: ['prettier', '@typescript-eslint/eslint-plugin', 'mocha'],
   rules: {
     '@typescript-eslint/array-type': ['error', { default: 'generic' }],
     '@typescript-eslint/explicit-member-accessibility': 'off',
@@ -24,6 +24,9 @@ module.exports = {
       files: 'test/**/*.{js,ts}',
       env: {
         mocha: true
+      },
+      rules: {
+        'mocha/no-exclusive-tests': 'error'
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@typescript-eslint/parser": "^2.1.0",
     "eslint": "^6.2.1",
     "eslint-config-prettier": "^6.0.0",
+    "eslint-plugin-mocha": "^6.1.1",
     "eslint-plugin-prettier": "^3.1.0",
     "fs-extra": "^8.1.0",
     "husky": "^3.0.5",

--- a/test/function_test.ts
+++ b/test/function_test.ts
@@ -718,7 +718,7 @@ describe('functions', () => {
       2
     ));
 
-  it.only('correctly hoists variable declarations for async functions', () => {
+  it('correctly hoists variable declarations for async functions', () => {
     checkCS2(
       `
         class A

--- a/yarn.lock
+++ b/yarn.lock
@@ -1377,6 +1377,13 @@ eslint-config-prettier@^6.0.0:
   dependencies:
     get-stdin "^6.0.0"
 
+eslint-plugin-mocha@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-6.1.1.tgz#5a036f2f806e1a5fb7d19f7538ebeff3afb15377"
+  integrity sha512-p/otruG425jRYDa28HjbBYYXoFNzq3Qp++gn5dbE44Kz4NvmIsSUKSV1T+RLYUcZOcdJKKAftXbaqkHFqReKoA==
+  dependencies:
+    ramda "^0.26.1"
+
 eslint-plugin-prettier@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz#8695188f95daa93b0dc54b249347ca3b79c4686d"
@@ -2643,6 +2650,11 @@ pump@^3.0.0:
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+
+ramda@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 read-pkg@^5.1.1:
   version "5.2.0"


### PR DESCRIPTION

I accidentally commited and merged to master an `it.only` exclusive mocha test. This has happened several times and I finally got sick of it. Now we fail the build if I forget one!