### PR TITLE
fix(class): ensure multiple bindings work in generated constructor

### DIFF
--- a/src/stages/main/patchers/ClassBlockPatcher.ts
+++ b/src/stages/main/patchers/ClassBlockPatcher.ts
@@ -49,9 +49,9 @@ export default class ClassBlockPatcher extends BlockPatcher {
         } else {
           constructor += `constructor() {\n`;
         }
-        const bindingStatements = boundMethods.map(
-          (method) => `${methodBodyIndent}${getBindingCodeForMethod(method)};\n`
-        );
+        const bindingStatements = boundMethods
+          .map((method) => `${methodBodyIndent}${getBindingCodeForMethod(method)};\n`)
+          .join('');
         if (isSubclass) {
           const superStatement = `${methodBodyIndent}super(...args)\n`;
 

--- a/test/class_test.ts
+++ b/test/class_test.ts
@@ -663,15 +663,21 @@ describe('classes', () => {
       class A
         a: =>
           1
+        b: =>
+          2
     `,
       `
       class A {
         constructor() {
           this.a = this.a.bind(this);
+          this.b = this.b.bind(this);
         }
 
         a() {
           return 1;
+        }
+        b() {
+          return 2;
         }
       }
     `


### PR DESCRIPTION
Annoyingly, TypeScript didn't catch this because adding non-string things to a string is allowed since they get coerced to a string. For arrays, it calls `join()` on the array which by default joins with a comma. With a single binding this happened to work, but it breaks with multiple bindings.

Closes #2169