### PR TITLE
fix: upgrade `tslib` to v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "lines-and-columns": "^1.1.6",
     "magic-string": "^0.25.7",
     "mz": "^2.7.0",
-    "tslib": "^2.0.1"
+    "tslib": "^2.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5529,7 +5529,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-tslib@^2.0.1:
+tslib@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==


### PR DESCRIPTION
Without this, I get `__spreadArray is not a function` loading decaffeinate on the website REPL. It seems this helper was added in v2.1.0, and something is expecting it to be there (`tsc`?). I think this will fix it.