### PR TITLE
Make codemod transform ignore babel config, babelrc

### DIFF
--- a/src/stages/resugar/index.ts
+++ b/src/stages/resugar/index.ts
@@ -19,6 +19,8 @@ export default class ResugarStage {
 
     const code = transform(content, {
       plugins: Array.from(this.getPluginsForOptions(options)),
+      configFile: false,
+      babelrc: false,
     }).code as string;
 
     return {


### PR DESCRIPTION
Should fix #1622. Basically `codemod.transform` directly calls `babel.transformSync`, and babel [will pick up](https://babeljs.io/docs/en/options#configfile) `babel.config.json` by default. We don't actually care how the target repo compiles its code, we're only resugaring the code that's been converted, so just forcing babel to not look up any config fixes the issue.

Fixed this with patch-package on our work repo, takes 100+ compile errors down to zero.

```patch
diff --git a/node_modules/decaffeinate/dist/stages/resugar/index.js b/node_modules/decaffeinate/dist/stages/resugar/index.js
--- a/node_modules/decaffeinate/dist/stages/resugar/index.js
+++ b/node_modules/decaffeinate/dist/stages/resugar/index.js
@@ -19,6 +19,8 @@ var ResugarStage = /** @class */ (function () {
         log(content);
         var code = core_1.transform(content, {
             plugins: Array.from(this.getPluginsForOptions(options)),
+            configFile: false,
+            babelrc: false
         }).code;
         return {
             code: code,
```