### PR TITLE
fix(package): include all desired files

### DIFF
--- a/script/build
+++ b/script/build
@@ -28,4 +28,5 @@ echo 'Building CommonJS version.'
 # Restructure.
 rm -rf dist/test
 mv dist/src/* dist/
+rm -f dist/package.json
 rmdir dist/src


### PR DESCRIPTION
`npm pack` seems to use nested `package.json` when deciding what to pack. This wasn't there before, but one of the upgrades, likely TypeScript, now copies over the `package.json` file. Removing it restores packing behavior to what it was before.