### PR TITLE
Exit with code 1 when the patcher fails

### DIFF
--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -435,7 +435,8 @@ describe('decaffeinate CLI', () => {
       > 2 |   constructor: ->
       > 3 |     @a = 1
       > 4 |     super(arguments...)
-    `
+    `,
+      1
     );
   });
 


### PR DESCRIPTION
Tools like `bulk-decaffeinate` rely on errors to determine when it is safe to run `decaffeinate`.

Currently, running `decaffeinate --disallow-invalid-constructors` exits with code 0 instead of code 1, which leads `bulk-decaffeinate` to believe no errors were encountered in the "check" run.

This change makes it instead exit with code 1, which results in the correct behavior in `bulk-decaffeinate`.