### PR TITLE
Add source map support

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@babel/types": "^7.12.6",
     "@codemod/core": "^2.0.1",
     "@codemod/parser": "^1.2.1",
+    "@jridgewell/remapping": "^2.3.5",
     "@resugar/codemod-declarations-block-scope": "^1.0.3",
     "@resugar/codemod-functions-arrow": "^1.0.2",
     "@resugar/codemod-modules-commonjs": "^1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   '@codemod/parser':
     specifier: ^1.2.1
     version: 1.2.1
+  '@jridgewell/remapping':
+    specifier: ^2.3.5
+    version: 2.3.5
   '@resugar/codemod-declarations-block-scope':
     specifier: ^1.0.3
     version: 1.0.3
@@ -2169,7 +2172,14 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.1
       '@jridgewell/sourcemap-codec': 1.4.14
-      '@jridgewell/trace-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.17
+
+  /@jridgewell/gen-mapping@0.3.13:
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+    dev: false
 
   /@jridgewell/gen-mapping@0.3.2:
     resolution: {integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==}
@@ -2178,6 +2188,13 @@ packages:
       '@jridgewell/set-array': 1.1.1
       '@jridgewell/sourcemap-codec': 1.4.14
       '@jridgewell/trace-mapping': 0.3.17
+    dev: false
+
+  /@jridgewell/remapping@2.3.5:
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
     dev: false
 
   /@jridgewell/resolve-uri@3.0.7:
@@ -2195,6 +2212,10 @@ packages:
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
 
+  /@jridgewell/sourcemap-codec@1.5.5:
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+    dev: false
+
   /@jridgewell/trace-mapping@0.3.13:
     resolution: {integrity: sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==}
     dependencies:
@@ -2206,6 +2227,13 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+
+  /@jridgewell/trace-mapping@0.3.31:
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: false
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { readdir, readFile, stat, writeFile } from 'mz/fs';
 import { basename, dirname, extname, join } from 'path';
-import { convert, modernizeJS } from './index';
+import { convert, modernizeJS, SourceMap } from './index';
 import { DEFAULT_OPTIONS, Options } from './options';
 import PatchError from './utils/PatchError';
 
