### PR TITLE
test(ci): update node versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,6 @@ aliases:
 
 version: 2
 jobs:
-  node-v8-latest:
-    docker:
-      - image: circleci/node:8
-    <<: *unit_test
   node-v10-latest:
     docker:
       - image: circleci/node:10
@@ -43,6 +39,10 @@ jobs:
   node-v12-latest:
     docker:
       - image: circleci/node:12
+    <<: *unit_test
+  node-v13-latest:
+    docker:
+      - image: circleci/node:13
     <<: *unit_test
   deploy:
     docker:
@@ -60,16 +60,16 @@ workflows:
   version: 2
   test-deploy:
     jobs:
-      - node-v8-latest
       - node-v10-latest
       - node-v11-latest
       - node-v12-latest
+      - node-v13-latest
       - deploy:
           requires:
-            - node-v8-latest
             - node-v10-latest
             - node-v11-latest
             - node-v12-latest
+            - node-v13-latest
           filters:
             branches:
               only: master


### PR DESCRIPTION
Node v8.x is about to be EOL’d, and Node v13.x is available now.