### PR TITLE
fix: bind after super call in CS2

### DIFF
--- a/test/class_test.ts
+++ b/test/class_test.ts
@@ -335,7 +335,7 @@ describe('classes', () => {
     });
 
     it('creates a constructor for bound methods with a `super` call in extended classes when requested', () => {
-      check(
+      checkCS1(
         `
       class A extends B
         a: =>
@@ -346,6 +346,31 @@ describe('classes', () => {
         constructor(...args) {
           this.a = this.a.bind(this);
           super(...args);
+        }
+
+        a() {
+          return 1;
+        }
+      }
+    `
+      );
+
+      // The behavior is different in CS2. Binding happens after `super`.
+      // CS2 also has a runtime check to verify inside bound methods, but
+      // we don't bother with that:
+      //
+      // https://coffeescript.org/#try:class%20A%20extends%20B%0A%20%20a%3A%20%3D%3E%0A%20%20%20%201
+      checkCS2(
+        `
+      class A extends B
+        a: =>
+          1
+    `,
+        `
+      class A extends B {
+        constructor(...args) {
+          super(...args);
+          this.a = this.a.bind(this);
         }
 
         a() {

--- a/test/suggestions_test.ts
+++ b/test/suggestions_test.ts
@@ -1,8 +1,8 @@
-import check, { checkCS1 } from './support/check';
+import check, { checkCS1, checkCS2 } from './support/check';
 
 describe('suggestions', () => {
   it('provides a suggestion for invalid constructors', () => {
-    check(
+    checkCS1(
       `
       class A extends B
         c: =>
@@ -19,6 +19,35 @@ describe('suggestions', () => {
         constructor(...args) {
           this.c = this.c.bind(this);
           super(...args);
+        }
+      
+        c() {
+          return d;
+        }
+      }
+    `,
+      {
+        options: {
+          disableSuggestionComment: false,
+        },
+      }
+    );
+    checkCS2(
+      `
+      class A extends B
+        c: =>
+          d
+    `,
+      `
+      /*
+       * decaffeinate suggestions:
+       * DS102: Remove unnecessary code created because of implicit returns
+       * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
+       */
+      class A extends B {
+        constructor(...args) {
+          super(...args);
+          this.c = this.c.bind(this);
         }
       
         c() {


### PR DESCRIPTION
CS2 changed the behavior of when classes would bind methods to be compatible with ES6 classes. They bind after the call to super, rather than before as in CS1. When targeting CS2, follow that same behavior.

Refs https://github.com/decaffeinate/decaffeinate/issues/2141.