### PR TITLE
fix: allow `--modernize-js` with `--no-bare`

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -193,10 +193,6 @@ function parseArguments(args: ReadonlyArray<string>, io: IO): ParseOptionsResult
     }
   }
 
-  if (!baseOptions.bare && modernizeJS) {
-    return { kind: 'error', message: 'cannot use --modernize-js with --no-bare' };
-  }
-
   if (!baseOptions.bare && baseOptions.useJSModules) {
     return { kind: 'error', message: 'cannot use --use-js-modules with --no-bare' };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ export function modernizeJS(source: string, options: Options = {}): ConversionRe
   const result = runStages(source, options, stages);
   result.code = convertNewlines(result.code, originalNewlineStr);
   return {
-    code: result.code,
+    code: options.bare ? result.code : `(function() {\n${result.code}\n}).call(this);`,
   };
 }
 

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -528,6 +528,10 @@ describe('decaffeinate CLI', () => {
     await runCli(['--modernize-js'], 'var a;', 'let a;');
   });
 
+  it('allows --modernize-js with --no-bare', async () => {
+    await runCli(['--modernize-js', '--no-bare'], 'var a;', '(function() {\nlet a;\n}).call(this);');
+  });
+
   it('discovers JS files with --modernize-js specified', async () => {
     copySync('./test_fixtures/F.js', './test_fixtures/searchDir/F.js');
     await runCli(
@@ -565,18 +569,6 @@ describe('decaffeinate CLI', () => {
 
   it('can wrap output in an IIFE', async () => {
     await runCli(['--no-bare'], '', `(function() {\n\n}).call(this);`);
-  });
-
-  it('cannot use --modernize-js with --no-bare', async () => {
-    await runCli(
-      ['--no-bare', '--modernize-js'],
-      '',
-      '',
-      `
-      cannot use --modernize-js with --no-bare
-    `,
-      1
-    );
   });
 
   it('cannot use --use-js-modules with --no-bare', async () => {


### PR DESCRIPTION
I don't see why this would be useful, but might as well allow it. Per https://github.com/decaffeinate/decaffeinate/pull/2481#discussion_r917463444.