@@ -53,6 +53,7 @@ interface CLIOptions {
   readonly modernizeJS: boolean;
   readonly version: boolean;
   readonly help: boolean;
+  readonly sourceMap: boolean;
 }
 
 interface ParseOptionsError {
@@ -66,6 +67,7 @@ function parseArguments(args: ReadonlyArray<string>, io: IO): ParseOptionsResult
   let modernizeJS = false;
   let help = false;
   let version = false;
+  let sourceMap = false;
 
   for (let i = 2; i < args.length; i++) {
     const arg = args[i];
@@ -182,6 +184,11 @@ function parseArguments(args: ReadonlyArray<string>, io: IO): ParseOptionsResult
         baseOptions.nullishCoalescing = true;
         break;
 
+      case '--source-map':
+        sourceMap = true;
+        baseOptions.sourceMap = true;
+        break;
+
       default:
         if (arg.startsWith('-')) {
           return { kind: 'error', message: `unrecognized option: ${arg}` };
@@ -195,7 +202,7 @@ function parseArguments(args: ReadonlyArray<string>, io: IO): ParseOptionsResult
     return { kind: 'error', message: 'cannot use --use-js-modules with --no-bare' };
   }
 
-  return { kind: 'success', paths, baseOptions, modernizeJS, version, help };
+  return { kind: 'success', paths, baseOptions, modernizeJS, version, help, sourceMap };
 }
 
 /**
@@ -241,12 +248,18 @@ async function runWithPaths(paths: Array<string>, options: CLIOptions, io: IO): 
   async function processFile(path: string): Promise<boolean> {
     const extension = path.endsWith('.coffee.md') ? '.coffee.md' : extname(path);
     const outputPath = join(dirname(path), basename(path, extension)) + '.js';
+    const mapPath = outputPath + '.map';
     io.stdout.write(`${path} → ${outputPath}\n`);
     const data = await readFile(path, 'utf8');
-    const resultCode = runWithCode(path, data, options, io);
-    const success = typeof resultCode === 'string';
-    if (success) {
-      await writeFile(outputPath, resultCode);
+    const result = runWithResult(path, data, options, io);
+    const success = result !== undefined;
+    if (success && result !== undefined) {
+      let { code } = result;
+      if (result.map) {
+        await writeFile(mapPath, JSON.stringify(result.map));
+        code += `\n//# sourceMappingURL=${basename(mapPath)}`;
+      }
+      await writeFile(outputPath, code);
     }
     return success;
   }
@@ -265,10 +278,10 @@ async function runWithStdio(options: CLIOptions, io: IO): Promise<boolean> {
     let data = '';
     io.stdin.on('data', (chunk) => (data += chunk));
     io.stdin.on('end', () => {
-      const resultCode = runWithCode('stdin', data, options, io);
-      const success = typeof resultCode === 'string';
-      if (success) {
-        io.stdout.write(resultCode);
+      const result = runWithResult('stdin', data, options, io);
+      const success = result !== undefined;
+      if (success && result !== undefined) {
+        io.stdout.write(result.code);
       }
       resolve(success);
     });
@@ -276,15 +289,20 @@ async function runWithStdio(options: CLIOptions, io: IO): Promise<boolean> {
 }
 
 /**
- * Run decaffeinate on the given code string and return the resulting code.
+ * Run decaffeinate on the given code string and return the result.
  */
-function runWithCode(name: string, code: string, options: CLIOptions, io: IO): string | undefined {
+function runWithResult(
+  name: string,
+  code: string,
+  options: CLIOptions,
+  io: IO,
+): { code: string; map?: SourceMap } | undefined {
   const baseOptions = Object.assign({ filename: name }, options.baseOptions);
   try {
     if (options.modernizeJS) {
-      return modernizeJS(code, baseOptions).code;
+      return modernizeJS(code, baseOptions);
     } else {
-      return convert(code, baseOptions).code;
+      return convert(code, baseOptions);
     }
   } catch (err: unknown) {
     assert(err instanceof Error);
@@ -348,6 +366,8 @@ function usage(exe: string, out: NodeJS.WritableStream): void {
   out.write('                           match exactly.\n');
   out.write('  --logical-assignment     Use the ES2021 logical assignment operators `&&=`, `||=`,\n');
   out.write('                           and `??=`.\n');
+  out.write('  --source-map             Generate a .js.map sourcemap file alongside each output\n');
+  out.write('                           .js file, mapping back to the original .coffee source.\n');
   out.write('\n');
   out.write('EXAMPLES\n');
   out.write('\n');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import remapping, { type EncodedSourceMap } from '@jridgewell/remapping';
 import { lex } from 'coffee-lex';
 import { nodes as getCoffee1Nodes, tokens as getCoffee1Tokens } from 'decaffeinate-coffeescript';
 import { nodes as getCoffee2Nodes, tokens as getCoffee2Tokens } from 'decaffeinate-coffeescript2';
@@ -26,12 +27,24 @@ import notNull from './utils/notNull';
 import assert from 'assert';
 export { PatchError };
 
+export interface SourceMap {
+  version: number;
+  file?: string | null;
+  sourceRoot?: string;
+  sources: Array<string | null>;
+  sourcesContent?: Array<string | null>;
+  names: Array<string>;
+  mappings: string;
+}
+
 export interface ConversionResult {
   code: string;
+  map?: SourceMap;
 }
 
 export interface StageResult {
   code: string;
+  map?: SourceMap;
   suggestions: Array<Suggestion>;
 }
 
@@ -82,6 +95,7 @@ export function convert(source: string, options: Options = {}): ConversionResult
   result.code = convertNewlines(result.code, originalNewlineStr);
   return {
     code: options.bare ? result.code : `(function() {\n${result.code}\n}).call(this);`,
+    map: result.map,
   };
 }
 
@@ -95,18 +109,33 @@ export function modernizeJS(source: string, options: Options = {}): ConversionRe
   result.code = convertNewlines(result.code, originalNewlineStr);
   return {
     code: options.bare ? result.code : `(function() {\n${result.code}\n}).call(this);`,
+    map: result.map,
   };
 }
 
 function runStages(initialContent: string, options: Options, stages: Array<Stage>): StageResult {
   let content = initialContent;
   const suggestions: Array<Suggestion> = [];
-  stages.forEach((stage) => {
-    const { code, suggestions: stageSuggestions } = runStage(stage, content, options);
+  const maps: Array<SourceMap> = [];
+
+  for (const stage of stages) {
+    const { code, map, suggestions: stageSuggestions } = runStage(stage, content, options);
     content = code;
     suggestions.push(...stageSuggestions);
-  });
-  return { code: content, suggestions: mergeSuggestions(suggestions) };
+    if (map) {
+      maps.push(map);
+    }
+  }
+
+  // Compose all per-stage maps into one map from final output → original source.
+  // remapping expects maps in reverse order (last stage first).
+  // JSON round-trip ensures mappings are encoded as a VLQ string.
+  const composedMap =
+    options.sourceMap && maps.length > 0
+      ? (JSON.parse(remapping(maps.slice().reverse() as Array<EncodedSourceMap>, () => null).toString()) as SourceMap)
+      : undefined;
+
+  return { code: content, map: composedMap, suggestions: mergeSuggestions(suggestions) };
 }
 
 function runStage(stage: Stage, content: string, options: Options): StageResult {

--- a/src/options.ts
+++ b/src/options.ts
@@ -20,6 +20,7 @@ export interface Options {
   logicalAssignment?: boolean;
   nullishCoalescing?: boolean;
   bare?: boolean;
+  sourceMap?: boolean;
 }
 
 export const DEFAULT_OPTIONS: Options = {
@@ -44,6 +45,7 @@ export const DEFAULT_OPTIONS: Options = {
   logicalAssignment: false,
   nullishCoalescing: false,
   bare: true,
+  sourceMap: false,
 };
 
 export function resolveOptions(options: Options): Options {

--- a/src/stages/TransformCoffeeScriptStage.ts
+++ b/src/stages/TransformCoffeeScriptStage.ts
@@ -6,6 +6,7 @@ import NodePatcher, { PatcherClass } from '../patchers/NodePatcher';
 import { Suggestion } from '../suggestions';
 import { logger } from '../utils/debug';
 import DecaffeinateContext from '../utils/DecaffeinateContext';
+import generateSourceMap from '../utils/generateSourceMap';
 import notNull from '../utils/notNull';
 import PatchError from '../utils/PatchError';
 
@@ -17,12 +18,14 @@ export default class TransformCoffeeScriptStage {
     log(content);
 
     const context = DecaffeinateContext.create(content, Boolean(options.useCS2));
-    const editor = new MagicString(content);
+    const editor = new MagicString(content, { filename: options.filename });
     const stage = new this(context.programNode, context, editor, options);
     const patcher = stage.build();
     patcher.patch();
+
     return {
       code: editor.toString(),
+      map: generateSourceMap(editor, options),
       suggestions: stage.suggestions,
     };
   }

--- a/src/stages/add-variable-declarations/index.ts
+++ b/src/stages/add-variable-declarations/index.ts
@@ -1,17 +1,21 @@
 import { addVariableDeclarations } from 'add-variable-declarations';
 import MagicString from 'magic-string';
 import { StageResult } from '../../index';
+import { Options } from '../../options';
 import { logger } from '../../utils/debug';
+import generateSourceMap from '../../utils/generateSourceMap';
 
 export default class AddVariableDeclarationsStage {
-  static run(content: string): StageResult {
+  static run(content: string, options: Options): StageResult {
     const log = logger(this.name);
     log(content);
 
-    const editor = new MagicString(content);
+    const editor = new MagicString(content, { filename: options.filename });
     addVariableDeclarations(content, editor);
+
     return {
       code: editor.toString(),
+      map: generateSourceMap(editor, options),
       suggestions: [],
     };
   }

--- a/src/stages/semicolons/index.ts
+++ b/src/stages/semicolons/index.ts
@@ -2,14 +2,16 @@ import { parse } from '@codemod/parser';
 import * as asi from 'automatic-semicolon-insertion';
 import MagicString from 'magic-string';
 import { StageResult } from '../../index';
+import { Options } from '../../options';
 import { logger } from '../../utils/debug';
+import generateSourceMap from '../../utils/generateSourceMap';
 
 export default class SemicolonsStage {
-  static run(content: string): StageResult {
+  static run(content: string, options: Options): StageResult {
     const log = logger(this.name);
     log(content);
 
-    const editor = new MagicString(content);
+    const editor = new MagicString(content, { filename: options.filename });
     const ast = parse(content, {
       tokens: true,
     });
@@ -21,6 +23,7 @@ export default class SemicolonsStage {
 
     return {
       code: editor.toString(),
+      map: generateSourceMap(editor, options),
       suggestions: [],
     };
   }

--- a/src/utils/generateSourceMap.ts
+++ b/src/utils/generateSourceMap.ts
@@ -1,0 +1,18 @@
+import MagicString from 'magic-string';
+import type { SourceMap } from '../index';
+import type { Options } from '../options';
+
+/**
+ * If sourceMap generation is enabled, produce a hi-res V3 sourcemap from the
+ * given MagicString editor. Returns `undefined` when sourceMap is off.
+ */
+export default function generateSourceMap(editor: MagicString, options: Options): SourceMap | undefined {
+  if (!options.sourceMap) {
+    return undefined;
+  }
+  return editor.generateMap({
+    source: options.filename,
+    includeContent: true,
+    hires: true,
+  });
+}

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -1,5 +1,5 @@
 import { equal, ok } from 'assert';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
 import { copySync } from 'fs-extra';
 import { join } from 'path';
 import { PassThrough } from 'stream';
@@ -582,5 +582,56 @@ describe('decaffeinate CLI', () => {
     `,
       1,
     );
+  });
+
+  describe('--source-map', () => {
+    it('generates a .js.map file alongside the .js output', async () => {
+      await runCli(
+        ['./test_fixtures/A.coffee', '--source-map'],
+        '',
+        `
+        ./test_fixtures/A.coffee → test_fixtures/A.js
+      `,
+      );
+      ok(existsSync('test_fixtures/A.js'));
+      ok(existsSync('test_fixtures/A.js.map'));
+
+      const jsContent = readFileSync('test_fixtures/A.js', 'utf8');
+      expect(jsContent).toContain('//# sourceMappingURL=A.js.map');
+
+      const mapContent = JSON.parse(readFileSync('test_fixtures/A.js.map', 'utf8'));
+      expect(mapContent.version).toBe(3);
+      expect(mapContent.mappings).toBeTruthy();
+
+      // Clean up the map file
+      unlinkSync('test_fixtures/A.js.map');
+    });
+
+    it('does not generate a .js.map file without --source-map', async () => {
+      await runCli(
+        ['./test_fixtures/A.coffee'],
+        '',
+        `
+        ./test_fixtures/A.coffee → test_fixtures/A.js
+      `,
+      );
+      ok(existsSync('test_fixtures/A.js'));
+      expect(existsSync('test_fixtures/A.js.map')).toBe(false);
+
+      const jsContent = readFileSync('test_fixtures/A.js', 'utf8');
+      expect(jsContent).not.toContain('sourceMappingURL');
+    });
+
+    it('does not emit sourcemap for stdin mode', async () => {
+      await runCli(
+        ['--source-map'],
+        `
+        x = 1
+      `,
+        `
+        const x = 1;
+      `,
+      );
+    });
   });
 });

--- a/test/sourcemap_test.ts
+++ b/test/sourcemap_test.ts
@@ -1,0 +1,136 @@
+import { convert, modernizeJS } from '../src/index';
+import type { SourceMap } from '../src/index';
+import { DEFAULT_OPTIONS } from '../src/options';
+
+describe('sourcemap support', () => {
+  describe('convert', () => {
+    it('does not include a map when sourceMap is false', () => {
+      const result = convert('x = 1', { ...DEFAULT_OPTIONS, sourceMap: false });
+      expect(result.map).toBeUndefined();
+    });
+
+    it('returns a sourcemap object when sourceMap is true', () => {
+      const result = convert('x = 1', {
+        ...DEFAULT_OPTIONS,
+        sourceMap: true,
+        disableSuggestionComment: true,
+      });
+      expect(result.map).toBeDefined();
+      expect(result.map).toHaveProperty('version', 3);
+      expect(result.map).toHaveProperty('mappings');
+    });
+
+    it('includes sources array in the sourcemap', () => {
+      const result = convert('x = 1', {
+        ...DEFAULT_OPTIONS,
+        sourceMap: true,
+        filename: 'test.coffee',
+        disableSuggestionComment: true,
+      });
+      const map = result.map as SourceMap;
+      expect(map.sources).toBeDefined();
+      expect(map.sources).toContain('test.coffee');
+    });
+
+    it('produces a JSON-serializable map', () => {
+      const result = convert('square = (x) -> x * x', {
+        ...DEFAULT_OPTIONS,
+        sourceMap: true,
+        disableSuggestionComment: true,
+      });
+      const json = JSON.stringify(result.map);
+      const parsed = JSON.parse(json) as SourceMap;
+      expect(parsed.version).toBe(3);
+      expect(typeof parsed.mappings).toBe('string');
+    });
+
+    it('generates correct mappings for a simple assignment', () => {
+      const result = convert('a = 1', {
+        ...DEFAULT_OPTIONS,
+        sourceMap: true,
+        disableSuggestionComment: true,
+      });
+      const map = result.map as SourceMap;
+      expect(map.mappings).toBeTruthy();
+      expect(map.mappings.length).toBeGreaterThan(0);
+    });
+
+    it('works with multiline input', () => {
+      const source = 'a = 1\nb = 2\nc = a + b';
+      const result = convert(source, {
+        ...DEFAULT_OPTIONS,
+        sourceMap: true,
+        disableSuggestionComment: true,
+      });
+      expect(result.map).toBeDefined();
+      const map = result.map as SourceMap;
+      expect(map.version).toBe(3);
+      expect(map.mappings).toBeTruthy();
+    });
+
+    it('works with function definitions', () => {
+      const source = 'square = (x) -> x * x';
+      const result = convert(source, {
+        ...DEFAULT_OPTIONS,
+        sourceMap: true,
+        disableSuggestionComment: true,
+      });
+      expect(result.map).toBeDefined();
+      expect(result.code).toContain('square');
+    });
+
+    it('works with class definitions', () => {
+      const source = 'class Animal\n  constructor: (@name) ->\n  speak: -> @name';
+      const result = convert(source, {
+        ...DEFAULT_OPTIONS,
+        sourceMap: true,
+        disableSuggestionComment: true,
+      });
+      expect(result.map).toBeDefined();
+      const map = result.map as SourceMap;
+      expect(map.version).toBe(3);
+    });
+
+    it('uses the filename option in the sourcemap sources', () => {
+      const result = convert('x = 1', {
+        ...DEFAULT_OPTIONS,
+        sourceMap: true,
+        filename: 'my/file.coffee',
+        disableSuggestionComment: true,
+      });
+      const map = result.map as SourceMap;
+      expect(map.sources).toContain('my/file.coffee');
+    });
+
+    it('does not break code output when sourceMap is enabled', () => {
+      const withMap = convert('x = 1', {
+        ...DEFAULT_OPTIONS,
+        sourceMap: true,
+        disableSuggestionComment: true,
+      });
+      const withoutMap = convert('x = 1', {
+        ...DEFAULT_OPTIONS,
+        sourceMap: false,
+        disableSuggestionComment: true,
+      });
+      expect(withMap.code).toBe(withoutMap.code);
+    });
+  });
+
+  describe('modernizeJS', () => {
+    it('does not include a map when sourceMap is false', () => {
+      const result = modernizeJS('var a = 1;', { ...DEFAULT_OPTIONS, sourceMap: false });
+      expect(result.map).toBeUndefined();
+    });
+
+    it('returns undefined map when sourceMap is true but only babel stages run', () => {
+      // modernizeJS only runs ResugarStage which is babel-based and does not
+      // produce MagicString sourcemaps, so no map is composed.
+      const result = modernizeJS('var a = 1;', {
+        ...DEFAULT_OPTIONS,
+        sourceMap: true,
+      });
+      expect(result.map).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
I understand `decaffeinate` to be a project primarily for converting codebases from CoffeeScript to JavaScript. However, I think that doesn't entirely rule out using `decaffeinate` for a transitional period, where one might want to be able to track runtime features to the CoffeeScript source. This is not possible without sourcemap support. This PR tries to implement this.