### PR TITLE
chore(script): make `update-website` executable

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 /dist
+/script/update-website

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test": "is-ci test:ci test:watch",
     "test:ci": "jest --ci --maxWorkers=2",
     "test:watch": "jest --watch",
-    "update-website": "esr --cache ./script/update-website.ts"
+    "update-website": "./script/update-website"
   },
   "husky": {
     "hooks": {

--- a/script/update-website
+++ b/script/update-website
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require('esbuild-runner').install();
+require('./update-website.ts');


### PR DESCRIPTION
Instead of calling `esr` from the CLI, wrap the `.ts` file with an executable that installs `esbuild-runner`'s `require` hooks.