### PR TITLE
fix: place this assignments after super under CS2

### DIFF
--- a/src/stages/main/patchers/ConstructorPatcher.ts
+++ b/src/stages/main/patchers/ConstructorPatcher.ts
@@ -84,7 +84,7 @@ export default class ConstructorPatcher extends ObjectBodyMemberPatcher {
 
     // Any bindings would ideally go before the super call, so if there are any,
     // we'll need this before super.
-    if (this.getBindings().length > 0) {
+    if (this.getBindings().length > 0 && !this.options.useCS2) {
       return 'Cannot automatically convert a subclass that uses bound methods.';
     }
 

--- a/src/stages/normalize/patchers/ConstructorPatcher.ts
+++ b/src/stages/normalize/patchers/ConstructorPatcher.ts
@@ -1,6 +1,7 @@
 import NodePatcher from '../../../patchers/NodePatcher';
 import PassthroughPatcher from '../../../patchers/PassthroughPatcher';
 import { PatcherContext } from '../../../patchers/types';
+import FunctionPatcher from './FunctionPatcher';
 
 export default class ConstructorPatcher extends PassthroughPatcher {
   assignee: NodePatcher;
@@ -10,5 +11,9 @@ export default class ConstructorPatcher extends PassthroughPatcher {
     super(patcherContext, assignee, expression);
     this.assignee = assignee;
     this.expression = expression;
+
+    if (expression instanceof FunctionPatcher) {
+      expression.enableThisAfterSuper();
+    }
   }
 }

--- a/test/class_test.ts
+++ b/test/class_test.ts
@@ -180,6 +180,45 @@ describe('classes', () => {
       );
     });
 
+    it('subclass constructor with function body', () => {
+      checkCS1(
+        `
+        class A extends B
+          constructor: (@a) ->
+            super()
+      `,
+        `
+        class A extends B {
+          constructor(a) {
+            this.a = a;
+            super();
+          }
+        }
+      `
+      );
+
+      checkCS2(
+        `
+        class A extends B
+          constructor: (@a) ->
+            super()
+      `,
+        `
+        class A extends B {
+          constructor(a) {
+            super();
+            this.a = a;
+          }
+        }
+      `,
+        {
+          options: {
+            disallowInvalidConstructors: true,
+          },
+        }
+      );
+    });
+
     it('method', () => {
       check(
         `
@@ -294,6 +333,39 @@ describe('classes', () => {
         'Cannot automatically convert a subclass that uses bound methods.',
         {
           disallowInvalidConstructors: true,
+          useCS2: false,
+        }
+      );
+    });
+
+    it('passes existing constructor with bound methods in a subclass in CS2', () => {
+      checkCS2(
+        `
+      class A extends B
+        a: =>
+          1
+
+        constructor: ->
+          super()
+          this.b = 2;
+    `,
+        `
+      class A extends B {
+        a() {
+          return 1;
+        }
+
+        constructor() {
+          super();
+          this.a = this.a.bind(this);
+          this.b = 2;
+        }
+      }
+    `,
+        {
+          options: {
+            disallowInvalidConstructors: true,
+          },
         }
       );
     });


### PR DESCRIPTION
CoffeeScript 2 puts autogenerated `this` assignments after the call to the `super`-constructor.

For example, in this code:

```coffee
class A extends B
  constructor: (@a) ->
    super()
  f: =>
```

The assignments to `this.a` and `this.f` are generated just after `super()`.

This commit ensures that decaffeinate follows the same rule.