### PR TITLE
chore: use `prepublishOnly`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,9 @@ aliases:
       - *install_dependencies_step
       - *save_cache_step
       - run:
+          name: build
+          command: 'yarn build'
+      - run:
           name: tests
           # Why `--maxWorkers`? https://vgpena.github.io/jest-circleci/
           command: 'yarn jest --ci --maxWorkers=2'

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build": "script/build",
     "lint": "eslint --ext .ts src script test",
     "lint:fix": "yarn lint --fix",
-    "prepublish": "yarn build",
+    "prepublishOnly": "yarn build",
     "pretest": "yarn build",
     "test": "jest",
     "update-website": "ts-node ./script/update-website.ts"


### PR DESCRIPTION
We don't need to rebuild after every `yarn add`.