### PR TITLE
chore: enable `corepack`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install pnpm
-        run: curl -L https://pnpm.js.org/pnpm.js | node - add --global pnpm
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -7,7 +7,15 @@ come in, and this document will explain how to help.
 
 ## Get the code, get it running
 
+Enable [`corepack`](https://nodejs.org/api/corepack.html), or otherwise install `pnpm` globally:
+
+```bash
+$ corepack enable
 ```
+
+Get the code and install the dependencies.
+
+```bash
 $ git clone https://github.com/decaffeinate/decaffeinate.git
 $ cd decaffeinate
 $ pnpm install
@@ -15,7 +23,7 @@ $ pnpm install
 
 Run the tests to make sure everything works as expected:
 
-```
+```bash
 $ pnpm test
 ```
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
       "sort-package-json"
     ]
   },
+  "packageManager": "pnpm@7.3.0",
   "dependencies": {
     "@babel/types": "^7.12.6",
     "@codemod/core": "^2.0.1",


### PR DESCRIPTION
Allows declaring the version of the package manager being used in the project in `packageManager` within `package.json`.