### PR TITLE
refactor: mark private methods as such

### DIFF
--- a/src/patchers/NodePatcher.ts
+++ b/src/patchers/NodePatcher.ts
@@ -92,10 +92,7 @@ export default class NodePatcher {
     return null;
   }
 
-  /**
-   * @private
-   */
-  setupLocationInformation(): void {
+  private setupLocationInformation(): void {
     const { node, context } = this;
 
     /**
@@ -1207,10 +1204,8 @@ export default class NodePatcher {
 
   /**
    * Gets the index ending the line following this patcher's node.
-   *
-   * @private
    */
-  getEndOfLine(): number {
+  private getEndOfLine(): number {
     const { source } = this.context;
     for (let i = this.outerEnd - '\n'.length; i < source.length; i++) {
       if (source[i] === '\n') {

--- a/src/stages/main/patchers/BinaryOpPatcher.ts
+++ b/src/stages/main/patchers/BinaryOpPatcher.ts
@@ -69,7 +69,7 @@ export default class BinaryOpPatcher extends NodePatcher {
     // override point for subclasses
   }
 
-  getOperator(): string {
+  protected getOperator(): string {
     return this.sourceOfToken(this.getOperatorToken());
   }
 

--- a/src/stages/main/patchers/BlockPatcher.ts
+++ b/src/stages/main/patchers/BlockPatcher.ts
@@ -248,10 +248,7 @@ export default class BlockPatcher extends SharedBlockPatcher {
     }
   }
 
-  /**
-   * @private
-   */
-  getSemicolonSourceTokenIndexBetween(left: NodePatcher, right: NodePatcher): SourceTokenListIndex | null {
+  private getSemicolonSourceTokenIndexBetween(left: NodePatcher, right: NodePatcher): SourceTokenListIndex | null {
     return this.indexOfSourceTokenBetweenPatchersMatching(left, right, (token) => token.type === SourceType.SEMICOLON);
   }
 

--- a/src/stages/main/patchers/ChainedComparisonOpPatcher.ts
+++ b/src/stages/main/patchers/ChainedComparisonOpPatcher.ts
@@ -82,10 +82,7 @@ export default class ChainedComparisonOpPatcher extends NodePatcher {
     );
   }
 
-  /**
-   * @private
-   */
-  getMiddleOperands(): Array<NodePatcher> {
+  private getMiddleOperands(): Array<NodePatcher> {
     return this.operands.slice(1, -1);
   }
 

--- a/src/stages/main/patchers/ClassPatcher.ts
+++ b/src/stages/main/patchers/ClassPatcher.ts
@@ -115,10 +115,7 @@ export default class ClassPatcher extends NodePatcher {
     return this.isAnonymous();
   }
 
-  /**
-   * @private
-   */
-  getClassToken(): SourceToken {
+  private getClassToken(): SourceToken {
     const tokens = this.context.sourceTokens;
     const classSourceToken = notNull(tokens.tokenAtIndex(this.contentStartTokenIndex));
     if (classSourceToken.type !== SourceType.CLASS) {
@@ -131,17 +128,11 @@ export default class ClassPatcher extends NodePatcher {
     return classSourceToken;
   }
 
-  /**
-   * @private
-   */
-  isAnonymous(): boolean {
+  private isAnonymous(): boolean {
     return this.nameAssignee === null;
   }
 
-  /**
-   * @private
-   */
-  isNamespaced(): boolean {
+  private isNamespaced(): boolean {
     return !this.isAnonymous() && !(this.nameAssignee instanceof IdentifierPatcher);
   }
 
@@ -155,9 +146,6 @@ export default class ClassPatcher extends NodePatcher {
     return this.nameAssignee !== null && name !== null && this.getScope().getBinding(name) !== this.nameAssignee.node;
   }
 
-  /**
-   * @private
-   */
   getName(): string | null {
     const { nameAssignee } = this;
     let name;
@@ -178,10 +166,7 @@ export default class ClassPatcher extends NodePatcher {
     return this.superclass !== null;
   }
 
-  /**
-   * @private
-   */
-  getBraceInsertionOffset(): number {
+  private getBraceInsertionOffset(): number {
     if (this.superclass) {
       return this.superclass.outerEnd;
     }

--- a/src/stages/main/patchers/ConditionalPatcher.ts
+++ b/src/stages/main/patchers/ConditionalPatcher.ts
@@ -80,9 +80,6 @@ export default class ConditionalPatcher extends NodePatcher {
     );
   }
 
-  /**
-   * @private
-   */
   willPatchAsIIFE(): boolean {
     return !this.willPatchAsTernary() && this.forcedToPatchAsExpression();
   }
@@ -210,10 +207,7 @@ export default class ConditionalPatcher extends NodePatcher {
     this.patchAlternateForStatement();
   }
 
-  /**
-   * @private
-   */
-  patchConditionForStatement(): void {
+  private patchConditionForStatement(): void {
     // `unless a` → `if a`
     //  ^^^^^^        ^^
     const ifToken = notNull(this.sourceTokenAtIndex(this.getIfSourceTokenIndex()));
@@ -248,10 +242,7 @@ export default class ConditionalPatcher extends NodePatcher {
     }
   }
 
-  /**
-   * @private
-   */
-  patchConsequentForStatement(): void {
+  private patchConsequentForStatement(): void {
     this.insert(this.condition.outerEnd, ' {');
 
     if (this.alternate) {
@@ -271,10 +262,7 @@ export default class ConditionalPatcher extends NodePatcher {
     }
   }
 
-  /**
-   * @private
-   */
-  patchAlternateForStatement(): void {
+  private patchAlternateForStatement(): void {
     const elseTokenIndex = this.getElseSourceTokenIndex();
     if (this.alternate && elseTokenIndex) {
       const ifToken = this.sourceTokenAtIndex(notNull(elseTokenIndex.next()));
@@ -329,10 +317,8 @@ export default class ConditionalPatcher extends NodePatcher {
 
   /**
    * Gets the index of the token representing the `if` at the start.
-   *
-   * @private
    */
-  getIfSourceTokenIndex(): SourceTokenListIndex {
+  private getIfSourceTokenIndex(): SourceTokenListIndex {
     const ifTokenIndex = this.indexOfSourceTokenStartingAtSourceIndex(this.contentStart);
     if (!ifTokenIndex) {
       throw this.error('expected IF token at start of conditional');
@@ -346,10 +332,8 @@ export default class ConditionalPatcher extends NodePatcher {
   /**
    * Gets the index of the token representing the `else` between consequent and
    * alternate.
-   *
-   * @private
    */
-  getElseSourceTokenIndex(): SourceTokenListIndex | null {
+  private getElseSourceTokenIndex(): SourceTokenListIndex | null {
     const elseTokenIndex = this.indexOfSourceTokenBetweenSourceIndicesMatching(
       this.consequent !== null ? this.consequent.outerEnd : this.condition.outerEnd,
       this.alternate !== null ? this.alternate.outerStart : this.outerEnd,
@@ -368,10 +352,8 @@ export default class ConditionalPatcher extends NodePatcher {
   /**
    * Gets the index of the token representing the `then` between condition and
    * consequent.
-   *
-   * @private
    */
-  getThenTokenIndex(): SourceTokenListIndex | null {
+  private getThenTokenIndex(): SourceTokenListIndex | null {
     let searchEnd;
     if (this.consequent) {
       searchEnd = this.consequent.outerStart;

--- a/src/stages/main/patchers/DoOpPatcher.ts
+++ b/src/stages/main/patchers/DoOpPatcher.ts
@@ -73,10 +73,7 @@ export default class DoOpPatcher extends NodePatcher {
     }
   }
 
-  /**
-   * @private
-   */
-  getDoTokenIndex(): SourceTokenListIndex {
+  private getDoTokenIndex(): SourceTokenListIndex {
     const index = this.contentStartTokenIndex;
     const token = this.sourceTokenAtIndex(index);
     if (!token || token.type !== SourceType.DO) {

--- a/src/stages/main/patchers/EqualityPatcher.ts
+++ b/src/stages/main/patchers/EqualityPatcher.ts
@@ -21,10 +21,7 @@ export default class EqualityPatcher extends BinaryOpPatcher {
     return getCompareOperator(this.sourceOfToken(token), this.negated);
   }
 
-  /**
-   * @private
-   */
-  getCompareToken(): SourceToken {
+  private getCompareToken(): SourceToken {
     const { left, right } = this;
     const compareTokenIndex = this.indexOfSourceTokenBetweenPatchersMatching(
       left,

--- a/src/stages/main/patchers/LogicalOpCompoundAssignOpPatcher.ts
+++ b/src/stages/main/patchers/LogicalOpCompoundAssignOpPatcher.ts
@@ -61,10 +61,7 @@ export default class LogicalOpCompoundAssignOpPatcher extends CompoundAssignOpPa
     this.insert(this.expression.outerEnd, ' }');
   }
 
-  /**
-   * @private
-   */
-  isOrOp(): boolean {
+  private isOrOp(): boolean {
     const operator = this.getOperatorToken();
     const op = this.sourceOfToken(operator);
     // There could be a space in the middle of the operator, like `or =` or

--- a/src/stages/main/patchers/LogicalOpPatcher.ts
+++ b/src/stages/main/patchers/LogicalOpPatcher.ts
@@ -21,10 +21,8 @@ export default class LogicalOpPatcher extends BinaryOpPatcher {
 
   /**
    * Apply De Morgan's law.
-   *
-   * @private
    */
-  getOperator(): string {
+  protected getOperator(): string {
     const operatorToken = this.getOperatorToken();
     let operator = this.context.source.slice(operatorToken.start, operatorToken.end);
     if (operator === 'and') {

--- a/src/stages/main/patchers/LoopPatcher.ts
+++ b/src/stages/main/patchers/LoopPatcher.ts
@@ -168,19 +168,13 @@ export default class LoopPatcher extends NodePatcher {
     return `${this.getResultArrayBinding()}.push(undefined)`;
   }
 
-  /**
-   * @private
-   */
-  getResultArrayBinding(): string {
+  private getResultArrayBinding(): string {
     if (!this._resultArrayBinding) {
       this._resultArrayBinding = this.claimFreeBinding('result');
     }
     return this._resultArrayBinding;
   }
 
-  /**
-   * @private
-   */
   getResultArrayElementBinding(): string {
     if (!this._resultArrayElementBinding) {
       this._resultArrayElementBinding = this.claimFreeBinding('item');

--- a/src/stages/main/patchers/ObjectInitialiserMemberPatcher.ts
+++ b/src/stages/main/patchers/ObjectInitialiserMemberPatcher.ts
@@ -31,10 +31,7 @@ export default class ObjectInitialiserMemberPatcher extends ObjectBodyMemberPatc
     }
   }
 
-  /**
-   * @private
-   */
-  patchAsShorthand({ expand = false }: { expand: boolean }): void {
+  private patchAsShorthand({ expand = false }: { expand: boolean }): void {
     const { key } = this;
     if (key instanceof MemberAccessOpPatcher) {
       key.patch();

--- a/src/stages/main/patchers/ObjectInitialiserPatcher.ts
+++ b/src/stages/main/patchers/ObjectInitialiserPatcher.ts
@@ -138,20 +138,14 @@ export default class ObjectInitialiserPatcher extends NodePatcher {
     }
   }
 
-  /**
-   * @private
-   */
-  shouldExpandCurlyBraces(): boolean {
+  private shouldExpandCurlyBraces(): boolean {
     return (
       this.isMultiline() ||
       (this.parent instanceof ObjectInitialiserMemberPatcher && notNull(this.parent.parent).isMultiline())
     );
   }
 
-  /**
-   * @private
-   */
-  patchMembers(): void {
+  private patchMembers(): void {
     this.members.forEach((member, i, members) => {
       member.patch();
       if (i !== members.length - 1) {

--- a/src/stages/main/patchers/ProgramPatcher.ts
+++ b/src/stages/main/patchers/ProgramPatcher.ts
@@ -21,10 +21,8 @@ export default class ProgramPatcher extends SharedProgramPatcher {
 
   /**
    * Removes continuation tokens (i.e. '\' at the end of a line).
-   *
-   * @private
    */
-  patchContinuations(): void {
+  private patchContinuations(): void {
     this.getProgramSourceTokens().forEach((token) => {
       if (token.type === SourceType.CONTINUATION) {
         this.remove(token.start, token.end);
@@ -34,10 +32,8 @@ export default class ProgramPatcher extends SharedProgramPatcher {
 
   /**
    * Replaces CoffeeScript style comments with JavaScript style comments.
-   *
-   * @private
    */
-  patchComments(): void {
+  private patchComments(): void {
     const { source } = this.context;
     this.getProgramSourceTokens().forEach((token) => {
       if (token.type === SourceType.COMMENT) {
@@ -54,10 +50,8 @@ export default class ProgramPatcher extends SharedProgramPatcher {
 
   /**
    * Patches a block comment.
-   *
-   * @private
    */
-  patchBlockComment(comment: SourceToken): void {
+  private patchBlockComment(comment: SourceToken): void {
     const { start, end } = comment;
     this.overwrite(start, start + BLOCK_COMMENT_DELIMITER.length, '/*');
 
@@ -109,20 +103,16 @@ export default class ProgramPatcher extends SharedProgramPatcher {
 
   /**
    * Patches a single-line comment.
-   *
-   * @private
    */
-  patchLineComment(comment: SourceToken): void {
+  private patchLineComment(comment: SourceToken): void {
     const { start } = comment;
     this.overwrite(start, start + '#'.length, '//');
   }
 
   /**
    * Patches a shebang comment.
-   *
-   * @private
    */
-  patchShebangComment(comment: SourceToken): void {
+  private patchShebangComment(comment: SourceToken): void {
     const { start, end } = comment;
     const commentBody = this.slice(start, end);
     const coffeeIndex = commentBody.indexOf('coffee');

--- a/src/stages/main/patchers/RangePatcher.ts
+++ b/src/stages/main/patchers/RangePatcher.ts
@@ -26,10 +26,7 @@ export default class RangePatcher extends BinaryOpPatcher {
     }
   }
 
-  /**
-   * @private
-   */
-  patchAsLiteralArray(): void {
+  private patchAsLiteralArray(): void {
     if (!(this.left.node instanceof Int) || !(this.right.node instanceof Int)) {
       throw this.error('Expected ints on both sides for a literal array.');
     }
@@ -58,10 +55,7 @@ export default class RangePatcher extends BinaryOpPatcher {
     this.overwrite(this.contentStart, this.contentEnd, `[${list}]`);
   }
 
-  /**
-   * @private
-   */
-  patchAsIIFE(): void {
+  private patchAsIIFE(): void {
     const helper = this.registerHelper('__range__', RANGE_HELPER);
 
     // `[a..b]` → `__range__(a..b]`
@@ -81,10 +75,7 @@ export default class RangePatcher extends BinaryOpPatcher {
     this.overwrite(this.right.outerEnd, this.contentEnd, `, ${JSON.stringify(this.isInclusive())})`);
   }
 
-  /**
-   * @private
-   */
-  canBecomeLiteralArray(): boolean {
+  private canBecomeLiteralArray(): boolean {
     const range = this.getLiteralRange();
 
     if (!range) {
@@ -95,10 +86,7 @@ export default class RangePatcher extends BinaryOpPatcher {
     return Math.abs(last - first) <= MAXIMUM_LITERAL_RANGE_ELEMENTS;
   }
 
-  /**
-   * @private
-   */
-  getLiteralRange(): [number, number] | null {
+  private getLiteralRange(): [number, number] | null {
     const left = this.left.node;
     const right = this.right.node;
 
@@ -115,9 +103,6 @@ export default class RangePatcher extends BinaryOpPatcher {
     }
   }
 
-  /**
-   * @private
-   */
   isInclusive(): boolean {
     return this.node.isInclusive;
   }

--- a/src/stages/main/patchers/SlicePatcher.ts
+++ b/src/stages/main/patchers/SlicePatcher.ts
@@ -164,18 +164,12 @@ export default class SlicePatcher extends NodePatcher {
     this.remove(indexEnd.start, indexEnd.end);
   }
 
-  /**
-   * @private
-   */
   isInclusive(): boolean {
     const slice = this.getSliceSourceToken();
     return slice.end - slice.start === '..'.length;
   }
 
-  /**
-   * @private
-   */
-  getIndexStartSourceToken(): SourceToken {
+  private getIndexStartSourceToken(): SourceToken {
     const tokens = this.context.sourceTokens;
     const index = tokens.indexOfTokenMatchingPredicate(
       (token) => token.type === SourceType.LBRACKET,
@@ -187,10 +181,7 @@ export default class SlicePatcher extends NodePatcher {
     return notNull(tokens.tokenAtIndex(index));
   }
 
-  /**
-   * @private
-   */
-  getSliceSourceToken(): SourceToken {
+  private getSliceSourceToken(): SourceToken {
     const tokens = this.context.sourceTokens;
     const { source } = this.context;
     const index = tokens.indexOfTokenMatchingPredicate(
@@ -209,10 +200,7 @@ export default class SlicePatcher extends NodePatcher {
     return notNull(tokens.tokenAtIndex(index));
   }
 
-  /**
-   * @private
-   */
-  getIndexEndSourceToken(): SourceToken {
+  private getIndexEndSourceToken(): SourceToken {
     const tokens = this.context.sourceTokens;
     const index = tokens.lastIndexOfTokenMatchingPredicate(
       (token) => token.type === SourceType.RBRACKET,

--- a/src/stages/main/patchers/SuperPatcher.ts
+++ b/src/stages/main/patchers/SuperPatcher.ts
@@ -55,10 +55,7 @@ export default class SuperPatcher extends NodePatcher {
     }
   }
 
-  /**
-   * @private
-   */
-  getEnclosingMethodInfo(): MethodInfo {
+  private getEnclosingMethodInfo(): MethodInfo {
     const methodAssignment = this.getEnclosingMethodAssignment();
     if (methodAssignment instanceof ClassAssignOpPatcher) {
       let accessCode;
@@ -95,10 +92,7 @@ export default class SuperPatcher extends NodePatcher {
     }
   }
 
-  /**
-   * @private
-   */
-  getEnclosingClassName(patcher: NodePatcher): string | null {
+  private getEnclosingClassName(patcher: NodePatcher): string | null {
     let { parent } = patcher;
     while (parent) {
       if (parent instanceof ClassPatcher) {
@@ -112,10 +106,7 @@ export default class SuperPatcher extends NodePatcher {
     throw this.error('Expected super expression to be in a class body.');
   }
 
-  /**
-   * @private
-   */
-  getEnclosingMethodAssignment(): NodePatcher {
+  private getEnclosingMethodAssignment(): NodePatcher {
     let { parent } = this;
     while (parent) {
       if (
@@ -133,10 +124,8 @@ export default class SuperPatcher extends NodePatcher {
   /**
    * Extract the 'A' and 'b' from a node like `A.prototype.b = -> c`, if it
    * matches that form. Return null otherwise.
-   *
-   * @private
    */
-  getPrototypeAssignInfo(patcher: NodePatcher): MethodInfo | null {
+  private getPrototypeAssignInfo(patcher: NodePatcher): MethodInfo | null {
     const prototypeAssignPatchers = extractPrototypeAssignPatchers(patcher);
     if (!prototypeAssignPatchers) {
       return null;
@@ -169,10 +158,8 @@ export default class SuperPatcher extends NodePatcher {
    * - CoffeeScript allows `super` from nested methods (which end up compiling
    *   to use whatever `arguments` is relevant at that point in code if the
    *   `super` is written without args).
-   *
-   * @private
    */
-  canConvertToJsSuper(): boolean {
+  private canConvertToJsSuper(): boolean {
     const methodAssignment = this.getEnclosingMethodAssignment();
     if (methodAssignment instanceof ConstructorPatcher || methodAssignment instanceof ClassAssignOpPatcher) {
       return methodAssignment.expression === this.getEnclosingFunction();
@@ -180,10 +167,7 @@ export default class SuperPatcher extends NodePatcher {
     return false;
   }
 
-  /**
-   * @private
-   */
-  getEnclosingFunction(): NodePatcher {
+  private getEnclosingFunction(): NodePatcher {
     let { parent } = this;
     while (parent) {
       if (parent instanceof FunctionPatcher) {
@@ -194,10 +178,7 @@ export default class SuperPatcher extends NodePatcher {
     throw this.error('super called outside of a function.');
   }
 
-  /**
-   * @private
-   */
-  getFollowingOpenParenToken(): SourceToken {
+  private getFollowingOpenParenToken(): SourceToken {
     const openParenTokenIndex = this.indexOfSourceTokenAfterSourceTokenIndex(
       this.contentEndTokenIndex,
       SourceType.CALL_START

--- a/src/stages/main/patchers/SwitchCasePatcher.ts
+++ b/src/stages/main/patchers/SwitchCasePatcher.ts
@@ -101,10 +101,7 @@ export default class SwitchCasePatcher extends NodePatcher {
     this.negated = !this.negated;
   }
 
-  /**
-   * @private
-   */
-  getWhenToken(): SourceToken {
+  private getWhenToken(): SourceToken {
     const whenToken = this.sourceTokenAtIndex(this.contentStartTokenIndex);
     if (!whenToken) {
       throw this.error(`bad token index for start of 'when'`);
@@ -115,10 +112,7 @@ export default class SwitchCasePatcher extends NodePatcher {
     return whenToken;
   }
 
-  /**
-   * @private
-   */
-  getCommaTokens(): Array<SourceToken> {
+  private getCommaTokens(): Array<SourceToken> {
     const result: Array<SourceToken> = [];
     for (let i = 1; i < this.conditions.length; i++) {
       const left = this.conditions[i - 1];
@@ -136,10 +130,7 @@ export default class SwitchCasePatcher extends NodePatcher {
     return result;
   }
 
-  /**
-   * @private
-   */
-  hasExistingBreak(): boolean {
+  private hasExistingBreak(): boolean {
     if (!(this.consequent instanceof BlockPatcher)) {
       return false;
     }
@@ -149,10 +140,8 @@ export default class SwitchCasePatcher extends NodePatcher {
 
   /**
    * Gets the token representing the `then` between condition and consequent.
-   *
-   * @private
    */
-  getThenToken(): SourceToken | null {
+  private getThenToken(): SourceToken | null {
     const thenTokenIndex = this.indexOfSourceTokenBetweenSourceIndicesMatching(
       this.conditions[0].outerEnd,
       this.consequent !== null ? this.consequent.outerStart : this.contentEnd,

--- a/src/stages/main/patchers/SwitchPatcher.ts
+++ b/src/stages/main/patchers/SwitchPatcher.ts
@@ -110,10 +110,7 @@ export default class SwitchPatcher extends NodePatcher {
     return this.willPatchAsExpression();
   }
 
-  /**
-   * @private
-   */
-  overwriteElse(): void {
+  private overwriteElse(): void {
     // `else` → `default:`
     //           ^^^^^^^^
     const elseToken = this.getElseToken();
@@ -122,10 +119,7 @@ export default class SwitchPatcher extends NodePatcher {
     }
   }
 
-  /**
-   * @private
-   */
-  getElseToken(): SourceToken | null {
+  private getElseToken(): SourceToken | null {
     let searchStart;
     if (this.cases.length > 0) {
       searchStart = this.cases[this.cases.length - 1].outerEnd;
@@ -155,10 +149,7 @@ export default class SwitchPatcher extends NodePatcher {
     return this.sourceTokenAtIndex(elseTokenIndex);
   }
 
-  /**
-   * @private
-   */
-  getSwitchToken(): SourceToken {
+  private getSwitchToken(): SourceToken {
     const switchToken = this.sourceTokenAtIndex(this.contentStartTokenIndex);
     if (!switchToken) {
       throw this.error(`bad token index for start of 'switch'`);

--- a/src/stages/main/patchers/TryPatcher.ts
+++ b/src/stages/main/patchers/TryPatcher.ts
@@ -184,10 +184,7 @@ export default class TryPatcher extends NodePatcher {
     return false;
   }
 
-  /**
-   * @private
-   */
-  getTryToken(): SourceToken {
+  private getTryToken(): SourceToken {
     const tryTokenIndex = this.contentStartTokenIndex;
     const tryToken = this.sourceTokenAtIndex(tryTokenIndex);
     if (!tryToken || tryToken.type !== SourceType.TRY) {
@@ -196,10 +193,7 @@ export default class TryPatcher extends NodePatcher {
     return tryToken;
   }
 
-  /**
-   * @private
-   */
-  getCatchToken(): SourceToken | null {
+  private getCatchToken(): SourceToken | null {
     let searchStart;
     if (this.body) {
       searchStart = this.body.outerEnd;
@@ -229,10 +223,7 @@ export default class TryPatcher extends NodePatcher {
     return this.sourceTokenAtIndex(catchTokenIndex);
   }
 
-  /**
-   * @private
-   */
-  getThenTokenIndex(): SourceTokenListIndex | null {
+  private getThenTokenIndex(): SourceTokenListIndex | null {
     let searchStart;
     if (this.catchAssignee) {
       searchStart = this.catchAssignee.outerEnd;
@@ -265,10 +256,7 @@ export default class TryPatcher extends NodePatcher {
     );
   }
 
-  /**
-   * @private
-   */
-  getFinallyToken(): SourceToken | null {
+  private getFinallyToken(): SourceToken | null {
     let searchStart;
     if (this.catchBody) {
       searchStart = this.catchBody.outerEnd;
@@ -298,10 +286,7 @@ export default class TryPatcher extends NodePatcher {
     return this.sourceTokenAtIndex(finallyTokenIndex);
   }
 
-  /**
-   * @private
-   */
-  getErrorBinding(): string {
+  private getErrorBinding(): string {
     if (!this._errorBinding) {
       this._errorBinding = this.claimFreeBinding('error');
     }

--- a/src/stages/main/patchers/UnaryExistsOpPatcher.ts
+++ b/src/stages/main/patchers/UnaryExistsOpPatcher.ts
@@ -111,10 +111,7 @@ export default class UnaryExistsOpPatcher extends UnaryOpPatcher {
     this.negated = !this.negated;
   }
 
-  /**
-   * @private
-   */
-  needsTypeofCheck(): boolean {
+  private needsTypeofCheck(): boolean {
     return this.expression.mayBeUnboundReference();
   }
 

--- a/src/stages/main/patchers/WhilePatcher.ts
+++ b/src/stages/main/patchers/WhilePatcher.ts
@@ -120,10 +120,7 @@ export default class WhilePatcher extends LoopPatcher {
     }
   }
 
-  /**
-   * @private
-   */
-  getWhileTokenIndex(): SourceTokenListIndex {
+  private getWhileTokenIndex(): SourceTokenListIndex {
     const whileTokenIndex = this.contentStartTokenIndex;
     const whileToken = this.sourceTokenAtIndex(whileTokenIndex);
     if (!whileToken || whileToken.type !== SourceType.WHILE) {
@@ -132,10 +129,7 @@ export default class WhilePatcher extends LoopPatcher {
     return whileTokenIndex;
   }
 
-  /**
-   * @private
-   */
-  getThenTokenIndex(): SourceTokenListIndex | null {
+  private getThenTokenIndex(): SourceTokenListIndex | null {
     const whileTokenIndex = this.getWhileTokenIndex();
     if (!whileTokenIndex) {
       throw this.error(`could not get first token of 'while' loop`);

--- a/src/stages/normalize/patchers/ForPatcher.ts
+++ b/src/stages/normalize/patchers/ForPatcher.ts
@@ -98,10 +98,7 @@ export default class ForPatcher extends NodePatcher {
     }
   }
 
-  /**
-   * @private
-   */
-  isPostFor(): boolean {
+  private isPostFor(): boolean {
     return this.body && this.body.contentStart < this.target.contentStart;
   }
 
@@ -120,10 +117,7 @@ export default class ForPatcher extends NodePatcher {
     }
   }
 
-  /**
-   * @private
-   */
-  getForToken(): SourceToken {
+  private getForToken(): SourceToken {
     if (this.isPostFor()) {
       const afterForToken = this.getFirstHeaderPatcher();
       const index = this.indexOfSourceTokenBetweenPatchersMatching(
@@ -146,10 +140,7 @@ export default class ForPatcher extends NodePatcher {
     }
   }
 
-  /**
-   * @private
-   */
-  getFirstHeaderPatcher(): NodePatcher {
+  private getFirstHeaderPatcher(): NodePatcher {
     const candidates = [this.keyAssignee, this.valAssignee, this.target];
     let result: NodePatcher | null = null;
     candidates.forEach((candidate) => {

--- a/src/stages/normalize/patchers/WhilePatcher.ts
+++ b/src/stages/normalize/patchers/WhilePatcher.ts
@@ -47,10 +47,8 @@ export default class WhilePatcher extends NodePatcher {
   /**
    * `BODY 'while' CONDITION ('when' GUARD)?` → `while CONDITION [when GUARD] then BODY`
    * `BODY 'until' CONDITION ('when' GUARD)?` → `until CONDITION [when GUARD] then BODY`
-   *
-   * @private
    */
-  normalize(): void {
+  private normalize(): void {
     if (this.body === null) {
       throw this.error('Expected non-null body.');
     }
@@ -76,10 +74,7 @@ export default class WhilePatcher extends NodePatcher {
     this.overwrite(this.contentStart, this.contentEnd, newContent);
   }
 
-  /**
-   * @private
-   */
-  isPostWhile(): boolean {
+  private isPostWhile(): boolean {
     return this.body !== null && this.condition.contentStart > this.body.contentStart;
   }
 }

--- a/src/utils/Scope.ts
+++ b/src/utils/Scope.ts
@@ -129,17 +129,11 @@ export default class Scope {
     return binding;
   }
 
-  /**
-   * @private
-   */
-  key(name: string): string {
+  private key(name: string): string {
     return `$${name}`;
   }
 
-  /**
-   * @private
-   */
-  unkey(key: string): string {
+  private unkey(key: string): string {
     return key.slice(1);
   }
 


### PR DESCRIPTION
Anything that was marked `@private` but actually needed to be public or protected I updated manually.