### PR TITLE
chore(deps): update codemod-objects-concise

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@resugar/codemod-declarations-block-scope": "^1.0.2",
     "@resugar/codemod-functions-arrow": "^1.0.2",
     "@resugar/codemod-modules-commonjs": "^1.0.4",
-    "@resugar/codemod-objects-concise": "^1.0.1",
+    "@resugar/codemod-objects-concise": "^1.0.2",
     "@resugar/codemod-objects-destructuring": "^1.0.1",
     "@resugar/codemod-objects-shorthand": "^1.0.1",
     "@resugar/codemod-strings-template": "^1.0.1",
@@ -80,7 +80,7 @@
     "@babel/core": "^7.6.2",
     "@babel/preset-env": "^7.6.0",
     "@babel/traverse": "^7.6.0",
-    "@babel/types": "^7.6.1",
+    "@babel/types": "^7.7.2",
     "@types/babel__core": "^7.1.3",
     "@types/babel__generator": "^7.6.0",
     "@types/babel__template": "^7.0.2",
@@ -108,7 +108,7 @@
     "typescript": "^3.5.3"
   },
   "resolutions": {
-    "**/@babel/types": "7.6.1",
+    "**/@babel/types": "7.7.2",
     "**/@resugar/helper-comments": "^1.0.2"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,16 +703,7 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@7.6.1", "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5", "@babel/types@^7.7.0", "@babel/types@^7.7.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
-  integrity sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==
-  dependencies:
-    esutils "^2.0.2"
-    lodash "^4.17.13"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.6.1":
+"@babel/types@7.7.2", "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5", "@babel/types@^7.6.1", "@babel/types@^7.7.0", "@babel/types@^7.7.1", "@babel/types@^7.7.2":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.2.tgz#550b82e5571dcd174af576e23f0adba7ffc683f7"
   integrity sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==
@@ -954,7 +945,7 @@
   dependencies:
     "@resugar/helper-comments" "^1.0.0"
 
-"@resugar/codemod-objects-concise@^1.0.1":
+"@resugar/codemod-objects-concise@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@resugar/codemod-objects-concise/-/codemod-objects-concise-1.0.2.tgz#1bb90f834acf0896c24affbc9d0535dd9e09d79d"
   integrity sha512-Qf/zKkBzfGg1Q+2HSrssPllKYrwLxuDF/p39pz10keJtAhkYEcCbWcaHJRr5TgV9Pl9qnzzMImP9TG6KBwx7eA==


### PR DESCRIPTION

This package was being published with `.ts` files, which causes problems with TypeScript 3.7. It's since been fixed in v1.0.2.