### PR TITLE
Fix incorrect link in docs

### DIFF
--- a/docs/conversion-guide.md
+++ b/docs/conversion-guide.md
@@ -77,7 +77,7 @@ but don't work as well in JavaScript.
 
 For a comprehensive list of things to keep in mind when looking over the
 JavaScript output, see
-[Cleanup suggestions after running decaffeinate](./correctness-issues.md).
+[Cleanup suggestions after running decaffeinate](./suggestions.md).
 
 ### Run your tests
 


### PR DESCRIPTION
Link to cleanup suggestions was actually linking to the `How decaffeinate approaches correctness` page