### PR TITLE
feat: add `bare` option to allow IIFE wrapper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,10 @@ interface Stage {
  * and formatting.
  */
 export function convert(source: string, options: Options = {}): ConversionResult {
+  if (!options.bare && options.useJSModules) {
+    throw new Error('useJSModules requires bare output');
+  }
+
   source = removeUnicodeBOMIfNecessary(source);
   options = resolveOptions(options);
   const originalNewlineStr = detectNewlineStr(source);
@@ -77,7 +81,7 @@ export function convert(source: string, options: Options = {}): ConversionResult
   }
   result.code = convertNewlines(result.code, originalNewlineStr);
   return {
-    code: result.code,
+    code: options.bare ? result.code : `(function() {\n${result.code}\n}).call(this);`,
   };
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -19,6 +19,7 @@ export interface Options {
   optionalChaining?: boolean;
   logicalAssignment?: boolean;
   nullishCoalescing?: boolean;
+  bare?: boolean;
 }
 
 export const DEFAULT_OPTIONS: Options = {
@@ -39,6 +40,10 @@ export const DEFAULT_OPTIONS: Options = {
   looseIncludes: false,
   looseComparisonNegation: false,
   disallowInvalidConstructors: false,
+  optionalChaining: false,
+  logicalAssignment: false,
+  nullishCoalescing: false,
+  bare: true,
 };
 
 export function resolveOptions(options: Options): Options {

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -30,7 +30,8 @@ async function runCli(
   args: ReadonlyArray<string>,
   stdin: string,
   expectedStdout: string,
-  expectedStderr = ''
+  expectedStderr = '',
+  expectedExitCode = 0
 ): Promise<void> {
   if (stdin[0] === '\n') {
     stdin = stripSharedIndent(stdin);
@@ -67,7 +68,7 @@ async function runCli(
 
   // Check the exit code and output streams.
   expect({ exitCode, stdout: stdout.trim(), stderr: stderr.trim() }).toEqual({
-    exitCode: 0,
+    exitCode: expectedExitCode,
     stdout: expectedStdout.trim(),
     stderr: expectedStderr.trim(),
   });
@@ -559,6 +560,34 @@ describe('decaffeinate CLI', () => {
       stripSharedIndent(`
       const a = 1;
     `)
+    );
+  });
+
+  it('can wrap output in an IIFE', async () => {
+    await runCli(['--no-bare'], '', `(function() {\n\n}).call(this);`);
+  });
+
+  it('cannot use --modernize-js with --no-bare', async () => {
+    await runCli(
+      ['--no-bare', '--modernize-js'],
+      '',
+      '',
+      `
+      cannot use --modernize-js with --no-bare
+    `,
+      1
+    );
+  });
+
+  it('cannot use --use-js-modules with --no-bare', async () => {
+    await runCli(
+      ['--no-bare', '--use-js-modules'],
+      '',
+      '',
+      `
+      cannot use --use-js-modules with --no-bare
+    `,
+      1
     );
   });
 });

--- a/test/iife_test.ts
+++ b/test/iife_test.ts
@@ -1,0 +1,15 @@
+import check from './support/check';
+
+test('does not wrap in an IIFE by default', () => {
+  check(`a = 1`, `const a = 1;`);
+});
+
+test('wraps in an IIFE if requested', () => {
+  check(`a = 1`, `(function() {\nconst a = 1;\n}).call(this);`, { options: { bare: false } });
+});
+
+test('cannot be used with useJSModules', () => {
+  expect(() => check(`a = 1`, `const a = 1;`, { options: { useJSModules: true, bare: false } })).toThrow(
+    /useJSModules requires bare output/
+  );
+});

--- a/test/support/check.ts
+++ b/test/support/check.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { convert } from '../../src/index';
-import { Options } from '../../src/options';
+import { DEFAULT_OPTIONS, Options } from '../../src/options';
 import PatchError from '../../src/utils/PatchError';
 import stripSharedIndent from '../../src/utils/stripSharedIndent';
 
@@ -56,12 +56,13 @@ function maybeStripIndent(
 function checkOutput(source: string, expected: string, options: Options): void {
   try {
     const converted = convert(source, {
+      ...DEFAULT_OPTIONS,
       disableSuggestionComment: true,
       ...options,
     });
     let actual = converted.code;
     if (actual.endsWith('\n') && !expected.endsWith('\n')) {
-      actual = actual.substr(0, actual.length - 1);
+      actual = actual.slice(0, -1);
     }
     expect(actual).toBe(expected);
   } catch (err: unknown) {


### PR DESCRIPTION
Adds `bare` option, which is `true` by default, but when `false` will wrap the output in an IIFE similar to the official CoffeeScript compiler's default behavior. This can be triggered on the CLI with `--no-bare`, which mirrors `coffee`'s `--bare` flag.

**Example:**
```sh
❯ echo 'a = 1' | decaffeinate --no-bare
(function() {
const a = 1;

}).call(this);                                                                                                           
```

Closes #2412