### PR TITLE
fix(cli): pass the correct args

### DIFF
--- a/bin/decaffeinate
+++ b/bin/decaffeinate
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../').run(process.argv.slice(2));
+require('../').run(process.argv);


### PR DESCRIPTION
This was broken by 4c507bda29bc21b053c4cd71c966e96e48c72d63 starting in v7.0.0.