### PR TITLE
ci: only run `pull_request` trigger on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
 
     strategy:
       matrix:


### PR DESCRIPTION
From https://github.com/zopefoundation/meta/issues/145#issuecomment-1127295753