### PR TITLE
fix(cli): update newer flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,6 @@ decaffeinate could be improved, feel free to file an issue on the [issues] page.
   suggestions at the top of the output file.
 - `--no-array-includes`: Do not use `Array.prototype.includes` in generated
   code.
-- `--use-optional-chaining`: Use the upcoming
-  [optional chaining](https://github.com/tc39/proposal-optional-chaining) syntax
-  for operators like `?.` [**NOTE:** this is disabled and has no effect].
 - `--safe-import-function-identifiers`: Comma-separated list of function names
   that may safely be in the `import`/`require` section of the file. All other
   function calls will disqualify later `require`s from being converted to
@@ -180,7 +177,7 @@ decaffeinate could be improved, feel free to file an issue on the [issues] page.
 - `--loose-js-modules`: Allow named exports when converting to JS modules.
 - `--disallow-invalid-constructors`: Give an error when constructors use `this`
   before `super` or omit the `super` call in a subclass.
-- `--optional-chaining`: Do not transpile optional chaining.
+- `--optional-chaining`: Target JavaScript optional chaining. Note the semantics may not match exactly.
 - `--logical-assignment`: Use the ES2021 [logical
   assignment](https://github.com/tc39/proposal-logical-assignment) operators
   `&&=`, `||=`, and `??=`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,10 +66,6 @@ function parseArguments(args: Array<string>): CLIOptions {
         baseOptions.noArrayIncludes = true;
         break;
 
-      case '--use-optional-chaining':
-        console.warn(`NOTE: ${arg} is disabled and has no effect`);
-        break;
-
       case '--use-js-modules':
         baseOptions.useJSModules = true;
         break;
@@ -135,6 +131,7 @@ function parseArguments(args: Array<string>): CLIOptions {
         break;
 
       case '--optional-chaining':
+      case '--use-optional-chaining':
         baseOptions.optionalChaining = true;
         break;
 
@@ -265,8 +262,6 @@ function usage(): void {
   console.log('                           Do not include a comment with followup suggestions at the');
   console.log('                           top of the output file.');
   console.log('  --no-array-includes      Do not use Array.prototype.includes in generated code.');
-  console.log('  --use-optional-chaining  Use the upcoming optional chaining syntax for operators like `?.`.');
-  console.log('                           NOTE: this is disabled and has no effect.');
   console.log('  --use-js-modules         Convert require and module.exports to import and export.');
   console.log('  --loose-js-modules       Allow named exports when converting to JS modules.');
   console.log('  --safe-import-function-identifiers');
@@ -284,9 +279,10 @@ function usage(): void {
   console.log('  --disallow-invalid-constructors');
   console.log('                           Give an error when constructors use this before super or');
   console.log('                           omit the super call in a subclass.');
-  console.log('  --optional-chaining');
-  console.log('                           Target JavaScript optional chaining. Note the semantics may not');
+  console.log('  --optional-chaining      Target JavaScript optional chaining. Note the semantics may not');
   console.log('                           match exactly.');
+  console.log('  --logical-assignment     Use the ES2021 logical assignment operators `&&=`, `||=`,');
+  console.log('                           and `??=`.');
   console.log();
   console.log('EXAMPLES');
   console.log();


### PR DESCRIPTION
We had `--use-optional-chaining`, but that was disabled in #1338. This commit makes it an alias for `--optional-chaining`, which was added in #1969. Also adds `--logical-assignment` to the CLI help.